### PR TITLE
feat: allow resolvers to set a custom response status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,16 @@ func (m *MyInput) Resolve(ctx huma.Context) []error {
 }
 ```
 
+It is also possible for resolvers to return custom HTTP status codes for the response, by returning an error which satisfies the `huma.StatusError` interface. Errors are processed in the order they are returned and the last one wins, so this feature should be used sparingly. For example:
+
+```go
+type MyInput struct{}
+
+func (i *MyInput) Resolve(ctx huma.Context) []error {
+	return []error{huma.Error403Forbidden("nope")}
+}
+```
+
 > :whale: Exhaustive errors lessen frustration for users. It's better to return three errors in response to one request than to have the user make three requests which each return a new different error.
 
 #### Input Composition

--- a/huma.go
+++ b/huma.go
@@ -806,6 +806,15 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 		})
 
 		if len(res.Errors) > 0 {
+			for i := len(res.Errors) - 1; i >= 0; i-- {
+				// If there are errors, and they provide a status, then update the
+				// response status code to match. Otherwise, use the default status
+				// code is used. Since these run in order, the last error code wins.
+				if s, ok := res.Errors[i].(StatusError); ok {
+					errStatus = s.GetStatus()
+					break
+				}
+			}
 			WriteErr(api, ctx, errStatus, "validation failed", res.Errors...)
 			return
 		}


### PR DESCRIPTION
Enable resolvers to return an error which satisfies `huma.StatusError` in order to set a custom response status code. This means the utility HTTP errors can be used, like `huma.Error403Forbidden`, if desired, but also anything that implements that interface will work.

Here's a minimal example:

```go
type MyInput struct{}

func (i *MyInput) Resolve(ctx huma.Context) []error {
	return []error{huma.Error403Forbidden("nope")}
}
```

Note: errors are processed in-order and the last one wins. It's best to use this feature *very* sparingly.

Fixes #107.