### PR TITLE
fix: improved tests, fixed a few small issues

### DIFF
--- a/api.go
+++ b/api.go
@@ -158,7 +158,12 @@ func (r *api) Unmarshal(contentType string, data []byte, v any) error {
 	if end == -1 {
 		end = len(contentType)
 	}
-	f, ok := r.formats[contentType[start:end]]
+	ct := contentType[start:end]
+	if ct == "" {
+		// Default to assume JSON since this is an API.
+		ct = "application/json"
+	}
+	f, ok := r.formats[ct]
 	if !ok {
 		return fmt.Errorf("unknown content type: %s", contentType)
 	}
@@ -177,7 +182,6 @@ func (r *api) Negotiate(accept string) (string, error) {
 }
 
 func (a *api) Marshal(ctx Context, respKey string, ct string, v any) error {
-	// fmt.Println("marshaling", ct)
 	var err error
 
 	for _, t := range a.transformers {

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,16 @@
+package huma
+
+import (
+	"testing"
+
+	"github.com/go-chi/chi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlankConfig(t *testing.T) {
+	adapter := &testAdapter{chi.NewMux()}
+
+	assert.NotPanics(t, func() {
+		NewAPI(Config{}, adapter)
+	})
+}

--- a/conditional/params.go
+++ b/conditional/params.go
@@ -134,7 +134,7 @@ func (p *Params) PreconditionFailed(etag string, modified time.Time) huma.Status
 			)
 		}
 
-		return huma.Status304NotModied()
+		return huma.Status304NotModified()
 	}
 
 	return nil

--- a/error.go
+++ b/error.go
@@ -108,10 +108,6 @@ type StatusError interface {
 	Error() string
 }
 
-// Ensure the default error model satisfies these interfaces.
-var _ StatusError = (*ErrorModel)(nil)
-var _ ContentTypeFilter = (*ErrorModel)(nil)
-
 // NewError creates a new instance of an error model with the given status code,
 // message, and errors. If the error implements the `ErrorDetailer` interface,
 // the error details will be used. Otherwise, the error message will be used.
@@ -149,9 +145,9 @@ func WriteErr(api API, ctx Context, status int, msg string, errs ...error) {
 	api.Marshal(ctx, strconv.Itoa(status), ct, err)
 }
 
-// Status304NotModied returns a 304. This is not really an error, but provides
-// a way to send non-default responses.
-func Status304NotModied() StatusError {
+// Status304NotModified returns a 304. This is not really an error, but
+// provides a way to send non-default responses.
+func Status304NotModified() StatusError {
 	return NewError(http.StatusNotModified, "")
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,70 @@
+package huma
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Ensure the default error model satisfies these interfaces.
+var _ StatusError = (*ErrorModel)(nil)
+var _ ContentTypeFilter = (*ErrorModel)(nil)
+
+func TestError(t *testing.T) {
+	err := &ErrorModel{
+		Status: 400,
+		Detail: "test err",
+	}
+
+	// Add some children.
+	err.Add(&ErrorDetail{
+		Message:  "test detail",
+		Location: "body.foo",
+		Value:    "bar",
+	})
+
+	err.Add(fmt.Errorf("plain error"))
+
+	// Confirm errors were added.
+	assert.Equal(t, "test err", err.Error())
+	assert.Len(t, err.Errors, 2)
+	assert.Equal(t, "test detail (body.foo: bar)", err.Errors[0].Error())
+	assert.Equal(t, "plain error", err.Errors[1].Error())
+
+	// Ensure problem content types.
+	assert.Equal(t, "application/problem+json", err.ContentType("application/json"))
+	assert.Equal(t, "application/problem+cbor", err.ContentType("application/cbor"))
+	assert.Equal(t, "other", err.ContentType("other"))
+}
+
+func TestErrorResponses(t *testing.T) {
+	// NotModified has a slightly different signature.
+	assert.Equal(t, 304, Status304NotModified().GetStatus())
+
+	for _, item := range []struct {
+		constructor func(msg string, errs ...error) StatusError
+		expected    int
+	}{
+		{Error400BadRequest, 400},
+		{Error401Unauthorized, 401},
+		{Error403Forbidden, 403},
+		{Error404NotFound, 404},
+		{Error405MethodNotAllowed, 405},
+		{Error406NotAcceptable, 406},
+		{Error409Conflict, 409},
+		{Error410Gone, 410},
+		{Error412PreconditionFailed, 412},
+		{Error415UnsupportedMediaType, 415},
+		{Error422UnprocessableEntity, 422},
+		{Error429TooManyRequests, 429},
+		{Error500InternalServerError, 500},
+		{Error501NotImplemented, 501},
+		{Error502BadGateway, 502},
+		{Error503ServiceUnavailable, 503},
+		{Error504GatewayTimeout, 504},
+	} {
+		err := item.constructor("test")
+		assert.Equal(t, item.expected, err.GetStatus())
+	}
+}

--- a/schema.go
+++ b/schema.go
@@ -257,6 +257,12 @@ func SchemaFromField(registry Registry, parent reflect.Type, f reflect.StructFie
 		return fs
 	}
 	fs.Description = f.Tag.Get("doc")
+	if fs.Format == "date-time" && f.Tag.Get("header") != "" {
+		// Special case: this is a header and uses a different date/time format.
+		// Note that it can still be overridden by the `format` or `timeFormat`
+		// tags later.
+		fs.Format = "date-time-http"
+	}
 	if fmt := f.Tag.Get("format"); fmt != "" {
 		fs.Format = fmt
 	}

--- a/validate_test.go
+++ b/validate_test.go
@@ -35,9 +35,64 @@ var validateTests = []struct {
 		input: 0,
 	},
 	{
-		name:  "float64 success",
+		name:  "int from float64 success",
 		typ:   reflect.TypeOf(0),
 		input: float64(0),
+	},
+	{
+		name:  "int from int8 success",
+		typ:   reflect.TypeOf(0),
+		input: int8(0),
+	},
+	{
+		name:  "int from int16 success",
+		typ:   reflect.TypeOf(0),
+		input: int16(0),
+	},
+	{
+		name:  "int from int32 success",
+		typ:   reflect.TypeOf(0),
+		input: int32(0),
+	},
+	{
+		name:  "int from int64 success",
+		typ:   reflect.TypeOf(0),
+		input: int64(0),
+	},
+	{
+		name:  "int from uint success",
+		typ:   reflect.TypeOf(0),
+		input: uint(0),
+	},
+	{
+		name:  "int from uint8 success",
+		typ:   reflect.TypeOf(0),
+		input: uint8(0),
+	},
+	{
+		name:  "int from uint16 success",
+		typ:   reflect.TypeOf(0),
+		input: uint16(0),
+	},
+	{
+		name:  "int from uint32 success",
+		typ:   reflect.TypeOf(0),
+		input: uint32(0),
+	},
+	{
+		name:  "int from uint64 success",
+		typ:   reflect.TypeOf(0),
+		input: uint64(0),
+	},
+	{
+		name:  "float64 from int success",
+		typ:   reflect.TypeOf(0.0),
+		input: 0,
+	},
+	{
+		name:  "float64 from float32 success",
+		typ:   reflect.TypeOf(0.0),
+		input: float32(0),
 	},
 	{
 		name:  "int64 success",
@@ -216,6 +271,21 @@ var validateTests = []struct {
 		}{}),
 		input: map[string]any{"value": "bad"},
 		errs:  []string{"expected string to be RFC 3339 date-time"},
+	},
+	{
+		name: "date-time-http success",
+		typ: reflect.TypeOf(struct {
+			Value string `json:"value" format:"date-time-http"`
+		}{}),
+		input: map[string]any{"value": []byte("Mon, 01 Jan 2023 12:00:00 GMT")},
+	},
+	{
+		name: "expected date-time-http",
+		typ: reflect.TypeOf(struct {
+			Value time.Time `json:"value" format:"date-time-http"`
+		}{}),
+		input: map[string]any{"value": "bad"},
+		errs:  []string{"expected string to be RFC 1123 date-time"},
 	},
 	{
 		name: "date success",


### PR DESCRIPTION
Improved tests & coverage for v2. Fixed a few issues:

- Incorrect `time.Time` handling in some cases, or unexpected validation failures
- Better validation of pre-parsed params (e.g. `int` vs the JSON/CBOR `float64`, `[]string` fixes)
- Default content type assumption for request bodies if missing `Content-Type` header
- `Status304NotModied` → `Status304NotModified` 🤭 
