### PR TITLE
fix: panic on put without body

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -81,7 +81,7 @@ func (r *Router) AutoPatch() {
 			case http.MethodPut:
 				put = op
 				_, reqDef := put.requestForContentType("application/json")
-				if reqDef.model != nil {
+				if reqDef != nil && reqDef.model != nil {
 					kind = reqDef.model.Kind()
 					if kind == reflect.Ptr {
 						kind = reqDef.model.Elem().Kind()

--- a/resolver.go
+++ b/resolver.go
@@ -237,7 +237,7 @@ func setFields(ctx *hcontext, req *http.Request, input reflect.Value, t reflect.
 				continue
 			}
 
-			if reqDef.schema != nil && reqDef.schema.HasValidation() {
+			if reqDef != nil && reqDef.schema != nil && reqDef.schema.HasValidation() {
 				if !validAgainstSchema(ctx, locationBody+".", reqDef.schema, data) {
 					continue
 				}


### PR DESCRIPTION
This adds an additional `nil` check to prevent a panic when registering or handling a request for a `PUT` operation without a request body. Also adds a test to exercise the functionality and confirm the auto-patch feature skips such operations.