### PR TITLE
feat: allow hidden/undocumented resources

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -20,9 +20,15 @@ type Resource struct {
 	operations   []*Operation
 
 	tags []string
+
+	hidden bool
 }
 
 func (r *Resource) toOpenAPI(components *oaComponents) *gabs.Container {
+	if r.hidden {
+		return nil
+	}
+
 	doc := gabs.New()
 
 	for _, sub := range r.subResources {
@@ -109,4 +115,10 @@ func (r *Resource) SubResource(path string) *Resource {
 // Tags appends to the list of tags, used for documentation.
 func (r *Resource) Tags(names ...string) {
 	r.tags = append(r.tags, names...)
+}
+
+// Hidden removes this resource from the OpenAPI spec and documentation. It
+// is intended to be used for things like health check endpoints.
+func (r *Resource) Hidden() {
+	r.hidden = true
 }

--- a/resource_test.go
+++ b/resource_test.go
@@ -1,0 +1,24 @@
+package huma
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResource(t *testing.T) {
+	r := Resource{
+		path: "/test",
+	}
+
+	assert.NotNil(t, r.toOpenAPI(&oaComponents{}))
+}
+
+func TestHiddenResource(t *testing.T) {
+	r := Resource{
+		path: "/test",
+	}
+	r.Hidden()
+
+	assert.Nil(t, r.toOpenAPI(&oaComponents{}))
+}


### PR DESCRIPTION
Allows for creating hidden resource routes that don't appear in the OpenAPI spec or documentation. This is useful for creating endpoints like LB health checks, readiness checks, etc which can use the same server mux but should not appear as part of the API.