### PR TITLE
feat: method to use custom chi mux; enables incremental adoption of v2

### DIFF
--- a/router.go
+++ b/router.go
@@ -592,10 +592,17 @@ const (
 // New creates a new Huma router to which you can attach resources,
 // operations, middleware, etc.
 func New(docs, version string) *Router {
+	return NewWithMux(docs, version, chi.NewRouter())
+}
+
+// NewWithMux creates a new Huma router to which you can attach resources,
+// operations, middleware, etc. It allows you to specify the underlying
+// `*chi.Mux` instance to use.
+func NewWithMux(docs, version string, mux *chi.Mux) *Router {
 	title, desc := splitDocs(docs)
 
 	r := &Router{
-		mux:                      chi.NewRouter(),
+		mux:                      mux,
 		resources:                []*Resource{},
 		title:                    title,
 		description:              desc,


### PR DESCRIPTION
This change enables people to start playing with the v2 branch (requires a `replace` directive in your `go.mod` at the moment pointing to the v2 branch).

```go
import (
	"github.com/danielgtaylor/huma"
	humav2 "github.com/danielgtaylor/huma/v2"
	"github.com/danielgtaylor/huma/v2/adapters/humachi"
)

// ...

mux := chi.NewRouter()

app := huma.NewWithMux("My API", "1.0.0", mux)
// ... register v1 routes

// Set up v2 to use the same mux & register v2 routes
api := humachi.New(mux, humav2.DefaultConfig("My API", "1.0.0"))
humav2.Register(/* ... */)

app.Run()
```

Note: this does not merge the generated OpenAPI. You can manually use a Huma v1 Open API hook to do that to merge the v2 `api.OpenAPI()` if desired.