### PR TITLE
Add configurable CORS middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,10 +623,7 @@ cfg.AllowAllOrigins = true
 cfg.AllowHeaders = append(cfg.AllowHeaders, "Authorization", "X-My-Header")
 
 // And manual settings:
-g := gin.New()
-g.Use(huma.CORSHandler(cors.New(cfg)))
-g.NoRoute(huma.Handler404())
-r := huma.NewRouter("My API", "1.0.0", huma.WithGin(g))
+r := huma.NewRouter("My API", "1.0.0", huma.CORSHandler(cors.New(cfg)))
 ```
 
 ## Custom HTTP Server

--- a/README.md
+++ b/README.md
@@ -615,7 +615,11 @@ g.NoRoute(huma.Handler404())
 r := huma.NewRouter("My API", "1.0.0", huma.WithGin(g))
 ```
 
+
+## Custom CORS Handler
+
 If you would like CORS preflight requests to allow specific headers, do the following:
+
 ```go
 // CORS: Allow non-standard headers "Authorization" and "X-My-Header" in preflight requests
 cfg := cors.DefaultConfig()

--- a/README.md
+++ b/README.md
@@ -615,6 +615,20 @@ g.NoRoute(huma.Handler404())
 r := huma.NewRouter("My API", "1.0.0", huma.WithGin(g))
 ```
 
+If you would like CORS preflight requests to allow specific headers, do the following:
+```go
+// CORS: Allow non-standard headers "Authorization" and "X-My-Header" in preflight requests
+cfg := cors.DefaultConfig()
+cfg.AllowAllOrigins = true
+cfg.AllowHeaders = append(cfg.AllowHeaders, "Authorization", "X-My-Header")
+
+// And manual settings:
+g := gin.New()
+g.Use(huma.CORSHandler(cors.New(cfg)))
+g.NoRoute(huma.Handler404())
+r := huma.NewRouter("My API", "1.0.0", huma.WithGin(g))
+```
+
 ## Custom HTTP Server
 
 You can have full control over the `http.Server` that is created.

--- a/options.go
+++ b/options.go
@@ -375,6 +375,15 @@ func DocsHandler(f Handler) RouterOption {
 	}}
 }
 
+// CORSHandler sets the CORS handler function. This can be used to set custom
+// domains, headers, auth, etc. If not given, then a default CORS handler is
+// used instead.
+func CORSHandler(f Handler) RouterOption {
+	return &routerOption{func(r *Router) {
+		r.corsHandler = f
+	}}
+}
+
 // OpenAPIHook registers a function to be called after the OpenAPI spec is
 // generated but before being sent to the client.
 func OpenAPIHook(f func(*gabs.Container)) RouterOption {

--- a/router_test.go
+++ b/router_test.go
@@ -210,8 +210,6 @@ func TestRouterConfigurableCors(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodOptions, "/echo/world", nil)
-	req.Header.Add("Authorization", "Bearer CAFEBEEF")
-	req.Header.Add("X-Istreamplanet-User-Identity", "identity")
 	req.Header.Add("Origin", "blah")
 	r.ServeHTTP(w, req)
 

--- a/router_test.go
+++ b/router_test.go
@@ -182,7 +182,7 @@ func TestRouterDefault(t *testing.T) {
 func TestRouterConfigurableCors(t *testing.T) {
 	cfg := cors.DefaultConfig()
 	cfg.AllowAllOrigins = true
-	cfg.AllowHeaders = append(cfg.AllowHeaders, "Authorization", "X-istreamplanet-user-identity")
+	cfg.AllowHeaders = append(cfg.AllowHeaders, "Authorization", "X-Istreamplanet-User-Identity")
 
 	r := NewTestRouter(t, CORSHandler(cors.New(cfg)))
 
@@ -211,13 +211,14 @@ func TestRouterConfigurableCors(t *testing.T) {
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodOptions, "/echo/world", nil)
 	req.Header.Add("Authorization", "Bearer CAFEBEEF")
-	req.Header.Add("X-istreamplanet-user-identity", "identity")
+	req.Header.Add("X-Istreamplanet-User-Identity", "identity")
 	req.Header.Add("Origin", "blah")
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
-	assert.Equal(t, true, strings.Contains(w.Header().Get("Access-Control-Allow-Headers"), "Authorization"))
-	assert.Equal(t, true, strings.Contains(w.Header().Get("Access-Control-Allow-Headers"), "X-istreamplanet-identity"))
+	allowedHeaders := w.Header().Get("Access-Control-Allow-Headers")
+	assert.Equal(t, true, strings.Contains(allowedHeaders, "Authorization"))
+	assert.Equal(t, true, strings.Contains(allowedHeaders, "X-Istreamplanet-User-Identity"))
 
 }
 


### PR DESCRIPTION
From an earlier conversation, this PR gives the server the ability to add what custom headers are allowed within CORS preflight requests.