### PR TITLE
fix: implement Flusher interface for wrapped ResponseWriters

### DIFF
--- a/context.go
+++ b/context.go
@@ -100,6 +100,9 @@ type Context interface {
 	// WriteContent wraps http.ServeContent in order to handle serving streams
 	// it will handle Range and Modified (like If-Unmodified-Since) headers.
 	WriteContent(name string, content io.ReadSeeker, lastModified time.Time)
+
+	// Implement the http.Flusher interface
+	Flush()
 }
 
 type hcontext struct {
@@ -430,4 +433,10 @@ func (c *hcontext) WriteContent(name string, content io.ReadSeeker, lastModified
 
 	http.ServeContent(c.ResponseWriter, c.r, name, lastModified, content)
 	c.closed = true
+}
+
+func (c *hcontext) Flush() {
+	if f, ok := c.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -70,6 +70,14 @@ func (r *statusRecorder) WriteHeader(statusCode int) {
 	r.ResponseWriter.WriteHeader(statusCode)
 }
 
+// `statusRecorder` implements the Flusher interface if the
+// underlying `ResponseWriter` does
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // Logger creates a new middleware to set a tagged `*zap.SugarLogger` in the
 // request context. It debug logs request info. If the current terminal is a
 // TTY, it will try to use colored output automatically.


### PR DESCRIPTION
This seems to address issue #88.  As the standard library docs suggested, the problem is related to wrapping `ResponseWriter` instances.  I went through and implemented a `Flush` method for the `statusRecorder` and `huma.Context` types.  I tested this with a resource handler that was generated server side events (_i.e.,_ called `ctx.Write(...)` multiple times invoking `.Flush()` after each).  Running `curl -N ...` showed that the output was, in fact, getting flushed (which was definitely **not** the case before these changes).

I haven't tested this with an SSE client, but just running `curl -N` seems like an adequate test of the functionality for now.