### PR TITLE
fix: enforce path params are required

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -271,7 +271,14 @@ func setFields(ctx *hcontext, req *http.Request, input reflect.Value, t reflect.
 		if name, ok := f.Tag.Lookup(locationPath); ok {
 			pname = name
 			location = locationPath
-			if v := chi.URLParam(req, name); v != "" {
+			v := chi.URLParam(req, name)
+			if v == "" {
+				ctx.AddError(&ErrorDetail{
+					Message:  fmt.Sprintf("%s is required", name),
+					Location: location + "." + name,
+					Value:    v,
+				})
+			} else {
 				pv = v
 			}
 		}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -360,3 +360,24 @@ func TestRawBody(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnprocessableEntity, w.Result().StatusCode)
 }
+
+type PathParamTestModel struct {
+	TestParam string `path:"test-id"`
+}
+
+func TestPathParamAlwaysRequired(t *testing.T) {
+	app := newTestRouter()
+
+	app.Resource("/test/{test-id}/foo").Get("test", "Test",
+		NewResponse(http.StatusOK, "desc"),
+	).Run(func(ctx Context, input PathParamTestModel) {
+		ctx.WriteHeader(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest(http.MethodGet, "/test//foo", nil)
+	app.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+	assert.Contains(t, w.Body.String(), "test-id is required")
+}


### PR DESCRIPTION
Huma marks path params as required when [generating the OpenAPI docs](https://github.com/danielgtaylor/huma/blob/d1d01e55ff4ac708600da01064ab890cda018422/resolver.go#L480), which complies with OpenAPI 3.0. However, Huma does not check if path params values are non-empty during runtime. 

For example, in the bookstore example, not providing the `genre-id` will result in a 404 after failing to find an empty genre instead of a 400.

```sh
restish :8888/v1/genres//books
HTTP/1.1 404 Not Found

{
  $schema: "http://localhost:8888/schemas/ErrorModel.json"
  detail: "Genre  not found"
  status: 404
  title: "Not Found"
}
```

Huma uses the `Chi` router which does not mark path parameters as required unless regex or additional custom logic is added. This PR modifies the `resolver` to check if a path param value is empty and throws an error instead of continuing. 

The new output for the same bookstore request is as follows:
```sh
restish :8888/v1/genres//books
HTTP/1.1 400 Bad Request

{
  $schema: "http://localhost:8888/schemas/ErrorModel.json"
  detail: "Error while processing input parameters"
  errors: [
    {
      location: "path.genre-id"
      message: "genre-id is required"
      value: ""
    }
  ]
  status: 400
  title: "Bad Request"
}
```