### PR TITLE
fix: prevent double content-encoding

### DIFF
--- a/middleware/encoding.go
+++ b/middleware/encoding.go
@@ -38,6 +38,11 @@ func (w *contentEncodingWriter) Write(data []byte) (int, error) {
 		return w.writer.Write(data)
 	}
 
+	if w.Header().Get("Content-Encoding") != "" {
+		// Content encoding was already set, so we should ignore this!
+		return w.ResponseWriter.Write(data)
+	}
+
 	// Buffer the data until we can decide whether to compress it or not.
 	w.buf.Write(data)
 


### PR DESCRIPTION
This change updates the content encoding middleware to be aware of the `Content-Encoding` response header. If already present, it will act as a no-op rather than double-encoding the response body. Use cases:

- Enable custom content encodings within operation handlers
- Prevent double-encoding if multiple content-encoding middlewares exist
