### PR TITLE
feat: oneOf, anyOf, allOf, not schema support

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -88,6 +88,11 @@ type Schema struct {
 	Deprecated           bool               `yaml:"deprecated,omitempty"`
 	Extensions           map[string]any     `yaml:",inline"`
 
+	OneOf []*Schema `yaml:"oneOf,omitempty"`
+	AnyOf []*Schema `yaml:"anyOf,omitempty"`
+	AllOf []*Schema `yaml:"allOf,omitempty"`
+	Not   *Schema   `yaml:"not,omitempty"`
+
 	patternRe     *regexp.Regexp  `yaml:"-"`
 	requiredMap   map[string]bool `yaml:"-"`
 	propertyNames []string        `yaml:"-"`
@@ -161,6 +166,22 @@ func (s *Schema) PrecomputeMessages() {
 		for _, name := range s.Required {
 			s.msgRequired[name] = "expected required property " + name + " to be present"
 		}
+	}
+
+	for _, sub := range s.OneOf {
+		sub.PrecomputeMessages()
+	}
+
+	for _, sub := range s.AnyOf {
+		sub.PrecomputeMessages()
+	}
+
+	for _, sub := range s.AllOf {
+		sub.PrecomputeMessages()
+	}
+
+	if sub := s.Not; sub != nil {
+		sub.PrecomputeMessages()
 	}
 }
 


### PR DESCRIPTION
Adds support to the schema and validation for `oneOf`, `anyOf`, `allOf`, and `not` schemas. An example is included how these combined with a raw body can be used to create an operation with multiple input types.

Lays the groundwork to fix #128, though I want to revisit validation error messages and see how struct field tags could make use of these new features (particularly one-of support).