### PR TITLE
feat: add server variables for server URL template substitution

### DIFF
--- a/examples/bookstore/bookstore.go
+++ b/examples/bookstore/bookstore.go
@@ -60,7 +60,7 @@ var memoryDB = sync.Map{}
 func main() {
 	// Create a new router and give our API a title and version.
 	app := cli.NewRouter("BookStore API", "1.0.0")
-	app.ServerLink("Development server", "http://localhost:8888")
+	app.ServerLink("Development server", "http://localhost:8888", map[string]huma.CaServerVariable{})
 
 	genres := app.Resource("/v1/genres")
 	genres.Get("list-genres", "Returns a list of all genres",

--- a/examples/notes/notes.go
+++ b/examples/notes/notes.go
@@ -36,7 +36,7 @@ var memoryDB = sync.Map{}
 func main() {
 	// Create a new router and give our API a title and version.
 	app := cli.NewRouter("Notes API", "1.0.0")
-	app.ServerLink("Development server", "http://localhost:8888")
+	app.ServerLink("Development server", "http://localhost:8888", map[string]huma.CaServerVariable{})
 
 	notes := app.Resource("/v1/notes")
 	notes.Get("list-notes", "Returns a list of all notes",

--- a/openapi.go
+++ b/openapi.go
@@ -16,8 +16,16 @@ type oaContact struct {
 
 // oaServer describes an OpenAPI 3 API server location
 type oaServer struct {
-	URL         string `json:"url"`
-	Description string `json:"description,omitempty"`
+	URL         string                      `json:"url"`
+	Description string                      `json:"description,omitempty"`
+	Variables   map[string]CaServerVariable `json:"variables,omitempty"`
+}
+
+// CaServerVariable describe a server variable for server URL template substitution.
+type CaServerVariable struct {
+	Enum        []string `json:"enum,omitempty"`
+	Default     string   `json:"default,omitempty"`
+	Description string   `json:"description,omitempty"`
 }
 
 // paramLocation describes where in the HTTP request the parameter comes from.

--- a/router.go
+++ b/router.go
@@ -144,10 +144,11 @@ func (r *Router) Contact(name, email, url string) {
 }
 
 // ServerLink adds a new server link to this router for documentation.
-func (r *Router) ServerLink(description, uri string) {
+func (r *Router) ServerLink(description, uri string, variables map[string]CaServerVariable) {
 	r.servers = append(r.servers, oaServer{
 		Description: description,
 		URL:         uri,
+		Variables:   variables,
 	})
 }
 


### PR DESCRIPTION
Allow to use server variables like this
![image](https://user-images.githubusercontent.com/79602273/225945923-fd8bb137-45be-482d-8b96-1f9459fb4426.png)



ref: https://swagger.io/docs/specification/api-host-and-base-path/

Example PoC usage

```go
humaRouter.ServerLink("Example server", "{scheme}://{host}:{port}/api", map[string]huma.CaServerVariable{
	"scheme": {
		Enum:        []string{"http", "https"},
		Default:     "https",
		Description: "Example description 🔥",
	},
	"host": {
		Default:     "127.0.0.1",
		Description: "IP or domain where your server is located.",
	},
	"port": {
		Default:     "1337",
		Description: "Server port.",
	},
})
```