### PR TITLE
feat: ability to fetch router from huma context

### DIFF
--- a/router.go
+++ b/router.go
@@ -582,8 +582,8 @@ func New(docs, version string) *Router {
 			// Inject the operation info before other middleware so that the later
 			// middleware will have access to it.
 			reqContext := req.Context()
-			withOpenID := context.WithValue(reqContext, opIDContextKey, &OperationInfo{})
-			withRouter := context.WithValue(withOpenID, routerContextKey, r)
+			withOpID := context.WithValue(reqContext, opIDContextKey, &OperationInfo{})
+			withRouter := context.WithValue(withOpID, routerContextKey, r)
 			req = req.WithContext(withRouter)
 
 			next.ServeHTTP(w, req)

--- a/router.go
+++ b/router.go
@@ -255,7 +255,9 @@ func (r *Router) Resource(path string) *Resource {
 	return res
 }
 
-// GetOperation returns the path and
+// GetOperation returns an `OperationInfo` struct for the operation named by the
+// `id` argument.  The `OperationInfo` struct provides the URL template and a
+// summary of the operation along with any tags associated with the operation.
 func (r *Router) GetOperation(id string) *OperationInfo {
 	// Loop over all router resources looking for the specified operation
 	for _, res := range r.resources {

--- a/router_test.go
+++ b/router_test.go
@@ -64,6 +64,15 @@ func TestStreamingInput(t *testing.T) {
 		ctx.WriteHeader(http.StatusNoContent)
 	})
 
+	stream := r.GetOperation("stream")
+	assert.NotNil(t, stream)
+	assert.Equal(t, *stream, OperationInfo{
+		ID:          "stream",
+		URITemplate: "/stream",
+		Summary:     "Stream test",
+		Tags:        []string{},
+	})
+
 	w := httptest.NewRecorder()
 	body := bytes.NewReader(make([]byte, 1024))
 	req, _ := http.NewRequest(http.MethodPost, "/stream", body)


### PR DESCRIPTION
This allows us to query the router for information.  I've added a GetOperation method so we can query for information about a given operation.  This is useful in hypermedia APIs because it allows us to link across different endpoints without having to hardwire paths.  Instead, the cross-referencing is done via operation id.