### PR TITLE
feat: allow making query/header params required

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,11 +361,14 @@ Inputs and outputs are **always** structs that represent the entirety of the inc
 
 Requests can have parameters and/or a body as input to the handler function. Inputs use standard Go structs with special fields and/or tags. Here are the available tags:
 
-| Tag      | Description                        | Example                  |
-| -------- | ---------------------------------- | ------------------------ |
-| `path`   | Name of the path parameter         | `path:"thing-id"`        |
-| `query`  | Name of the query string parameter | `query:"q"`              |
-| `header` | Name of the header parameter       | `header:"Authorization"` |
+| Tag        | Description                           | Example                  |
+| ---------- | ------------------------------------- | ------------------------ |
+| `path`     | Name of the path parameter            | `path:"thing-id"`        |
+| `query`    | Name of the query string parameter    | `query:"q"`              |
+| `header`   | Name of the header parameter          | `header:"Authorization"` |
+| `required` | Mark a query/header param as required | `required:"true"`        |
+
+> :whale: The `required` tag is discouraged and is only used for query/header params, which should generally be optional for clients to send.
 
 The following parameter types are supported out of the box:
 

--- a/huma_test.go
+++ b/huma_test.go
@@ -190,6 +190,8 @@ func TestFeatures(t *testing.T) {
 					QueryDate   time.Time `query:"date" timeFormat:"2006-01-02"`
 					QueryUint   uint32    `query:"uint"`
 					QueryBool   bool      `query:"bool"`
+					QueryReq    bool      `query:"req" required:"true"`
+					HeaderReq   string    `header:"req" required:"true"`
 				}) (*struct{}, error) {
 					return nil, nil
 				})
@@ -202,6 +204,8 @@ func TestFeatures(t *testing.T) {
 				assert.Contains(t, resp.Body.String(), "invalid float")
 				assert.Contains(t, resp.Body.String(), "invalid date/time")
 				assert.Contains(t, resp.Body.String(), "invalid bool")
+				assert.Contains(t, resp.Body.String(), "required query parameter is missing")
+				assert.Contains(t, resp.Body.String(), "required header parameter is missing")
 			},
 		},
 		{


### PR DESCRIPTION
> :whale: In general, you should consider path parameters or a body for required arguments.

While discouraged, this enables marking query & header params as required via struct field tags, like this:

```go
type MyInput struct {
  Start time.Time `query:"start" required:"true"`
}
```

Fixes #21.