### PR TITLE
fix: prevent panic on examples for pointer field types

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -198,7 +198,7 @@ func boolTag(f reflect.StructField, tag string) bool {
 		} else if v == "false" {
 			return false
 		} else {
-			panic("invalid bool tag '" + tag + "' for field '" + f.Name + "': " + v)
+			panic(fmt.Errorf("invalid bool tag '%s' for field '%s': %v", tag, f.Name, v))
 		}
 	}
 	return false
@@ -209,7 +209,7 @@ func intTag(f reflect.StructField, tag string) *int {
 		if i, err := strconv.Atoi(v); err == nil {
 			return &i
 		} else {
-			panic("invalid int tag '" + tag + "' for field '" + f.Name + "': " + v + " (" + err.Error() + ")")
+			panic(fmt.Errorf("invalid int tag '%s' for field '%s': %v (%w)", tag, f.Name, v, err))
 		}
 	}
 	return nil
@@ -220,7 +220,7 @@ func floatTag(f reflect.StructField, tag string) *float64 {
 		if i, err := strconv.ParseFloat(v, 64); err == nil {
 			return &i
 		} else {
-			panic("invalid float tag '" + tag + "' for field '" + f.Name + "': " + v + " (" + err.Error() + ")")
+			panic(fmt.Errorf("invalid float tag '%s' for field '%s': %v (%w)", tag, f.Name, v, err))
 		}
 	}
 	return nil
@@ -243,7 +243,7 @@ func jsonTagValue(f reflect.StructField, t reflect.Type, value string) any {
 
 	var v any
 	if err := json.Unmarshal([]byte(value), &v); err != nil {
-		panic("invalid tag for field '" + f.Name + "': " + err.Error())
+		panic(fmt.Errorf("invalid tag for field '%s': %w", f.Name, err))
 	}
 
 	vv := reflect.ValueOf(v)
@@ -256,14 +256,14 @@ func jsonTagValue(f reflect.StructField, t reflect.Type, value string) any {
 			tmp := reflect.MakeSlice(t, 0, vv.Len())
 			for i := 0; i < vv.Len(); i++ {
 				if !vv.Index(i).Elem().Type().ConvertibleTo(t.Elem()) {
-					panic(fmt.Errorf("unable to convert %v to %v: %w", vv.Index(i).Interface(), t.Elem(), ErrSchemaInvalid))
+					panic(fmt.Errorf("unable to convert %v to %v for field '%s': %w", vv.Index(i).Interface(), t.Elem(), f.Name, ErrSchemaInvalid))
 				}
 
 				tmp = reflect.Append(tmp, vv.Index(i).Elem().Convert(t.Elem()))
 			}
 			v = tmp.Interface()
 		} else if !tv.ConvertibleTo(deref(t)) {
-			panic(fmt.Errorf("unable to convert %v to %v: %w", tv, t, ErrSchemaInvalid))
+			panic(fmt.Errorf("unable to convert %v to %v for field '%s': %w", tv, t, f.Name, ErrSchemaInvalid))
 		}
 
 		converted := reflect.ValueOf(v).Convert(deref(t))

--- a/schema_test.go
+++ b/schema_test.go
@@ -370,7 +370,7 @@ func TestSchema(t *testing.T) {
 			}`,
 		},
 		{
-			name: "fiel-pointer-example",
+			name: "field-pointer-example",
 			input: struct {
 				Int *int64  `json:"int" example:"123"`
 				Str *string `json:"str" example:"foo"`
@@ -420,6 +420,13 @@ func TestSchema(t *testing.T) {
 			}{},
 			panics: `invalid tag for field 'Value': invalid character 'b' looking for beginning of value`,
 		},
+		{
+			name: "panic-json-type",
+			input: struct {
+				Value int `json:"value" example:"true"`
+			}{},
+			panics: `unable to convert bool to int for field 'Value': schema is invalid`,
+		},
 	}
 
 	for _, c := range cases {
@@ -427,7 +434,7 @@ func TestSchema(t *testing.T) {
 			r := NewMapRegistry("#/components/schemas/", DefaultSchemaNamer)
 
 			if c.panics != "" {
-				assert.PanicsWithValue(t, c.panics, func() {
+				assert.PanicsWithError(t, c.panics, func() {
 					r.Schema(reflect.TypeOf(c.input), false, "")
 				})
 			} else {

--- a/schema_test.go
+++ b/schema_test.go
@@ -370,6 +370,29 @@ func TestSchema(t *testing.T) {
 			}`,
 		},
 		{
+			name: "fiel-pointer-example",
+			input: struct {
+				Int *int64  `json:"int" example:"123"`
+				Str *string `json:"str" example:"foo"`
+			}{},
+			expected: `{
+				"type": "object",
+				"additionalProperties": false,
+				"required": ["int", "str"],
+				"properties": {
+					"int": {
+						"type": "integer",
+						"format": "int64",
+						"examples": [123]
+					},
+					"str": {
+						"type": "string",
+						"examples": ["foo"]
+					}
+				}
+			}`,
+		},
+		{
 			name: "panic-bool",
 			input: struct {
 				Value string `json:"value" readOnly:"bad"`


### PR DESCRIPTION
Small fix to better support inputs/outputs with fields that are pointers and provide an example for the generated schema.

Fixes #18.