### PR TITLE
Huma now accepts naked boolean queryparams

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -275,7 +275,7 @@ func setFields(ctx *hcontext, req *http.Request, input reflect.Value, t reflect.
 			location = locationQuery
 			if v := req.URL.Query().Get(name); v != "" {
 				pv = v
-			} else if req.URL.Query().Has(name) {
+			} else if req.URL.Query().Has(name) && f.Type.Kind() == reflect.Bool {
 				// name has no associated value, but exists in the map of QueryParams.  This is a boolean value
 				pv = "true"
 			}

--- a/resolver.go
+++ b/resolver.go
@@ -275,6 +275,9 @@ func setFields(ctx *hcontext, req *http.Request, input reflect.Value, t reflect.
 			location = locationQuery
 			if v := req.URL.Query().Get(name); v != "" {
 				pv = v
+			} else if req.URL.Query().Has(name) {
+				// name has no associated value, but exists in the map of QueryParams.  This is a boolean value
+				pv = "true"
 			}
 		}
 

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -142,6 +142,22 @@ func TestInvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 }
 
-func TestBooleanQueryParam(t *testing.T) {
+func TestBooleanQueryParamNoVal(t *testing.T) {
+	app := newTestRouter()
+
+	app.Resource("/").Get("test", "Test",
+		NewResponse(http.StatusOK, "desc"),
+	).Run(func(ctx Context, input struct {
+		BooleanParam bool   `query:"b"`
+		OtherParam   string `query:"s"`
+	}) {
+		ctx.WriteHeader(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/?s=test&e", nil)
+	app.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
 
 }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -255,3 +255,39 @@ func TestBooleanQueryParamTrailingExplicitSet(t *testing.T) {
 	assert.Equal(t, o.BooleanParam, true)
 	assert.Equal(t, o.OtherParam, "test")
 }
+
+func TestBooleanQueryParamTrailingNotSet(t *testing.T) {
+	app := newTestRouter()
+
+	app.Resource("/").Get("test", "Test",
+		NewResponse(http.StatusOK, "desc"),
+	).Run(func(ctx Context, input QueryParamTestModel) {
+		out := &QueryParamTestModel{
+			BooleanParam: input.BooleanParam,
+			OtherParam:   input.OtherParam,
+		}
+		j, err := json.Marshal(out)
+		if err == nil {
+			ctx.Write(j)
+		} else {
+			ctx.WriteError(http.StatusBadRequest, "error marshaling to json", err)
+		}
+
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/?s=test&b=true", nil)
+	app.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+	decoder := json.NewDecoder(w.Body)
+	var o QueryParamTestModel
+
+	err := decoder.Decode(&o)
+	if err != nil {
+		assert.Fail(t, "Unable to decode json response")
+	}
+
+	assert.Equal(t, o.BooleanParam, true)
+	assert.Equal(t, o.OtherParam, "test")
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,6 +1,7 @@
 package huma
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -142,22 +143,43 @@ func TestInvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 }
 
+type QueryParamTestModel struct {
+	BooleanParam bool   `query:"b"`
+	OtherParam   string `query:"s"`
+}
+
 func TestBooleanQueryParamNoVal(t *testing.T) {
 	app := newTestRouter()
 
 	app.Resource("/").Get("test", "Test",
 		NewResponse(http.StatusOK, "desc"),
-	).Run(func(ctx Context, input struct {
-		BooleanParam bool   `query:"b"`
-		OtherParam   string `query:"s"`
-	}) {
-		ctx.WriteHeader(http.StatusOK)
+	).Run(func(ctx Context, input QueryParamTestModel) {
+		out := &QueryParamTestModel{
+			BooleanParam: input.BooleanParam,
+			OtherParam:   input.OtherParam,
+		}
+		j, err := json.Marshal(out)
+		if err == nil {
+			ctx.Write(j)
+		} else {
+			ctx.WriteError(http.StatusBadRequest, "error marshaling to json", err)
+		}
+
 	})
 
 	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/?s=test&e", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/?s=test&b", nil)
 	app.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+	decoder := json.NewDecoder(w.Body)
+	var o QueryParamTestModel
+	// fmt.Println(w.Body)
+	err := decoder.Decode(&o)
+	if err != nil {
+		assert.Fail(t, "Unable to decode json response")
+	}
 
+	assert.Equal(t, o.BooleanParam, true)
+	assert.Equal(t, o.OtherParam, "test")
 }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -220,7 +220,7 @@ func TestBooleanQueryParamTrailingEqual(t *testing.T) {
 	assert.Equal(t, o.OtherParam, "test")
 }
 
-func TestBooleanQueryParamTrailingExplicitSet(t *testing.T) {
+func TestBooleanQueryParamExplicitSet(t *testing.T) {
 	app := newTestRouter()
 
 	app.Resource("/").Get("test", "Test",
@@ -256,7 +256,7 @@ func TestBooleanQueryParamTrailingExplicitSet(t *testing.T) {
 	assert.Equal(t, o.OtherParam, "test")
 }
 
-func TestBooleanQueryParamTrailingNotSet(t *testing.T) {
+func TestBooleanQueryParamNotSet(t *testing.T) {
 	app := newTestRouter()
 
 	app.Resource("/").Get("test", "Test",

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -141,3 +141,7 @@ func TestInvalidJSON(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 }
+
+func TestBooleanQueryParam(t *testing.T) {
+
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -276,7 +276,7 @@ func TestBooleanQueryParamTrailingNotSet(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	r, _ := http.NewRequest(http.MethodGet, "/?s=test&b=true", nil)
+	r, _ := http.NewRequest(http.MethodGet, "/?s=test", nil)
 	app.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
@@ -288,6 +288,6 @@ func TestBooleanQueryParamTrailingNotSet(t *testing.T) {
 		assert.Fail(t, "Unable to decode json response")
 	}
 
-	assert.Equal(t, o.BooleanParam, true)
+	assert.Equal(t, o.BooleanParam, false)
 	assert.Equal(t, o.OtherParam, "test")
 }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -183,3 +183,39 @@ func TestBooleanQueryParamNoVal(t *testing.T) {
 	assert.Equal(t, o.BooleanParam, true)
 	assert.Equal(t, o.OtherParam, "test")
 }
+
+func TestBooleanQueryParamTrailingEqual(t *testing.T) {
+	app := newTestRouter()
+
+	app.Resource("/").Get("test", "Test",
+		NewResponse(http.StatusOK, "desc"),
+	).Run(func(ctx Context, input QueryParamTestModel) {
+		out := &QueryParamTestModel{
+			BooleanParam: input.BooleanParam,
+			OtherParam:   input.OtherParam,
+		}
+		j, err := json.Marshal(out)
+		if err == nil {
+			ctx.Write(j)
+		} else {
+			ctx.WriteError(http.StatusBadRequest, "error marshaling to json", err)
+		}
+
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/?s=test&b=", nil)
+	app.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+	decoder := json.NewDecoder(w.Body)
+	var o QueryParamTestModel
+	// fmt.Println(w.Body)
+	err := decoder.Decode(&o)
+	if err != nil {
+		assert.Fail(t, "Unable to decode json response")
+	}
+
+	assert.Equal(t, o.BooleanParam, true)
+	assert.Equal(t, o.OtherParam, "test")
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -174,7 +174,7 @@ func TestBooleanQueryParamNoVal(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
 	decoder := json.NewDecoder(w.Body)
 	var o QueryParamTestModel
-	// fmt.Println(w.Body)
+
 	err := decoder.Decode(&o)
 	if err != nil {
 		assert.Fail(t, "Unable to decode json response")
@@ -210,7 +210,43 @@ func TestBooleanQueryParamTrailingEqual(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
 	decoder := json.NewDecoder(w.Body)
 	var o QueryParamTestModel
-	// fmt.Println(w.Body)
+
+	err := decoder.Decode(&o)
+	if err != nil {
+		assert.Fail(t, "Unable to decode json response")
+	}
+
+	assert.Equal(t, o.BooleanParam, true)
+	assert.Equal(t, o.OtherParam, "test")
+}
+
+func TestBooleanQueryParamTrailingExplicitSet(t *testing.T) {
+	app := newTestRouter()
+
+	app.Resource("/").Get("test", "Test",
+		NewResponse(http.StatusOK, "desc"),
+	).Run(func(ctx Context, input QueryParamTestModel) {
+		out := &QueryParamTestModel{
+			BooleanParam: input.BooleanParam,
+			OtherParam:   input.OtherParam,
+		}
+		j, err := json.Marshal(out)
+		if err == nil {
+			ctx.Write(j)
+		} else {
+			ctx.WriteError(http.StatusBadRequest, "error marshaling to json", err)
+		}
+
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/?s=test&b=true", nil)
+	app.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+	decoder := json.NewDecoder(w.Body)
+	var o QueryParamTestModel
+
 	err := decoder.Decode(&o)
 	if err != nil {
 		assert.Fail(t, "Unable to decode json response")

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -291,3 +291,39 @@ func TestBooleanQueryParamNotSet(t *testing.T) {
 	assert.Equal(t, o.BooleanParam, false)
 	assert.Equal(t, o.OtherParam, "test")
 }
+
+func TestStringQueryEmpty(t *testing.T) {
+	app := newTestRouter()
+
+	app.Resource("/").Get("test", "Test",
+		NewResponse(http.StatusOK, "desc"),
+	).Run(func(ctx Context, input QueryParamTestModel) {
+		out := &QueryParamTestModel{
+			BooleanParam: input.BooleanParam,
+			OtherParam:   input.OtherParam,
+		}
+		j, err := json.Marshal(out)
+		if err == nil {
+			ctx.Write(j)
+		} else {
+			ctx.WriteError(http.StatusBadRequest, "error marshaling to json", err)
+		}
+
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/?s=&b", nil)
+	app.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+	decoder := json.NewDecoder(w.Body)
+	var o QueryParamTestModel
+
+	err := decoder.Decode(&o)
+	if err != nil {
+		assert.Fail(t, "Unable to decode json response")
+	}
+
+	assert.Equal(t, o.BooleanParam, true)
+	assert.Equal(t, o.OtherParam, "")
+}


### PR DESCRIPTION
Today in order to use a boolean with queryparams it needs to be set like this: `?param=true`, now you can set it with `?param` or `?param`