### PR TITLE
feat: return more specific error codes

### DIFF
--- a/context.go
+++ b/context.go
@@ -78,6 +78,7 @@ type hcontext struct {
 	http.ResponseWriter
 	r                     *http.Request
 	errors                []error
+	errorCodeHint         int
 	op                    *Operation
 	closed                bool
 	docsPrefix            string

--- a/context.go
+++ b/context.go
@@ -78,7 +78,7 @@ type hcontext struct {
 	http.ResponseWriter
 	r                     *http.Request
 	errors                []error
-	errorCodeHint         int
+	errorCode             int
 	op                    *Operation
 	closed                bool
 	docsPrefix            string

--- a/operation.go
+++ b/operation.go
@@ -276,7 +276,7 @@ func (o *Operation) Run(handler interface{}) {
 			docsPrefix:            o.resource.router.docsPrefix,
 			urlPrefix:             o.resource.router.urlPrefix,
 			disableSchemaProperty: o.resource.router.disableSchemaProperty,
-			errorCodeHint:         http.StatusBadRequest,
+			errorCode:             http.StatusBadRequest,
 		}
 
 		// If there is no input struct (just a context), then the call is simple.
@@ -310,11 +310,11 @@ func (o *Operation) Run(handler interface{}) {
 		if !ctx.HasError() {
 			// No errors yet, so any errors that come after should be treated as a
 			// semantic rather than structural error.
-			ctx.errorCodeHint = http.StatusUnprocessableEntity
+			ctx.errorCode = http.StatusUnprocessableEntity
 		}
 		resolveFields(ctx, "", input)
 		if ctx.HasError() {
-			ctx.WriteError(ctx.errorCodeHint, "Error while processing input parameters")
+			ctx.WriteError(ctx.errorCode, "Error while processing input parameters")
 			return
 		}
 

--- a/resolver.go
+++ b/resolver.go
@@ -70,9 +70,9 @@ func validAgainstSchema(ctx *hcontext, label string, schema *schema.Schema, data
 		for _, desc := range result.Errors() {
 			// Note: some descriptions start with the context location so we trim
 			// those off to prevent duplicating data. (e.g. see the enum error)
-			if ctx.errorCodeHint <= 400 {
+			if ctx.errorCode <= 400 {
 				// Set if a more specific code hasn't been set yet.
-				ctx.errorCodeHint = http.StatusUnprocessableEntity
+				ctx.errorCode = http.StatusUnprocessableEntity
 			}
 			ctx.AddError(&ErrorDetail{
 				Message:  strings.TrimPrefix(desc.Description(), desc.Context().String()+" "),
@@ -205,7 +205,7 @@ func setFields(ctx *hcontext, req *http.Request, input reflect.Value, t reflect.
 			if length := req.Header.Get("Content-Length"); length != "" {
 				if l, err := strconv.ParseInt(length, 10, 64); err == nil {
 					if l > ctx.op.maxBodyBytes {
-						ctx.errorCodeHint = http.StatusRequestEntityTooLarge
+						ctx.errorCode = http.StatusRequestEntityTooLarge
 						ctx.AddError(&ErrorDetail{
 							Message:  fmt.Sprintf("Request body too large, limit = %d bytes", ctx.op.maxBodyBytes),
 							Location: locationBody,
@@ -220,13 +220,13 @@ func setFields(ctx *hcontext, req *http.Request, input reflect.Value, t reflect.
 			data, err := ioutil.ReadAll(req.Body)
 			if err != nil {
 				if strings.Contains(err.Error(), "request body too large") {
-					ctx.errorCodeHint = http.StatusRequestEntityTooLarge
+					ctx.errorCode = http.StatusRequestEntityTooLarge
 					ctx.AddError(&ErrorDetail{
 						Message:  fmt.Sprintf("Request body too large, limit = %d bytes", ctx.op.maxBodyBytes),
 						Location: locationBody,
 					})
 				} else if e, ok := err.(net.Error); ok && e.Timeout() {
-					ctx.errorCodeHint = http.StatusRequestTimeout
+					ctx.errorCode = http.StatusRequestTimeout
 					ctx.AddError(&ErrorDetail{
 						Message:  fmt.Sprintf("Request body took too long to read: timed out after %v", ctx.op.bodyReadTimeout),
 						Location: locationBody,

--- a/router_test.go
+++ b/router_test.go
@@ -198,7 +198,7 @@ func TestTooBigBody(t *testing.T) {
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodPut, "/test", strings.NewReader(`{"id": "foo"}`))
 	app.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
 	assert.Contains(t, w.Body.String(), "Request body too large")
 
 	// With content length
@@ -206,7 +206,7 @@ func TestTooBigBody(t *testing.T) {
 	req, _ = http.NewRequest(http.MethodPut, "/test", strings.NewReader(`{"id": "foo"}`))
 	req.Header.Set("Content-Length", "13")
 	app.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
 	assert.Contains(t, w.Body.String(), "Request body too large")
 }
 
@@ -250,7 +250,7 @@ func TestBodySlow(t *testing.T) {
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodPut, "/test", &slowReader{})
 	app.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusRequestTimeout, w.Code)
 	assert.Contains(t, w.Body.String(), "timed out")
 }
 
@@ -414,7 +414,7 @@ func TestCustomRequestSchema(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, "/foo", strings.NewReader("1234"))
 	app.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+	assert.Equal(t, http.StatusUnprocessableEntity, w.Result().StatusCode)
 }
 
 func TestGetOperationName(t *testing.T) {


### PR DESCRIPTION
This PR changes the status code behavior for errors to attempt to return more specific status codes when possible while still striving for exhaustive error responses. As can be seen in the README, the new flow is:

```mermaid
flowchart TD
	Request[Request has errors?] -->|yes| Panic
	Request -->|no| Continue[Continue to handler]
	Panic[Panic?] -->|yes| 500
	Panic -->|no| RequestBody[Request body too large?]
	RequestBody -->|yes| 413
	RequestBody -->|no| RequestTimeout[Request took too long to read?]
	RequestTimeout -->|yes| 408
	RequestTimeout -->|no| ParseFailure[Cannot parse input?]
	ParseFailure -->|yes| 400
	ParseFailure -->|no| ValidationFailure[Validation failed?]
	ValidationFailure -->|yes| 422
	ValidationFailure -->|no| 400
```

The change is fairly small & unobtrusive. Several tests have been updated to reflect the changes. It should not break clients, however your API will have new documented responses when upgrading Huma.

Note: the above flowchart deliberately excludes stuff like `405 Method Not Allowed` because that returns at the low-level router before any of the above executes.