### PR TITLE
fix: properly instantiate nested schemas

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -277,7 +277,8 @@ func (o *Operation) Run(handler interface{}) {
 				o.requests[ct].model = f.Type
 
 				if !o.requests[ct].override {
-					s, err := schema.GenerateWithMode(f.Type, schema.ModeWrite, nil, map[string]string{})
+					nestedSchemas := map[string]schema.NestedSchemaReference{}
+					s, err := schema.GenerateWithMode(f.Type, schema.ModeWrite, nil, nestedSchemas)
 					if err != nil {
 						panic(fmt.Errorf("unable to generate JSON schema: %w", err))
 					}

--- a/resolver.go
+++ b/resolver.go
@@ -513,7 +513,8 @@ func getParamInfo(t reflect.Type) (map[string]oaParam, []string) {
 			p.CLIName = cliName
 		}
 
-		_, _, s, err := schema.GenerateFromField(f, schema.ModeRead, map[string]string{})
+		nestedSchemas := map[string]schema.NestedSchemaReference{}
+		_, _, s, err := schema.GenerateFromField(f, schema.ModeRead, nestedSchemas)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
My previous fix for recursion prevented the crash but it wasn't a complete fix.  The issue I uncovered is that the OpenAPI specification data was incomplete.  You can see this by trying to access `/schemas/SomeSchema.json` where `SomeSchema` refers to a Go type that is not a response type but is nested inside a response type.  Before this fix, that would result in an error.  But just as bad, the OpenAPI spec generated (_i.e.,_ the contents of `/openapi.json`) were incomplete...schema definitions were missing there as well.

The reason for this is that my fix for infinite recursion was to simply replace all struct fields with a `$ref` to the actual schema rather than elaborate the schema in place.  As far as I can tell, this works fine.  But the reason it is incomplete is that the way `huma` constructs the OpenAPI components and their schemas is to simply generate a schema for the response type and publish that.  It didn't publish the nested schemas.  The reason is that previously _it didn't need to_ because they were all inline and so they would get picked up anyway.  But now they are not inline, they are simply referenced.  But that `$ref` pointer didn't resolve properly because it pointed to a schema definition that was never actually inserted into the OpenAPI specification document.

This change fixes that.  The fix is pretty simple and it arose from me not understanding how `huma` traverses the resources to build the OpenAPI spec.  With this fix in place, every time we skip over a nested schema `$ref` (to avoid recursion) while generate a schema, we make a note of this.  This information is then available after the schema is generated.  In the case of injecting the response schema into the OpenAPI components, we include a second pass where we _also_ inject any nested schemas if they haven't already been injected.

As a result, both the `/schemas/SomeType.json` URLs resolve to an actual JSON Schema document but also the `/openapi.json` file is complete (_i.e.,_ includes all definitions referenced via `$ref`).