### PR TITLE
fix: auto-mark patch deprecated

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -168,7 +168,8 @@ func generatePatch(resource *Resource, get *Operation, put *Operation) {
 				model:    jsonPatchType,
 			},
 		},
-		responses: responses,
+		responses:  responses,
+		deprecated: put.deprecated,
 	})
 
 	// Manually register the handler with the router. This bypasses the normal


### PR DESCRIPTION
This will mark auto-generated `PATCH` operations to also be flagged as `deprecated` if the corresponding `PUT` operation is flagged as so. 