### PR TITLE
fix: accept status code 0 as default response

### DIFF
--- a/context.go
+++ b/context.go
@@ -115,7 +115,7 @@ func (c *hcontext) WriteHeader(status int) {
 	if c.op != nil {
 		allowed := []string{}
 		for _, r := range c.op.responses {
-			if r.status == status {
+			if r.status == status || r.status == 0 {
 				for _, h := range r.headers {
 					allowed = append(allowed, h)
 				}
@@ -273,7 +273,7 @@ func (c *hcontext) writeModel(ct string, status int, model interface{}) {
 		statuses := []string{}
 		for _, r := range c.op.responses {
 			statuses = append(statuses, fmt.Sprintf("%d", r.status))
-			if r.status == status {
+			if r.status == status || r.status == 0 {
 				responses = append(responses, r)
 				if r.model != nil {
 					names = append(names, r.model.Name())

--- a/operation.go
+++ b/operation.go
@@ -111,6 +111,9 @@ func (o *Operation) toOpenAPI(components *oaComponents) *gabs.Container {
 	// responses
 	for i, resp := range o.responses {
 		status := fmt.Sprintf("%v", resp.status)
+		if resp.status == 0 {
+			status = "default"
+		}
 		doc.Set(resp.description, "responses", status, "description")
 
 		headers := resp.headers

--- a/router_test.go
+++ b/router_test.go
@@ -462,3 +462,19 @@ func TestSubResource(t *testing.T) {
 		// Do nothing
 	})
 }
+
+func TestDefaultResponse(t *testing.T) {
+	app := newTestRouter()
+
+	// This should not crash.
+	app.Resource("/").Get("get-root", "docs", NewResponse(0, "Default repsonse")).Run(func(ctx Context) {
+		ctx.WriteHeader(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	app.ServeHTTP(w, req)
+
+	// This should not panic and should return the 200 OK
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+}


### PR DESCRIPTION
This makes it so you can set a response status code of `0` to signify this is the OpenAPI "default" response, and updates a couple places to allow the responses to get written without causing errors. This helps in the rare case that you have a bunch of response status codes you could return and would rather use a default than list them all out.