### PR TITLE
feat: avoids infinite recursion

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -94,8 +94,10 @@ func (c *oaComponents) addSchema(t reflect.Type, mode schema.Mode, hint string, 
 			},
 		}
 	} else {
+		// TODO: See if this type has a predefined schema associated with it
+		// via a predefined map, a callback or an interface.
 		var err error
-		if s, err = schema.GenerateWithMode(t, mode, nil); err != nil {
+		if s, err = schema.GenerateWithMode(t, mode, nil, map[string]string{}); err != nil {
 			panic(err)
 		}
 	}

--- a/operation.go
+++ b/operation.go
@@ -277,7 +277,7 @@ func (o *Operation) Run(handler interface{}) {
 				o.requests[ct].model = f.Type
 
 				if !o.requests[ct].override {
-					s, err := schema.GenerateWithMode(f.Type, schema.ModeWrite, nil)
+					s, err := schema.GenerateWithMode(f.Type, schema.ModeWrite, nil, map[string]string{})
 					if o.resource != nil && o.resource.router != nil && !o.resource.router.disableSchemaProperty {
 						s.AddSchemaField()
 					}

--- a/operation.go
+++ b/operation.go
@@ -278,11 +278,11 @@ func (o *Operation) Run(handler interface{}) {
 
 				if !o.requests[ct].override {
 					s, err := schema.GenerateWithMode(f.Type, schema.ModeWrite, nil, map[string]string{})
-					if o.resource != nil && o.resource.router != nil && !o.resource.router.disableSchemaProperty {
-						s.AddSchemaField()
-					}
 					if err != nil {
 						panic(fmt.Errorf("unable to generate JSON schema: %w", err))
+					}
+					if o.resource != nil && o.resource.router != nil && !o.resource.router.disableSchemaProperty {
+						s.AddSchemaField()
 					}
 					o.requests[ct].schema = s
 				}

--- a/resolver.go
+++ b/resolver.go
@@ -513,7 +513,7 @@ func getParamInfo(t reflect.Type) (map[string]oaParam, []string) {
 			p.CLIName = cliName
 		}
 
-		_, _, s, err := schema.GenerateFromField(f, schema.ModeRead)
+		_, _, s, err := schema.GenerateFromField(f, schema.ModeRead, map[string]string{})
 		if err != nil {
 			panic(err)
 		}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -486,10 +486,6 @@ func GenerateWithMode(t reflect.Type, mode Mode, schema *Schema, definedRefs map
 		schema.AdditionalProperties = false
 
 		for _, f := range getFields(t) {
-			fname := f.Type.Name()
-			if fname == tname {
-				return nil, fmt.Errorf("Recursion detected")
-			}
 			name, optional, s, err := GenerateFromField(f, mode, definedRefs)
 			if err != nil {
 				return nil, err

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -476,7 +476,7 @@ func GenerateWithMode(t reflect.Type, mode Mode, schema *Schema, definedRefs map
 			if exists {
 				return &Schema{Ref: ref}, nil
 			} else {
-				definedRefs[tname] = fmt.Sprintf("./schemas/%s", tname)
+				definedRefs[tname] = fmt.Sprintf("#/components/schemas/%s", tname)
 			}
 		}
 


### PR DESCRIPTION
I'm submitting this pull request in response to issue #75.  

This keeps track (during recursion) of what (`struct`) types have already been defined.  If it encounters an already defined schema, it simply replaces it with an `$ref` rather than elaborating the schema again (and again, and again).

This isn't perfect.  It makes some assumptions about the schema name.

Note, even though the `$ref` I added was something like `./schemas/Foo`, when it gets generated by the schemas endpoint it is `./schemas/Foo.json` which is not good.  Specifically, I'm thinking about cases where we might want to put in a `$ref` that is something like `#/definitions/Foo`.  In that case, no `.json` is required (or desirable).  So you might want to consider revisiting the logic that appends to the `$ref`s.

The other problem here is one that I mentioned in #74 which is that if any of these recursive schemas are generic, then you get a `$ref` that looks something like `./schemas/Struct[parameter].json`.  The `/schemas` endpoint cannot handles these.  So while the schema generation part now works (no more crashes due to infinite recursion), it will almost certainly run into trouble if any client were to actually follow these `$ref`s.

Please let me know if any others concerns you have with this PR.