### PR TITLE
fix: copy router into sub-resources

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -95,6 +95,7 @@ func (r *Resource) SubResource(path string) *Resource {
 	sub := &Resource{
 		path:         r.path + path,
 		mux:          r.mux.Route(path, nil),
+		router:       r.router,
 		subResources: []*Resource{},
 		operations:   []*Operation{},
 		tags:         append([]string{}, r.tags...),

--- a/router_test.go
+++ b/router_test.go
@@ -400,3 +400,12 @@ func TestGetOperationDoesNotCrash(t *testing.T) {
 		assert.NotNil(t, info)
 	})
 }
+
+func TestSubResource(t *testing.T) {
+	app := newTestRouter()
+
+	// This should not crash.
+	app.Resource("/").SubResource("/foo").SubResource("/bar").Get("get-bar", "docs", NewResponse(http.StatusOK, "ok")).Run(func(ctx Context) {
+		// Do nothing
+	})
+}


### PR DESCRIPTION
Tiny bug fix to make sure sub-resources get all fields copied. This gets used later when declaring operations on the sub-resources.