### PR TITLE
fix: param date/time parsing, better tests/coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 ignore:
   - benchmark
   - examples
+  - adapters

--- a/schema.go
+++ b/schema.go
@@ -260,6 +260,16 @@ func SchemaFromField(registry Registry, parent reflect.Type, f reflect.StructFie
 	if fmt := f.Tag.Get("format"); fmt != "" {
 		fs.Format = fmt
 	}
+	if timeFmt := f.Tag.Get("timeFormat"); timeFmt != "" {
+		switch timeFmt {
+		case "2006-01-02":
+			fs.Format = "date"
+		case "15:04:05":
+			fs.Format = "time"
+		default:
+			fs.Format = timeFmt
+		}
+	}
 	if enc := f.Tag.Get("encoding"); enc != "" {
 		fs.ContentEncoding = enc
 	}


### PR DESCRIPTION
This PR adds some additional tests and corrects an issue with parameter date/time parsing and validation. The custom `timeFormat` of `2006-01-02` and `15:04:05` are also correctly identified as JSON schema `date` and `time` now as well, so additional validation is possible.