### PR TITLE
fix: serialization of time.Time and struct pointers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/koron-go/gqlcost v0.2.2
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-isatty v0.0.14
-	github.com/mitchellh/mapstructure v1.4.3
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/cobra v1.4.0

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -31,9 +31,10 @@ func TestExhaustiveErrors(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest(http.MethodGet, "/?bool=bad&int=bad&float32=bad&float64=bad&tags=1,2,bad&time=bad", strings.NewReader(`{"test": 1}`))
+	r.Host = "example.com"
 	app.ServeHTTP(w, r)
 
-	assert.JSONEq(t, `{"title":"Bad Request","status":400,"detail":"Error while parsing input parameters","errors":[{"message":"cannot parse boolean","location":"query.bool","value":"bad"},{"message":"cannot parse integer","location":"query.int","value":"bad"},{"message":"cannot parse float","location":"query.float32","value":"bad"},{"message":"cannot parse float","location":"query.float64","value":"bad"},{"message":"cannot parse integer","location":"query[2].tags","value":"bad"},{"message":"unable to validate against schema: invalid character 'b' looking for beginning of value","location":"query.tags","value":"[1,2,bad]"},{"message":"cannot parse time","location":"query.time","value":"bad"},{"message":"Must be greater than or equal to 5","location":"body.test","value":1}]}`, w.Body.String())
+	assert.JSONEq(t, `{"$schema": "https://example.com/schemas/ErrorModel.json", "title":"Bad Request","status":400,"detail":"Error while parsing input parameters","errors":[{"message":"cannot parse boolean","location":"query.bool","value":"bad"},{"message":"cannot parse integer","location":"query.int","value":"bad"},{"message":"cannot parse float","location":"query.float32","value":"bad"},{"message":"cannot parse float","location":"query.float64","value":"bad"},{"message":"cannot parse integer","location":"query[2].tags","value":"bad"},{"message":"unable to validate against schema: invalid character 'b' looking for beginning of value","location":"query.tags","value":"[1,2,bad]"},{"message":"cannot parse time","location":"query.time","value":"bad"},{"message":"Must be greater than or equal to 5","location":"body.test","value":1}]}`, w.Body.String())
 }
 
 type Dep1 struct {
@@ -104,9 +105,11 @@ func TestNestedResolverError(t *testing.T) {
 			]
 		}
 	}`))
+	r.Host = "example.com"
 	app.ServeHTTP(w, r)
 
 	assert.JSONEq(t, `{
+		"$schema": "https://example.com/schemas/ErrorModel.json",
 		"status": 400,
 		"title": "Bad Request",
 		"detail": "Error while parsing input parameters",


### PR DESCRIPTION
This fixes a bug where `time.Time{}` was improperly handled by `mapstructure`, which is now replaced with a custom shallow copy function that behaves better. Also handles struct pointers properly now for adding `$schema` fields.