### PR TITLE
feat: add convenience model validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,6 +918,28 @@ o.Extensions["x-cli-autoconfig"] = huma.AutoConfig{
 
 See the [CLI AutoConfiguration](https://rest.sh/#/openapi?id=autoconfiguration) documentation for more info, including how to ask the user for custom parameters.
 
+## Model Validation
+
+Huma includes a utility to make it a little easier to validate models outside of the normal HTTP request/response flow, for example on app startup to load example or default data and verify it is correct. This is just a thin wrapper around the built-in validation functionality, but abstracts away some of the boilerplate required for efficient operation and provides a simple API.
+
+```go
+type MyExample struct {
+	Name string `json:"name" maxLength:"5"`
+	Age int `json:"age" minimum:"25"`
+}
+
+var value any
+json.Unmarshal([]byte(`{"name": "abcdefg", "age": 1}`), &value)
+
+validator := huma.ModelValidator()
+errs := validator.Validate(reflect.TypeOf(MyExample{}), value)
+if errs != nil {
+	fmt.Println("Validation error", errs)
+}
+```
+
+> :whale: The `huma.ModelValidator` is **not** goroutine-safe! For more flexible validation, use the `huma.Validate` function directly and provide your own registry, path buffer, validation result struct, etc.
+
 ## Low-Level API
 
 Huma v2 is written so that you can use the low-level API directly if you want to. This is useful if you want to add some new feature or abstraction that Huma doesn't support out of the box. Huma's own `huma.Register` function, automatic HTTP `PATCH` handlers, and the `sse` package are all built on top of the public low-level API.

--- a/validate_test.go
+++ b/validate_test.go
@@ -2,6 +2,7 @@ package huma
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -764,6 +765,34 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ExampleModelValidator() {
+	// Define a type you want to validate.
+	type Model struct {
+		Name string `json:"name" maxLength:"5"`
+		Age  int    `json:"age" minimum:"25"`
+	}
+
+	typ := reflect.TypeOf(Model{})
+
+	// Unmarshal some JSON into an `any` for validation. This input should not
+	// validate against the schema for the struct above.
+	var val any
+	json.Unmarshal([]byte(`{"name": "abcdefg", "age": 1}`), &val)
+
+	// Validate the unmarshaled data against the type and print errors.
+	validator := NewModelValidator()
+	errs := validator.Validate(typ, val)
+	fmt.Println(errs)
+
+	// Try again with valid data!
+	json.Unmarshal([]byte(`{"name": "foo", "age": 25}`), &val)
+	errs = validator.Validate(typ, val)
+	fmt.Println(errs)
+
+	// Output: [expected length <= 5 (name: abcdefg) expected number >= 25 (age: 1)]
+	// []
 }
 
 var BenchValidatePB *PathBuffer


### PR DESCRIPTION
Adds a basic convenience utility for validating data against model schemas outside of the normal request/response flow.

Fixes #121.