### PR TITLE
Fix: Update transforms.go to use explicit Host function from huma.Context

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -119,7 +119,7 @@ func (t *SchemaLinkTransformer) Transform(ctx Context, status string, v any) (an
 		return v, nil
 	}
 
-	host := ctx.Header("Host")
+	host := ctx.Host()
 	ctx.AppendHeader("Link", info.header)
 
 	vv := reflect.Indirect(reflect.ValueOf(v))


### PR DESCRIPTION
Hey @danielgtaylor 👋🏼 

Firstly - just found Huma and loving it - very quickly I've been able to get a TRPC-like workflow running which is amazing.

It looks like Chi does not provide the Host header through the Header func but it is explicitly available via the Host func. This meant the `$schema` never had a hostname and would return `https:///schema...`. 