### PR TITLE
fix: properly instantiate nested schemas, replaces #86

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,18 @@ Parameters have some additional validation tags:
 | ---------- | ------------------------------ | ----------------- |
 | `internal` | Internal-only (not documented) | `internal:"true"` |
 
+## Recursion
+
+Recursive inputs or outputs are supported by setting a special field in the schema generator (this is to support backward-compatibility):
+
+```go
+	// Set to false to generate references to each struct that are shared between
+	// the various operation inputs/outputs, enabling support for recursion.
+	schema.GenerateInline = false
+```
+
+The default behavior is to generate everything inline. Note that switching between the two styles is likely to break generated SDKs, so plan for a major version bump if/when you make the change.
+
 ## Middleware
 
 Standard [Go HTTP middleware](https://justinas.org/writing-http-middleware-in-go) is supported. It can be attached to the main router/app or to individual resources, but **must** be added _before_ operation handlers are added.

--- a/openapi.go
+++ b/openapi.go
@@ -116,7 +116,7 @@ func (c *oaComponents) addSchema(t reflect.Type, mode schema.Mode, hint string, 
 				}
 				// Add the generated schema to the list of schemas associatd
 				// with this component.
-				c.Schemas[k] = s
+				c.addExistingSchema(s, k, generateSchemaField)
 			}
 		}
 	}

--- a/operation.go
+++ b/operation.go
@@ -277,7 +277,8 @@ func (o *Operation) Run(handler interface{}) {
 				o.requests[ct].model = f.Type
 
 				if !o.requests[ct].override {
-					s, err := schema.GenerateWithMode(f.Type, schema.ModeWrite, nil, map[string]string{})
+					nestedSchemas := map[string]schema.NestedSchemaReference{}
+					s, err := schema.GenerateWithMode(f.Type, schema.ModeWrite, nil, nestedSchemas)
 					if err != nil {
 						panic(fmt.Errorf("unable to generate JSON schema: %w", err))
 					}

--- a/resolver.go
+++ b/resolver.go
@@ -513,7 +513,8 @@ func getParamInfo(t reflect.Type) (map[string]oaParam, []string) {
 			p.CLIName = cliName
 		}
 
-		_, _, s, err := schema.GenerateFromField(f, schema.ModeRead, map[string]string{})
+		nestedSchemas := map[string]schema.NestedSchemaReference{}
+		_, _, s, err := schema.GenerateFromField(f, schema.ModeRead, nestedSchemas)
 		if err != nil {
 			panic(err)
 		}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -15,6 +15,12 @@ import (
 	"time"
 )
 
+// GenerateInline controls whether schemas are generated inline or as references
+// to components. Inline schemas are the existing default behavior, but do not
+// support recursive schemas. If you need recursive schemas, set this to false
+// before generating any schemas.
+var GenerateInline bool = true
+
 // ErrSchemaInvalid is sent when there is a problem building the schema.
 var ErrSchemaInvalid = errors.New("schema is invalid")
 
@@ -477,16 +483,18 @@ func GenerateWithMode(t reflect.Type, mode Mode, schema *Schema, definedRefs map
 			return &Schema{Type: TypeString, Format: "uri"}, nil
 		}
 
-		tname := t.Name()
-		if tname != "" {
-			ref, exists := definedRefs[tname]
-			if exists {
-				return &Schema{Ref: ref.Ref}, nil
-			} else {
-				definedRefs[tname] = NestedSchemaReference{
-					Name: tname,
-					Ref:  fmt.Sprintf("#/components/schemas/%s", tname),
-					Type: t,
+		if !GenerateInline {
+			tname := t.Name()
+			if tname != "" {
+				ref, exists := definedRefs[tname]
+				if exists {
+					return &Schema{Ref: ref.Ref}, nil
+				} else {
+					definedRefs[tname] = NestedSchemaReference{
+						Name: tname,
+						Ref:  fmt.Sprintf("#/components/schemas/%s", tname),
+						Type: t,
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This continues the work from #86, and reverts the new behavior to be behind a feature flag that must be enabled to not break existing service's generated SDKs. To enable the new behavior, just set `schema.GenerateInline = false`.