### PR TITLE
fix: better handling of zero values; no panic for generic types

### DIFF
--- a/context.go
+++ b/context.go
@@ -239,13 +239,13 @@ func shallowStructToMap(v reflect.Value, result map[string]interface{}) {
 			if name == "-" {
 				continue
 			}
-			if len(parts) == 2 && parts[1] == "omitempty" && v.Field(i).IsZero() {
+			if len(parts) > 1 && parts[1] == "omitempty" {
 				vf := v.Field(i)
 				zero := vf.IsZero()
 				if vf.Kind() == reflect.Slice || vf.Kind() == reflect.Map {
 					// Special case: omit if they have no items in them to match the
 					// JSON encoder.
-					zero = vf.Len() > 0
+					zero = vf.Len() == 0
 				}
 				if zero {
 					continue

--- a/graphql_model.go
+++ b/graphql_model.go
@@ -32,7 +32,9 @@ func getFields(typ reflect.Type) []reflect.StructField {
 		if newTyp.Kind() == reflect.Ptr {
 			newTyp = newTyp.Elem()
 		}
-		fields = append(fields, getFields(newTyp)...)
+		if newTyp.Kind() == reflect.Struct {
+			fields = append(fields, getFields(newTyp)...)
+		}
 	}
 
 	return fields

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -200,7 +200,9 @@ func getFields(typ reflect.Type) []reflect.StructField {
 		if newTyp.Kind() == reflect.Ptr {
 			newTyp = newTyp.Elem()
 		}
-		fields = append(fields, getFields(newTyp)...)
+		if newTyp.Kind() == reflect.Struct {
+			fields = append(fields, getFields(newTyp)...)
+		}
 	}
 
 	return fields
@@ -542,6 +544,8 @@ func GenerateWithMode(t reflect.Type, mode Mode, schema *Schema) (*Schema, error
 		return GenerateWithMode(t.Elem(), mode, schema)
 	case reflect.Interface:
 		// Interfaces can be any type.
+	case reflect.Uintptr, reflect.UnsafePointer, reflect.Func:
+		// Ignored...
 	default:
 		return nil, fmt.Errorf("unsupported type %s from %s", t.Kind(), t)
 	}


### PR DESCRIPTION
Small fix for how zero values were getting turned into a map.

Also updates the code to support generating schemas and GraphQL from the new Go 1.18 generics (type parameters) feature, which introduces some new fields into the generated types at compile time that we need to ignore.