### PR TITLE
Add GetMultipartForm method to huma context

### DIFF
--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -3,6 +3,7 @@ package humachi
 import (
 	"context"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"time"
@@ -18,68 +19,73 @@ type chiContext struct {
 	w  http.ResponseWriter
 }
 
-func (ctx *chiContext) Operation() *huma.Operation {
-	return ctx.op
+func (c *chiContext) Operation() *huma.Operation {
+	return c.op
 }
 
-func (ctx *chiContext) Context() context.Context {
-	return ctx.r.Context()
+func (c *chiContext) Context() context.Context {
+	return c.r.Context()
 }
 
-func (ctx *chiContext) Method() string {
-	return ctx.r.Method
+func (c *chiContext) Method() string {
+	return c.r.Method
 }
 
-func (ctx *chiContext) Host() string {
-	return ctx.r.Host
+func (c *chiContext) Host() string {
+	return c.r.Host
 }
 
-func (ctx *chiContext) URL() url.URL {
-	return *ctx.r.URL
+func (c *chiContext) URL() url.URL {
+	return *c.r.URL
 }
 
-func (ctx *chiContext) Param(name string) string {
-	return chi.URLParam(ctx.r, name)
+func (c *chiContext) Param(name string) string {
+	return chi.URLParam(c.r, name)
 }
 
-func (ctx *chiContext) Query(name string) string {
-	return queryparam.Get(ctx.r.URL.RawQuery, name)
+func (c *chiContext) Query(name string) string {
+	return queryparam.Get(c.r.URL.RawQuery, name)
 }
 
-func (ctx *chiContext) Header(name string) string {
-	return ctx.r.Header.Get(name)
+func (c *chiContext) Header(name string) string {
+	return c.r.Header.Get(name)
 }
 
-func (ctx *chiContext) EachHeader(cb func(name, value string)) {
-	for name, values := range ctx.r.Header {
+func (c *chiContext) EachHeader(cb func(name, value string)) {
+	for name, values := range c.r.Header {
 		for _, value := range values {
 			cb(name, value)
 		}
 	}
 }
 
-func (ctx *chiContext) BodyReader() io.Reader {
-	return ctx.r.Body
+func (c *chiContext) BodyReader() io.Reader {
+	return c.r.Body
 }
 
-func (ctx *chiContext) SetReadDeadline(deadline time.Time) error {
-	return huma.SetReadDeadline(ctx.w, deadline)
+func (c *chiContext) GetMultipartForm() (*multipart.Form, error) {
+	err := c.r.ParseMultipartForm(8 * 1024)
+	return c.r.MultipartForm, err
 }
 
-func (ctx *chiContext) SetStatus(code int) {
-	ctx.w.WriteHeader(code)
+func (c *chiContext) SetReadDeadline(deadline time.Time) error {
+	return huma.SetReadDeadline(c.w, deadline)
 }
 
-func (ctx *chiContext) AppendHeader(name string, value string) {
-	ctx.w.Header().Add(name, value)
+func (c *chiContext) SetStatus(code int) {
+	c.w.WriteHeader(code)
 }
 
-func (ctx *chiContext) SetHeader(name string, value string) {
-	ctx.w.Header().Set(name, value)
+func (c *chiContext) AppendHeader(name string, value string) {
+	c.w.Header().Add(name, value)
 }
 
-func (ctx *chiContext) BodyWriter() io.Writer {
-	return ctx.w
+func (c *chiContext) SetHeader(name string, value string) {
+	c.w.Header().Set(name, value)
+}
+
+func (c *chiContext) BodyWriter() io.Writer {
+	return c.w
 }
 
 type chiAdapter struct {

--- a/adapters/humafiber/humafiber.go
+++ b/adapters/humafiber/humafiber.go
@@ -3,6 +3,7 @@ package humafiber
 import (
 	"context"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,8 +18,8 @@ type fiberCtx struct {
 	orig *fiber.Ctx
 }
 
-func (ctx *fiberCtx) Operation() *huma.Operation {
-	return ctx.op
+func (c *fiberCtx) Operation() *huma.Operation {
+	return c.op
 }
 
 func (c *fiberCtx) Matched() string {
@@ -33,8 +34,8 @@ func (c *fiberCtx) Method() string {
 	return c.orig.Method()
 }
 
-func (ctx *fiberCtx) Host() string {
-	return ctx.orig.Hostname()
+func (c *fiberCtx) Host() string {
+	return c.orig.Hostname()
 }
 
 func (c *fiberCtx) URL() url.URL {
@@ -62,6 +63,10 @@ func (c *fiberCtx) EachHeader(cb func(name, value string)) {
 
 func (c *fiberCtx) BodyReader() io.Reader {
 	return c.orig.Request().BodyStream()
+}
+
+func (c *fiberCtx) GetMultipartForm() (*multipart.Form, error) {
+	return c.orig.MultipartForm()
 }
 
 func (c *fiberCtx) SetReadDeadline(deadline time.Time) error {

--- a/adapters/humagin/humagin.go
+++ b/adapters/humagin/humagin.go
@@ -3,6 +3,7 @@ package humagin
 import (
 	"context"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,8 +18,8 @@ type ginCtx struct {
 	orig *gin.Context
 }
 
-func (ctx *ginCtx) Operation() *huma.Operation {
-	return ctx.op
+func (c *ginCtx) Operation() *huma.Operation {
+	return c.op
 }
 
 func (c *ginCtx) Context() context.Context {
@@ -29,8 +30,8 @@ func (c *ginCtx) Method() string {
 	return c.orig.Request.Method
 }
 
-func (ctx *ginCtx) Host() string {
-	return ctx.orig.Request.Host
+func (c *ginCtx) Host() string {
+	return c.orig.Request.Host
 }
 
 func (c *ginCtx) URL() url.URL {
@@ -61,8 +62,13 @@ func (c *ginCtx) BodyReader() io.Reader {
 	return c.orig.Request.Body
 }
 
-func (ctx *ginCtx) SetReadDeadline(deadline time.Time) error {
-	return huma.SetReadDeadline(ctx.orig.Writer, deadline)
+func (c *ginCtx) GetMultipartForm() (*multipart.Form, error) {
+	err := c.orig.Request.ParseMultipartForm(8 * 1024)
+	return c.orig.Request.MultipartForm, err
+}
+
+func (c *ginCtx) SetReadDeadline(deadline time.Time) error {
+	return huma.SetReadDeadline(c.orig.Writer, deadline)
 }
 
 func (c *ginCtx) SetStatus(code int) {

--- a/adapters/humahttprouter/humahttprouter.go
+++ b/adapters/humahttprouter/humahttprouter.go
@@ -3,6 +3,7 @@ package humahttprouter
 import (
 	"context"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
@@ -20,68 +21,73 @@ type httprouterContext struct {
 	ps httprouter.Params
 }
 
-func (ctx *httprouterContext) Operation() *huma.Operation {
-	return ctx.op
+func (c *httprouterContext) Operation() *huma.Operation {
+	return c.op
 }
 
-func (ctx *httprouterContext) Context() context.Context {
-	return ctx.r.Context()
+func (c *httprouterContext) Context() context.Context {
+	return c.r.Context()
 }
 
-func (ctx *httprouterContext) Method() string {
-	return ctx.r.Method
+func (c *httprouterContext) Method() string {
+	return c.r.Method
 }
 
-func (ctx *httprouterContext) Host() string {
-	return ctx.r.Host
+func (c *httprouterContext) Host() string {
+	return c.r.Host
 }
 
-func (ctx *httprouterContext) URL() url.URL {
-	return *ctx.r.URL
+func (c *httprouterContext) URL() url.URL {
+	return *c.r.URL
 }
 
-func (ctx *httprouterContext) Param(name string) string {
-	return ctx.ps.ByName(name)
+func (c *httprouterContext) Param(name string) string {
+	return c.ps.ByName(name)
 }
 
-func (ctx *httprouterContext) Query(name string) string {
-	return queryparam.Get(ctx.r.URL.RawQuery, name)
+func (c *httprouterContext) Query(name string) string {
+	return queryparam.Get(c.r.URL.RawQuery, name)
 }
 
-func (ctx *httprouterContext) Header(name string) string {
-	return ctx.r.Header.Get(name)
+func (c *httprouterContext) Header(name string) string {
+	return c.r.Header.Get(name)
 }
 
-func (ctx *httprouterContext) EachHeader(cb func(name, value string)) {
-	for name, values := range ctx.r.Header {
+func (c *httprouterContext) EachHeader(cb func(name, value string)) {
+	for name, values := range c.r.Header {
 		for _, value := range values {
 			cb(name, value)
 		}
 	}
 }
 
-func (ctx *httprouterContext) BodyReader() io.Reader {
-	return ctx.r.Body
+func (c *httprouterContext) BodyReader() io.Reader {
+	return c.r.Body
 }
 
-func (ctx *httprouterContext) SetReadDeadline(deadline time.Time) error {
-	return huma.SetReadDeadline(ctx.w, deadline)
+func (c *httprouterContext) GetMultipartForm() (*multipart.Form, error) {
+	err := c.r.ParseMultipartForm(8 * 1024)
+	return c.r.MultipartForm, err
 }
 
-func (ctx *httprouterContext) SetStatus(code int) {
-	ctx.w.WriteHeader(code)
+func (c *httprouterContext) SetReadDeadline(deadline time.Time) error {
+	return huma.SetReadDeadline(c.w, deadline)
 }
 
-func (ctx *httprouterContext) AppendHeader(name string, value string) {
-	ctx.w.Header().Add(name, value)
+func (c *httprouterContext) SetStatus(code int) {
+	c.w.WriteHeader(code)
 }
 
-func (ctx *httprouterContext) SetHeader(name string, value string) {
-	ctx.w.Header().Set(name, value)
+func (c *httprouterContext) AppendHeader(name string, value string) {
+	c.w.Header().Add(name, value)
 }
 
-func (ctx *httprouterContext) BodyWriter() io.Writer {
-	return ctx.w
+func (c *httprouterContext) SetHeader(name string, value string) {
+	c.w.Header().Set(name, value)
+}
+
+func (c *httprouterContext) BodyWriter() io.Writer {
+	return c.w
 }
 
 type httprouterAdapter struct {

--- a/adapters/humamux/humamux.go
+++ b/adapters/humamux/humamux.go
@@ -3,6 +3,7 @@ package humagmux
 import (
 	"context"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"time"
@@ -18,68 +19,73 @@ type gmuxContext struct {
 	w  http.ResponseWriter
 }
 
-func (ctx *gmuxContext) Operation() *huma.Operation {
-	return ctx.op
+func (c *gmuxContext) Operation() *huma.Operation {
+	return c.op
 }
 
-func (ctx *gmuxContext) Context() context.Context {
-	return ctx.r.Context()
+func (c *gmuxContext) Context() context.Context {
+	return c.r.Context()
 }
 
-func (ctx *gmuxContext) Method() string {
-	return ctx.r.Method
+func (c *gmuxContext) Method() string {
+	return c.r.Method
 }
 
-func (ctx *gmuxContext) Host() string {
-	return ctx.r.Host
+func (c *gmuxContext) Host() string {
+	return c.r.Host
 }
 
-func (ctx *gmuxContext) URL() url.URL {
-	return *ctx.r.URL
+func (c *gmuxContext) URL() url.URL {
+	return *c.r.URL
 }
 
-func (ctx *gmuxContext) Param(name string) string {
-	return mux.Vars(ctx.r)[name]
+func (c *gmuxContext) Param(name string) string {
+	return mux.Vars(c.r)[name]
 }
 
-func (ctx *gmuxContext) Query(name string) string {
-	return queryparam.Get(ctx.r.URL.RawQuery, name)
+func (c *gmuxContext) Query(name string) string {
+	return queryparam.Get(c.r.URL.RawQuery, name)
 }
 
-func (ctx *gmuxContext) Header(name string) string {
-	return ctx.r.Header.Get(name)
+func (c *gmuxContext) Header(name string) string {
+	return c.r.Header.Get(name)
 }
 
-func (ctx *gmuxContext) EachHeader(cb func(name, value string)) {
-	for name, values := range ctx.r.Header {
+func (c *gmuxContext) EachHeader(cb func(name, value string)) {
+	for name, values := range c.r.Header {
 		for _, value := range values {
 			cb(name, value)
 		}
 	}
 }
 
-func (ctx *gmuxContext) BodyReader() io.Reader {
-	return ctx.r.Body
+func (c *gmuxContext) BodyReader() io.Reader {
+	return c.r.Body
 }
 
-func (ctx *gmuxContext) SetReadDeadline(deadline time.Time) error {
-	return huma.SetReadDeadline(ctx.w, deadline)
+func (c *gmuxContext) GetMultipartForm() (*multipart.Form, error) {
+	err := c.r.ParseMultipartForm(8 * 1024)
+	return c.r.MultipartForm, err
 }
 
-func (ctx *gmuxContext) SetStatus(code int) {
-	ctx.w.WriteHeader(code)
+func (c *gmuxContext) SetReadDeadline(deadline time.Time) error {
+	return huma.SetReadDeadline(c.w, deadline)
 }
 
-func (ctx *gmuxContext) AppendHeader(name string, value string) {
-	ctx.w.Header().Add(name, value)
+func (c *gmuxContext) SetStatus(code int) {
+	c.w.WriteHeader(code)
 }
 
-func (ctx *gmuxContext) SetHeader(name string, value string) {
-	ctx.w.Header().Set(name, value)
+func (c *gmuxContext) AppendHeader(name string, value string) {
+	c.w.Header().Add(name, value)
 }
 
-func (ctx *gmuxContext) BodyWriter() io.Writer {
-	return ctx.w
+func (c *gmuxContext) SetHeader(name string, value string) {
+	c.w.Header().Set(name, value)
+}
+
+func (c *gmuxContext) BodyWriter() io.Writer {
+	return c.w
 }
 
 type gMux struct {

--- a/api.go
+++ b/api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -59,6 +60,7 @@ type Context interface {
 	Header(name string) string
 	EachHeader(cb func(name, value string))
 	BodyReader() io.Reader
+	GetMultipartForm() (*multipart.Form, error)
 	SetReadDeadline(time.Time) error
 	SetStatus(code int)
 	SetHeader(name, value string)

--- a/huma_test.go
+++ b/huma_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -26,76 +27,81 @@ type testContext struct {
 	w  http.ResponseWriter
 }
 
-func (ctx *testContext) Operation() *Operation {
-	return ctx.op
+func (c *testContext) Operation() *Operation {
+	return c.op
 }
 
-func (ctx *testContext) Matched() string {
-	return chi.RouteContext(ctx.r.Context()).RoutePattern()
+func (c *testContext) Matched() string {
+	return chi.RouteContext(c.r.Context()).RoutePattern()
 }
 
-func (ctx *testContext) Context() context.Context {
-	return ctx.r.Context()
+func (c *testContext) Context() context.Context {
+	return c.r.Context()
 }
 
-func (ctx *testContext) Method() string {
-	return ctx.r.Method
+func (c *testContext) Method() string {
+	return c.r.Method
 }
 
-func (ctx *testContext) Host() string {
-	return ctx.r.Host
+func (c *testContext) Host() string {
+	return c.r.Host
 }
 
-func (ctx *testContext) URL() url.URL {
-	return *ctx.r.URL
+func (c *testContext) URL() url.URL {
+	return *c.r.URL
 }
 
-func (ctx *testContext) Param(name string) string {
-	return chi.URLParam(ctx.r, name)
+func (c *testContext) Param(name string) string {
+	return chi.URLParam(c.r, name)
 }
 
-func (ctx *testContext) Query(name string) string {
-	return queryparam.Get(ctx.r.URL.RawQuery, name)
+func (c *testContext) Query(name string) string {
+	return queryparam.Get(c.r.URL.RawQuery, name)
 }
 
-func (ctx *testContext) Header(name string) string {
-	return ctx.r.Header.Get(name)
+func (c *testContext) Header(name string) string {
+	return c.r.Header.Get(name)
 }
 
-func (ctx *testContext) EachHeader(cb func(name, value string)) {
-	for name, values := range ctx.r.Header {
+func (c *testContext) EachHeader(cb func(name, value string)) {
+	for name, values := range c.r.Header {
 		for _, value := range values {
 			cb(name, value)
 		}
 	}
 }
 
-func (ctx *testContext) Body() ([]byte, error) {
-	return io.ReadAll(ctx.r.Body)
+func (c *testContext) Body() ([]byte, error) {
+	return io.ReadAll(c.r.Body)
 }
 
-func (ctx *testContext) BodyReader() io.Reader {
-	return ctx.r.Body
+func (c *testContext) BodyReader() io.Reader {
+	return c.r.Body
 }
 
-func (ctx *testContext) SetReadDeadline(deadline time.Time) error {
-	return http.NewResponseController(ctx.w).SetReadDeadline(deadline)
+func (c *testContext) GetMultipartForm() (*multipart.Form, error) {
+	err := c.r.ParseMultipartForm(8 * 1024)
+	return c.r.MultipartForm, err
 }
 
-func (ctx *testContext) SetStatus(code int) {
-	ctx.w.WriteHeader(code)
+func (c *testContext) SetReadDeadline(deadline time.Time) error {
+	return http.NewResponseController(c.w).SetReadDeadline(deadline)
 }
 
-func (ctx *testContext) AppendHeader(name string, value string) {
-	ctx.w.Header().Add(name, value)
+func (c *testContext) SetStatus(code int) {
+	c.w.WriteHeader(code)
 }
 
-func (ctx *testContext) SetHeader(name string, value string) {
-	ctx.w.Header().Set(name, value)
+func (c *testContext) AppendHeader(name string, value string) {
+	c.w.Header().Add(name, value)
 }
 
-func (ctx *testContext) BodyWriter() io.Writer {
-	return ctx.w
+func (c *testContext) SetHeader(name string, value string) {
+	c.w.Header().Set(name, value)
+}
+
+func (c *testContext) BodyWriter() io.Writer {
+	return c.w
 }
 
 type testAdapter struct {

--- a/humatest/humatest.go
+++ b/humatest/humatest.go
@@ -6,6 +6,7 @@ package humatest
 import (
 	"context"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -37,68 +38,73 @@ func NewContext(op *huma.Operation, r *http.Request, w http.ResponseWriter) huma
 	return &testContext{op, r, w}
 }
 
-func (ctx *testContext) Operation() *huma.Operation {
-	return ctx.op
+func (c *testContext) Operation() *huma.Operation {
+	return c.op
 }
 
-func (ctx *testContext) Context() context.Context {
-	return ctx.r.Context()
+func (c *testContext) Context() context.Context {
+	return c.r.Context()
 }
 
-func (ctx *testContext) Method() string {
-	return ctx.r.Method
+func (c *testContext) Method() string {
+	return c.r.Method
 }
 
-func (ctx *testContext) Host() string {
-	return ctx.r.Host
+func (c *testContext) Host() string {
+	return c.r.Host
 }
 
-func (ctx *testContext) URL() url.URL {
-	return *ctx.r.URL
+func (c *testContext) URL() url.URL {
+	return *c.r.URL
 }
 
-func (ctx *testContext) Param(name string) string {
-	return chi.URLParam(ctx.r, name)
+func (c *testContext) Param(name string) string {
+	return chi.URLParam(c.r, name)
 }
 
-func (ctx *testContext) Query(name string) string {
-	return queryparam.Get(ctx.r.URL.RawQuery, name)
+func (c *testContext) Query(name string) string {
+	return queryparam.Get(c.r.URL.RawQuery, name)
 }
 
-func (ctx *testContext) Header(name string) string {
-	return ctx.r.Header.Get(name)
+func (c *testContext) Header(name string) string {
+	return c.r.Header.Get(name)
 }
 
-func (ctx *testContext) EachHeader(cb func(name, value string)) {
-	for name, values := range ctx.r.Header {
+func (c *testContext) EachHeader(cb func(name, value string)) {
+	for name, values := range c.r.Header {
 		for _, value := range values {
 			cb(name, value)
 		}
 	}
 }
 
-func (ctx *testContext) BodyReader() io.Reader {
-	return ctx.r.Body
+func (c *testContext) BodyReader() io.Reader {
+	return c.r.Body
 }
 
-func (ctx *testContext) SetReadDeadline(deadline time.Time) error {
-	return http.NewResponseController(ctx.w).SetReadDeadline(deadline)
+func (c *testContext) GetMultipartForm() (*multipart.Form, error) {
+	err := c.r.ParseMultipartForm(8 * 1024)
+	return c.r.MultipartForm, err
 }
 
-func (ctx *testContext) SetStatus(code int) {
-	ctx.w.WriteHeader(code)
+func (c *testContext) SetReadDeadline(deadline time.Time) error {
+	return http.NewResponseController(c.w).SetReadDeadline(deadline)
 }
 
-func (ctx *testContext) AppendHeader(name string, value string) {
-	ctx.w.Header().Add(name, value)
+func (c *testContext) SetStatus(code int) {
+	c.w.WriteHeader(code)
 }
 
-func (ctx *testContext) SetHeader(name string, value string) {
-	ctx.w.Header().Set(name, value)
+func (c *testContext) AppendHeader(name string, value string) {
+	c.w.Header().Add(name, value)
 }
 
-func (ctx *testContext) BodyWriter() io.Writer {
-	return ctx.w
+func (c *testContext) SetHeader(name string, value string) {
+	c.w.Header().Set(name, value)
+}
+
+func (c *testContext) BodyWriter() io.Writer {
+	return c.w
 }
 
 type testAdapter struct {


### PR DESCRIPTION
There is currently no way to get multipart form from a huma context. I need this feature in the Resolve method because I get a multipart request in one of the endpoints. At the moment the only way to get the form is through reflection, which I would like to avoid, as I think other developers would like to avoid as well.
I also renamed adapters struct methods receivers to 'c'. At the moment the adapters had 'c' and 'ctx' mixed in.