### PR TITLE
feat: security & autoconfiguration

### DIFF
--- a/autoconfig.go
+++ b/autoconfig.go
@@ -1,0 +1,20 @@
+package huma
+
+// AutoConfigVar represents a variable given by the user when prompted during
+// auto-configuration setup of an API.
+type AutoConfigVar struct {
+	Description string        `json:"description,omitempty"`
+	Example     string        `json:"example,omitempty"`
+	Default     interface{}   `json:"default,omitempty"`
+	Enum        []interface{} `json:"enum,omitempty"`
+}
+
+// AutoConfig holds an API's automatic configuration settings for the CLI. These
+// are advertised via OpenAPI extension and picked up by the CLI to make it
+// easier to get started using an API.
+type AutoConfig struct {
+	Security string                   `json:"security"`
+	Headers  map[string]string        `json:"headers,omitempty"`
+	Prompt   map[string]AutoConfigVar `json:"prompt,omitempty"`
+	Params   map[string]string        `json:"params"`
+}

--- a/openapi.go
+++ b/openapi.go
@@ -46,7 +46,8 @@ type oaParam struct {
 }
 
 type oaComponents struct {
-	Schemas map[string]*schema.Schema `json:"schemas,omitempty"`
+	Schemas         map[string]*schema.Schema   `json:"schemas,omitempty"`
+	SecuritySchemes map[string]oaSecurityScheme `json:"securitySchemes,omitempty"`
 }
 
 func (c *oaComponents) AddSchema(t reflect.Type, mode schema.Mode, hint string) string {
@@ -99,4 +100,21 @@ func (c *oaComponents) AddSchema(t reflect.Type, mode schema.Mode, hint string) 
 	c.Schemas[name] = s
 
 	return "#/components/schemas/" + name
+}
+
+type oaFlow struct {
+	AuthorizationURL string            `json:"authorizationUrl,omitempty"`
+	TokenURL         string            `json:"tokenUrl,omitempty"`
+	Scopes           map[string]string `json:"scopes,omitempty"`
+}
+
+type oaFlows struct {
+	ClientCredentials *oaFlow `json:"clientCredentials,omitempty"`
+	AuthorizationCode *oaFlow `json:"authorizationCode,omitempty"`
+}
+
+type oaSecurityScheme struct {
+	Type   string  `json:"type"`
+	Scheme string  `json:"scheme,omitempty"`
+	Flows  oaFlows `json:"flows,omitempty"`
 }


### PR DESCRIPTION
New settings for documenting gateway-based auth schemes and CLI autoconfiguration to make using e.g. [Restish](https://rest.sh) easier.