### PR TITLE
fix: $schema in request, fixes #48

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -103,23 +103,14 @@ func (c *oaComponents) addSchema(t reflect.Type, mode schema.Mode, hint string, 
 	return c.addExistingSchema(s, name, generateSchemaField)
 }
 
- //AddExistingSchema adds an existing schema instance under the given name.
+// AddExistingSchema adds an existing schema instance under the given name.
 func (c *oaComponents) AddExistingSchema(s *schema.Schema, name string, generateSchemaField bool) string {
 	return c.addExistingSchema(s, name, generateSchemaField)
 }
 
 func (c *oaComponents) addExistingSchema(s *schema.Schema, name string, generateSchemaField bool) string {
-	if generateSchemaField && s.Type == schema.TypeObject && s.Properties != nil {
-		if s.Properties["$schema"] == nil {
-			// Some editors allow you to place a $schema key which gives you rich
-			// validation and code completion support. Let's enable that by allowing
-			// a field here if it doesn't already exist in the model.
-			s.Properties["$schema"] = &schema.Schema{
-				Type:        schema.TypeString,
-				Format:      "uri",
-				Description: "An optional URL to a JSON Schema document describing this resource",
-			}
-		}
+	if generateSchemaField {
+		s.AddSchemaField()
 	}
 
 	orig := name

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -23,26 +23,26 @@ func TestComponentSchemas(t *testing.T) {
 	}
 
 	// Adding two different versions of the same component.
-	ref := components.AddSchema(reflect.TypeOf(&componentFoo{}), schema.ModeRead, "hint")
+	ref := components.AddSchema(reflect.TypeOf(&componentFoo{}), schema.ModeRead, "hint", true)
 	assert.Equal(t, ref, "#/components/schemas/componentFoo")
 	assert.NotNil(t, components.Schemas["componentFoo"])
 
-	ref = components.AddSchema(reflect.TypeOf(&componentFoo{}), schema.ModeWrite, "hint")
+	ref = components.AddSchema(reflect.TypeOf(&componentFoo{}), schema.ModeWrite, "hint", true)
 	assert.Equal(t, ref, "#/components/schemas/componentFoo2")
 	assert.NotNil(t, components.Schemas["componentFoo2"])
 
 	// Re-adding the second should not create a third.
-	ref = components.AddSchema(reflect.TypeOf(&componentFoo{}), schema.ModeWrite, "hint")
+	ref = components.AddSchema(reflect.TypeOf(&componentFoo{}), schema.ModeWrite, "hint", true)
 	assert.Equal(t, ref, "#/components/schemas/componentFoo2")
 	assert.Nil(t, components.Schemas["componentFoo3"])
 
 	// Adding a list of pointers to a struct.
-	ref = components.AddSchema(reflect.TypeOf([]*componentBar{}), schema.ModeAll, "hint")
+	ref = components.AddSchema(reflect.TypeOf([]*componentBar{}), schema.ModeAll, "hint", true)
 	assert.Equal(t, ref, "#/components/schemas/componentBarList")
 	assert.NotNil(t, components.Schemas["componentBarList"])
 
 	// Adding an anonymous empty struct, should use the hint.
-	ref = components.AddSchema(reflect.TypeOf(struct{}{}), schema.ModeAll, "hint")
+	ref = components.AddSchema(reflect.TypeOf(struct{}{}), schema.ModeAll, "hint", true)
 	assert.Equal(t, ref, "#/components/schemas/hint")
 	assert.NotNil(t, components.Schemas["hint"])
 }

--- a/operation.go
+++ b/operation.go
@@ -240,6 +240,9 @@ func (o *Operation) Run(handler interface{}) {
 
 			if o.requestSchema == nil {
 				o.requestSchema, err = schema.GenerateWithMode(body.Type, schema.ModeWrite, nil)
+				if o.resource != nil && o.resource.router != nil && !o.resource.router.disableSchemaProperty {
+					o.requestSchema.AddSchemaField()
+				}
 				if err != nil {
 					panic(fmt.Errorf("unable to generate JSON schema: %w", err))
 				}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -171,6 +171,24 @@ func (s *Schema) RemoveProperty(name string) {
 	}
 }
 
+// AddSchemaField adds a $schema field if none is present, allowing the
+// resource to be self-descriptive and enabling editor features like
+// code completion / suggestions as you type & inline linting / validation.
+func (s *Schema) AddSchemaField() {
+	if s.Type == TypeObject && s.Properties != nil {
+		if s.Properties["$schema"] == nil {
+			// Some editors allow you to place a $schema key which gives you rich
+			// validation and code completion support. Let's enable that by allowing
+			// a field here if it doesn't already exist in the model.
+			s.Properties["$schema"] = &Schema{
+				Type:        TypeString,
+				Format:      "uri",
+				Description: "An optional URL to a JSON Schema document describing this resource",
+			}
+		}
+	}
+}
+
 // Generate creates a JSON schema for a Go type. Struct field tags
 // can be used to provide additional metadata such as descriptions and
 // validation.

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Example() {
@@ -620,4 +621,12 @@ func TestExampleBadJSON(t *testing.T) {
 
 	_, err := Generate(reflect.TypeOf(Foo{}))
 	assert.Error(t, err)
+}
+
+func TestAddSchemaField(t *testing.T) {
+	dummy := struct{ Name string }{Name: "test"}
+	s, err := Generate(reflect.TypeOf(dummy))
+	require.NoError(t, err)
+	s.AddSchemaField()
+	assert.NotNil(t, s.Properties["$schema"])
 }


### PR DESCRIPTION
This fixes the tests, fixes a bug where a request with `$schema` can fail validation, and writes a new round-trip test.