### PR TITLE
fix: don't override vary header

### DIFF
--- a/middleware/encoding.go
+++ b/middleware/encoding.go
@@ -61,7 +61,7 @@ func (w *contentEncodingWriter) Write(data []byte) (int, error) {
 			w.writer = br
 		}
 		w.Header().Set("Content-Encoding", w.encoding)
-		w.Header().Set("Vary", "Accept-Encoding")
+		w.Header().Add("Vary", "Accept-Encoding")
 		w.ResponseWriter.WriteHeader(w.status)
 		w.wroteHeader = true
 		bufData := w.buf.Bytes()


### PR DESCRIPTION
Huma currently overrides the `Vary` response header to always be `Vary: Accept-Encoding`. This is problematic because it overrides other potential headers the server might set to indicate how the browser should cache the resource. For example, `Vary: Origin` may be needed to avoid CORs when the same resource is being called by multiple origins [docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#cors_and_caching).

This PR instead has Huma add the `Vary: Accept-Encoding` to avoid overwriting other `Vary` values already set. 