### PR TITLE
Weiser/add prefixed docs

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -19,10 +19,10 @@ func splitDocs(docs string) (title, desc string) {
 	return
 }
 
-// RapiDocHandler renders documentation using RapiDoc.
-func RapiDocHandler(pageTitle string) Handler {
-	return func(c *gin.Context) {
-		c.Data(200, "text/html", []byte(fmt.Sprintf(`<!doctype html>
+// RapiDocTemplate is the template used to generate the RapiDoc.  It needs two args to render:
+// 1. the title
+// 2. the path to the openapi.yaml file
+var RapiDocTemplate = `<!doctype html>
 <html>
 <head>
 	<title>%s</title>
@@ -31,21 +31,19 @@ func RapiDocHandler(pageTitle string) Handler {
 </head>
 <body>
   <rapi-doc
-		spec-url="/openapi.json"
+		spec-url="%s"
 		render-style="read"
     show-header="false"
     primary-color="#f74799"
     nav-accent-color="#47afe8"
   > </rapi-doc>
 </body>
-</html>`, pageTitle)))
-	}
-}
+</html>`
 
-// ReDocHandler renders documentation using ReDoc.
-func ReDocHandler(pageTitle string) Handler {
-	return func(c *gin.Context) {
-		c.Data(200, "text/html", []byte(fmt.Sprintf(`<!DOCTYPE html>
+// ReDocTemplate is the template used to generate the RapiDoc.  It needs two args to render:
+// 1. the title
+// 2. the path to the openapi.yaml file
+var ReDocTemplate = `<!DOCTYPE html>
 <html>
   <head>
     <title>%s</title>
@@ -55,17 +53,12 @@ func ReDocHandler(pageTitle string) Handler {
 		<style>body { margin: 0; padding: 0; }</style>
   </head>
   <body>
-    <redoc spec-url='/openapi.json'></redoc>
+    <redoc spec-url='%s'></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
   </body>
-</html>`, pageTitle)))
-	}
-}
+</html>`
 
-// SwaggerUIHandler renders documentation using Swagger UI.
-func SwaggerUIHandler(pageTitle string) Handler {
-	return func(c *gin.Context) {
-		c.Data(200, "text/html", []byte(fmt.Sprintf(`<!-- HTML for static distribution bundle build -->
+var SwaggerUITemplate = `<!-- HTML for static distribution bundle build -->
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -104,7 +97,7 @@ func SwaggerUIHandler(pageTitle string) Handler {
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/openapi.json",
+        url: "%s",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [
@@ -122,6 +115,25 @@ func SwaggerUIHandler(pageTitle string) Handler {
     }
   </script>
   </body>
-</html>`, pageTitle)))
+</html>`
+
+// RapiDocHandler renders documentation using RapiDoc.
+func RapiDocHandler(pageTitle string) Handler {
+	return func(c *gin.Context) {
+		c.Data(200, "text/html", []byte(fmt.Sprintf(RapiDocTemplate, pageTitle, "/openapi.json")))
+	}
+}
+
+// ReDocHandler renders documentation using ReDoc.
+func ReDocHandler(pageTitle string) Handler {
+	return func(c *gin.Context) {
+		c.Data(200, "text/html", []byte(fmt.Sprintf(ReDocTemplate, pageTitle, "/openapi.json")))
+	}
+}
+
+// SwaggerUIHandler renders documentation using Swagger UI.
+func SwaggerUIHandler(pageTitle string) Handler {
+	return func(c *gin.Context) {
+		c.Data(200, "text/html", []byte(fmt.Sprintf(SwaggerUITemplate, pageTitle, "/openapi.json")))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,5 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.uber.org/zap v1.10.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 )

--- a/options.go
+++ b/options.go
@@ -376,9 +376,20 @@ func HTTPServer(server *http.Server) RouterOption {
 // DocsHandler sets the documentation rendering handler function. You can
 // use `huma.RapiDocHandler`, `huma.ReDocHandler`, `huma.SwaggerUIHandler`, or
 // provide your own (e.g. with custom auth or branding).
+//
+// DEPRECATED! Use `DocsDomType` instead!
 func DocsHandler(f Handler) RouterOption {
+	fmt.Println("This option is deprecated, use `DocsDomType` instead")
 	return &routerOption{func(r *Router) {
 		r.docsHandler = f
+	}}
+}
+
+// DocsDomType sets the presentation for the docs UI.  Valid values are:
+// "rapi" (default), "redoc", or "swagger"
+func DocsDomType(t string) RouterOption {
+	return &routerOption{func(r *Router) {
+		r.docsDomType = t
 	}}
 }
 

--- a/options.go
+++ b/options.go
@@ -301,6 +301,13 @@ func ContactEmail(name, email string) RouterOption {
 	}}
 }
 
+// DocsRoutePrefix enables the API documentation to be available from `prefix/{docs, openapi.yaml}`
+func DocsRoutePrefix(prefix string) RouterOption {
+	return &routerOption{func(r *Router) {
+		r.docsPrefix = prefix
+	}}
+}
+
 // BasicAuth adds a named HTTP Basic Auth security scheme.
 func BasicAuth(name string) RouterOption {
 	return &routerOption{func(r *Router) {

--- a/router.go
+++ b/router.go
@@ -318,6 +318,7 @@ type Router struct {
 	root        *cobra.Command
 	prestart    []func()
 	docsHandler Handler
+	docsDomType string
 	docsPrefix  string
 	corsHandler Handler
 
@@ -358,6 +359,7 @@ func NewRouter(docs, version string, options ...RouterOption) *Router {
 		engine:      g,
 		prestart:    []func(){},
 		docsHandler: RapiDocHandler(title),
+		docsDomType: "rapi",
 		docsPrefix:  "",
 		corsHandler: cors.Default(),
 	}
@@ -380,11 +382,21 @@ func NewRouter(docs, version string, options ...RouterOption) *Router {
 	}
 
 	// Set up handlers for the auto-generated spec and docs.
-	r.engine.GET(fmt.Sprintf("%s/openapi.json", r.docsPrefix), openAPIHandlerJSON(r))
+	openapiJsonPath := fmt.Sprintf("%s/openapi.json", r.docsPrefix)
+	r.engine.GET(openapiJsonPath, openAPIHandlerJSON(r))
 	r.engine.GET(fmt.Sprintf("%s/openapi.yaml", r.docsPrefix), openAPIHandlerYAML(r))
 
 	r.engine.GET(fmt.Sprintf("%s/docs", r.docsPrefix), func(c *gin.Context) {
-		r.docsHandler(c)
+		docsPayload := ""
+		switch r.docsDomType {
+		case "rapi":
+			docsPayload = fmt.Sprintf(RapiDocTemplate, title, openapiJsonPath)
+		case "swagger":
+			docsPayload = fmt.Sprintf(SwaggerUITemplate, title, openapiJsonPath)
+		case "redoc":
+			docsPayload = fmt.Sprintf(ReDocTemplate, title, openapiJsonPath)
+		}
+		c.Data(200, "text/html", []byte(docsPayload))
 	})
 
 	// If downloads like a CLI or SDKs are available, serve them automatically

--- a/router.go
+++ b/router.go
@@ -318,6 +318,7 @@ type Router struct {
 	root        *cobra.Command
 	prestart    []func()
 	docsHandler Handler
+	docsPrefix  string
 	corsHandler Handler
 
 	// Tracks the currently running server for graceful shutdown.
@@ -357,6 +358,7 @@ func NewRouter(docs, version string, options ...RouterOption) *Router {
 		engine:      g,
 		prestart:    []func(){},
 		docsHandler: RapiDocHandler(title),
+		docsPrefix:  "",
 		corsHandler: cors.Default(),
 	}
 
@@ -378,10 +380,10 @@ func NewRouter(docs, version string, options ...RouterOption) *Router {
 	}
 
 	// Set up handlers for the auto-generated spec and docs.
-	r.engine.GET("/openapi.json", openAPIHandlerJSON(r))
-	r.engine.GET("/openapi.yaml", openAPIHandlerYAML(r))
+	r.engine.GET(fmt.Sprintf("%s/openapi.json", r.docsPrefix), openAPIHandlerJSON(r))
+	r.engine.GET(fmt.Sprintf("%s/openapi.yaml", r.docsPrefix), openAPIHandlerYAML(r))
 
-	r.engine.GET("/docs", func(c *gin.Context) {
+	r.engine.GET(fmt.Sprintf("%s/docs", r.docsPrefix), func(c *gin.Context) {
 		r.docsHandler(c)
 	})
 

--- a/router_test.go
+++ b/router_test.go
@@ -265,29 +265,9 @@ func TestRouter(t *testing.T) {
 }
 
 func TestRouterDocsPrefix(t *testing.T) {
-	type EchoResponse struct {
-		Value string `json:"value" description:"The echoed back word"`
-	}
 
-	r := NewTestRouter(t, DocsRoutePrefix("/prefix"))
-
-	r.Resource("/echo",
-		PathParam("word", "The word to echo back"),
-		QueryParam("greet", "Return a greeting", false),
-		ResponseJSON(http.StatusOK, "Successful echo response"),
-		ResponseError(http.StatusBadRequest, "Invalid input"),
-	).Put("Echo back an input word.", func(word string, greet bool) (*EchoResponse, *ErrorModel) {
-		if word == "test" {
-			return nil, &ErrorModel{Detail: "Value not allowed: test"}
-		}
-
-		v := word
-		if greet {
-			v = "Hello, " + word
-		}
-
-		return &EchoResponse{Value: v}, nil
-	})
+	r := NewRouter("api", "v", DocsRoutePrefix("/prefix"))
+	r.Resource("/hello").Get("doc", func() string { return "Hello" })
 
 	// Check spec & docs routes
 	w := httptest.NewRecorder()
@@ -299,6 +279,7 @@ func TestRouterDocsPrefix(t *testing.T) {
 	req, _ = http.NewRequest(http.MethodGet, "/prefix/docs", nil)
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, "prefix/openapi", w.Body.String())
 }
 
 func TestRouterRequestBody(t *testing.T) {

--- a/router_test.go
+++ b/router_test.go
@@ -279,7 +279,7 @@ func TestRouterDocsPrefix(t *testing.T) {
 	req, _ = http.NewRequest(http.MethodGet, "/prefix/docs", nil)
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, "prefix/openapi", w.Body.String())
+	assert.Contains(t, w.Body.String(), "prefix/openapi")
 }
 
 func TestRouterRequestBody(t *testing.T) {


### PR DESCRIPTION
I'm deploying my huma application behind a shared API gateway.  As such, I need all of my routes to be prefixed with my app name, i.e.
```
GET endpoint1 --> GET my-app/endpoint
```

For routes I myself can define, that is easy enough.

Buyt for the API docs, which have static routes of `/{docs, openapi.json,openapi.yaml}` I have no way to change those routes to
```
GET /docs --> GET /my-app/docs
```

This PR adds a new RouterOption, which when applied ensures that the auto-generated docs can be prefixed.