### PR TITLE
add support for HTTP OPTIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Operations perform an action on a resource using an HTTP method verb. The follow
 - Put
 - Patch
 - Delete
+- Options
 
 Operations can take dependencies, parameters, & request bodies and produce response headers and responses. These are each discussed in more detail below.
 

--- a/resource.go
+++ b/resource.go
@@ -188,3 +188,8 @@ func (r *Resource) Patch(docs string, handler interface{}) {
 func (r *Resource) Delete(docs string, handler interface{}) {
 	r.operation(http.MethodDelete, docs, handler)
 }
+
+// Options creates an HTTP OPTIONS operation on the resource.
+func (r *Resource) Options(docs string, handler interface{}) {
+	r.operation(http.MethodOptions, docs, handler)
+}

--- a/resource_test.go
+++ b/resource_test.go
@@ -129,7 +129,7 @@ func TestResourceWithAddedParam(t *testing.T) {
 }
 
 var resourceFuncsTest = []string{
-	"Head", "List", "Get", "Post", "Put", "Patch", "Delete",
+	"Head", "List", "Get", "Post", "Put", "Patch", "Delete", "Options",
 }
 
 func TestResourceFuncs(outer *testing.T) {
@@ -156,6 +156,8 @@ func TestResourceFuncs(outer *testing.T) {
 				f = res.Patch
 			case "Delete":
 				f = res.Delete
+			case "Options":
+				f = res.Options
 			default:
 				panic("invalid case " + local)
 			}


### PR DESCRIPTION
I _think_ this is what is needed to add support for HTTP OPTIONS.

But I also think that I should add a more fledged out example of using Options.  Should I add one to [humatest_test.go](https://github.com/danielgtaylor/huma/blob/master/humatest/humatest_test.go)?