### PR TITLE
fix: backport Huma v2 example pointer fix from #148

### DIFF
--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -145,11 +145,14 @@ func TestSchemaDefault(t *testing.T) {
 func TestSchemaExample(t *testing.T) {
 	type Example struct {
 		Foo string `json:"foo" example:"ex"`
+		Bar *int64 `json:"bar" example:"5"`
 	}
 
 	s, err := Generate(reflect.ValueOf(Example{}).Type())
 	assert.NoError(t, err)
 	assert.Equal(t, "ex", s.Properties["foo"].Example)
+	ex := int64(5)
+	assert.Equal(t, &ex, s.Properties["bar"].Example)
 }
 
 func TestSchemaNullable(t *testing.T) {


### PR DESCRIPTION
This backports a fix from Huma v2 into Huma v1, enabling the use of examples for fields which are pointers. An example is added to the existing tests.