### PR TITLE
fix: add missing CORS headers

### DIFF
--- a/context.go
+++ b/context.go
@@ -19,13 +19,15 @@ import (
 // explicitly being documented. Mostly they are low-level HTTP headers that
 // control access or connection settings.
 var allowedHeaders = map[string]bool{
-	"access-control-allow-origin":  true,
-	"access-control-allow-methods": true,
-	"access-control-allow-headers": true,
-	"access-control-max-age":       true,
-	"connection":                   true,
-	"keep-alive":                   true,
-	"vary":                         true,
+	"access-control-allow-origin":      true,
+	"access-control-expose-headers":    true,
+	"access-control-allow-methods":     true,
+	"access-control-allow-headers":     true,
+	"access-control-allow-credentials": true,
+	"access-control-max-age":           true,
+	"connection":                       true,
+	"keep-alive":                       true,
+	"vary":                             true,
 }
 
 // AddAllowedHeader adds a header to the list of allowed headers for the response.


### PR DESCRIPTION
According to [this](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#the_http_response_headers), there are two standard CORS headers that are missing here, `Access-Control-Expose-Headers` and `Access-Control-Allow-Credentials`.