### PR TITLE
feat: support custom field schemas; add omittable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,91 @@ Also take a look at [`http.ResponseController`](https://pkg.go.dev/net/http#Resp
 
 > :whale: The `sse` package provides a helper for streaming Server-Sent Events (SSE) responses that is easier to use than the above example!
 
+### Generated Schema Customization
+
+Schemas that are generated for input/output bodies can be customized in a couple of different ways. First, when registering your operation you can provide your own request and/or response schemas if you want to override the entire body. The automatic generation only applies when you have not provided your own schema in the OpenAPI.
+
+Second, this can be done on a per-field basis by making a struct that implements a special interface to get a schema, allowing you to e.g. encapsulate additional functionality within that field. This is the interface:
+
+```go
+// SchemaProvider is an interface that can be implemented by types to provide
+// a custom schema for themselves, overriding the built-in schema generation.
+// This can be used by custom types with their own special serialization rules.
+type SchemaProvider interface {
+	Schema(r huma.Registry) *huma.Schema
+}
+```
+
+The `huma.Registry` is passed to you and can be used to get schemas or refs for any embedded structs. Here is an example, where we want to know if a field was omitted vs. null vs. a value when sent as part of a request body. First we start by defininig the custom generic struct:
+
+```go
+// OmittableNullable is a field which can be omitted from the input,
+// set to `null`, or set to a value. Each state is tracked and can
+// be checked for in handling code.
+type OmittableNullable[T any] struct {
+	Sent  bool
+	Null  bool
+	Value T
+}
+
+// UnmarshalJSON unmarshals this value from JSON input.
+func (o *OmittableNullable[T]) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 {
+		o.Sent = true
+		if bytes.Equal(b, []byte("null")) {
+			o.Null = true
+			return nil
+		}
+		return json.Unmarshal(b, &o.Value)
+	}
+	return nil
+}
+
+// Schema returns a schema representing this value on the wire.
+// It returns the schema of the contained type.
+func (o OmittableNullable[T]) Schema(r huma.Registry) *huma.Schema {
+	return r.Schema(reflect.TypeOf(o.Value), true, "")
+}
+```
+
+This is how it can be used in an operation:
+
+```go
+type MyResponse struct {
+	Body struct {
+		Message string `json:"message"`
+	}
+}
+
+huma.Register(api, huma.Operation{
+	OperationID: "omittable",
+	Method:      http.MethodPost,
+	Path:        "/omittable",
+	Summary:     "Omittable / nullable example",
+}, func(ctx context.Context, input *struct {
+	// Making the body a pointer makes it optional, as it may be `nil`.
+	Body *struct {
+		Name OmittableNullable[string] `json:"name,omitempty" maxLength:"10"`
+	}
+}) (*MyResponse, error) {
+	resp := &MyResponse{}
+	if input.Body == nil {
+		resp.Body.Message = "Body was not sent"
+	} else if !input.Body.Name.Sent {
+		resp.Body.Message = "Name was omitted from the request"
+	} else if input.Body.Name.Null {
+		resp.Body.Message = "Name was set to null"
+	} else {
+		resp.Body.Message = "Name was set to: " + input.Body.Name.Value
+	}
+	return resp, nil
+})
+```
+
+If you go to view the generated docs, you will see that the type of the `name` field is `string` and that it is optional, with a max length of 10, indicating that the custom schema was correctly used in place of one generated for the `OmittableNullable[string]` struct.
+
+See https://github.com/danielgtaylor/huma/blob/main/examples/omit/main.go for a full example along with how to call it. This just scratches the surface of what's possible with custom schemas for fields.
+
 ### Exhaustive Errors
 
 Errors use [RFC 7807](https://tools.ietf.org/html/rfc7807) and return a structure that looks like:

--- a/examples/omit/main.go
+++ b/examples/omit/main.go
@@ -1,0 +1,108 @@
+// This example shows how to handle omittable/nullable fields and an optional
+// body in JSON input. Try the following requests:
+//
+//	# Omit the body
+//	restish post :8888/omittable
+//
+//	# Send a null body
+//	echo '{}' | restish post :8888/omittable
+//
+//	# Send a body with a null name
+//	restish post :8888/omittable name: null
+//
+//	# Send a body with a name
+//	restish post :8888/omittable name: Kari
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/go-chi/chi/v5"
+)
+
+// Options for the CLI.
+type Options struct {
+	Port int `help:"Port to listen on" default:"8888"`
+}
+
+// OmittableNullable is a field which can be omitted from the input,
+// set to `null`, or set to a value. Each state is tracked and can
+// be checked for in handling code.
+type OmittableNullable[T any] struct {
+	Sent  bool
+	Null  bool
+	Value T
+}
+
+// UnmarshalJSON unmarshals this value from JSON input.
+func (o *OmittableNullable[T]) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 {
+		o.Sent = true
+		if bytes.Equal(b, []byte("null")) {
+			o.Null = true
+			return nil
+		}
+		return json.Unmarshal(b, &o.Value)
+	}
+	return nil
+}
+
+// Schema returns a schema representing this value on the wire.
+// It returns the schema of the contained type.
+func (o OmittableNullable[T]) Schema(r huma.Registry) *huma.Schema {
+	return r.Schema(reflect.TypeOf(o.Value), true, "")
+}
+
+type MyResponse struct {
+	Body struct {
+		Message string `json:"message"`
+	}
+}
+
+func main() {
+	// Create a CLI app which takes a port option.
+	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+		// Create a new router & API
+		router := chi.NewMux()
+		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))
+
+		huma.Register(api, huma.Operation{
+			OperationID: "omittable",
+			Method:      http.MethodPost,
+			Path:        "/omittable",
+			Summary:     "Omittable / nullable example",
+		}, func(ctx context.Context, input *struct {
+			// Making the body a pointer makes it optional, as it may be `nil`.
+			Body *struct {
+				Name OmittableNullable[string] `json:"name,omitempty" maxLength:"10"`
+			}
+		}) (*MyResponse, error) {
+			resp := &MyResponse{}
+			if input.Body == nil {
+				resp.Body.Message = "Body was not sent"
+			} else if !input.Body.Name.Sent {
+				resp.Body.Message = "Name was omitted from the request"
+			} else if input.Body.Name.Null {
+				resp.Body.Message = "Name was set to null"
+			} else {
+				resp.Body.Message = "Name was set to: " + input.Body.Name.Value
+			}
+			return resp, nil
+		})
+
+		// Tell the CLI how to start your router.
+		hooks.OnStart(func() {
+			http.ListenAndServe(fmt.Sprintf(":%d", options.Port), router)
+		})
+	})
+
+	// Run the CLI. When passed no commands, it starts the server.
+	cli.Run()
+}

--- a/registry.go
+++ b/registry.go
@@ -55,6 +55,12 @@ func (r *mapRegistry) Schema(t reflect.Type, allowRef bool, hint string) *Schema
 		getsRef = false
 	}
 
+	v := reflect.New(t).Interface()
+	if _, ok := v.(SchemaProvider); ok {
+		// Special case: type provides its own schema
+		getsRef = false
+	}
+
 	name := r.namer(t, hint)
 
 	if getsRef {


### PR DESCRIPTION
This PR adds an optional `huma.SchemaProvider` interface, which a type can implement to provide its own custom JSON Schema, disabling the built-in schema generator and enabling customized behavior for request/response body fields.

When combined with custom serialization logic, this can enable use-cases like determining whether a field was sent at all, is `null`, or is a value. A new example is added to showcase this functionality.

As part of this work, a small change in `huma.go` is made to properly set the `operation.requestBody.required` OpenAPI field, and this field is then later checked to determine whether the body is required. This works much better with custom operation schemas, which would not be required before even when that field was set.

Fixes #137.