### PR TITLE
Add GetMux function to Resource to get the Chi Mux

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -122,3 +122,8 @@ func (r *Resource) Tags(names ...string) {
 func (r *Resource) Hidden() {
 	r.hidden = true
 }
+
+// GetMux gets the Chi router for this resource.
+func (r *Resource) GetMux() chi.Router {
+	return r.mux
+}


### PR DESCRIPTION
This semi addresses issue #20 in that it gives us a Getter to get the chi mux so we can add handlers for methods other than Huma Resources.