### PR TITLE
fix: allow fiber without StreamRequestBody, fixes #127

### DIFF
--- a/adapters/humafiber/humafiber.go
+++ b/adapters/humafiber/humafiber.go
@@ -1,6 +1,7 @@
 package humafiber
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"mime/multipart"
@@ -62,7 +63,11 @@ func (c *fiberCtx) EachHeader(cb func(name, value string)) {
 }
 
 func (c *fiberCtx) BodyReader() io.Reader {
-	return c.orig.Request().BodyStream()
+	if c.orig.App().Server().StreamRequestBody {
+		// Streaming is enabled, so send the reader.
+		return c.orig.Request().BodyStream()
+	}
+	return bytes.NewReader(c.orig.BodyRaw())
 }
 
 func (c *fiberCtx) GetMultipartForm() (*multipart.Form, error) {


### PR DESCRIPTION
This makes the use of `StreamRequestBody` optional when using Fiber. The adapter will return a reader for the body but may have already cached the input bytes.