### PR TITLE
feat: simplify humatest, allow sending body slice/map/struct, docs

### DIFF
--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -94,6 +94,11 @@ func (c *chiContext) BodyWriter() io.Writer {
 	return c.w
 }
 
+// NewContext creates a new Huma context from an HTTP request and response.
+func NewContext(op *huma.Operation, r *http.Request, w http.ResponseWriter) huma.Context {
+	return &chiContext{op: op, r: r, w: w}
+}
+
 type chiAdapter struct {
 	router chi.Router
 }
@@ -106,6 +111,11 @@ func (a *chiAdapter) Handle(op *huma.Operation, handler func(huma.Context)) {
 
 func (a *chiAdapter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	a.router.ServeHTTP(w, r)
+}
+
+// NewAdapter creates a new adapter for the given chi router.
+func NewAdapter(r chi.Router) huma.Adapter {
+	return &chiAdapter{router: r}
 }
 
 // New creates a new Huma API using the latest v5.x.x version of Chi.

--- a/humatest/humatest_test.go
+++ b/humatest/humatest_test.go
@@ -46,11 +46,28 @@ func TestHumaTestUtils(t *testing.T) {
 
 	w := api.Put("/test/abc123?q=foo",
 		"Content-Type: application/json",
+		"Host: example.com",
 		strings.NewReader(`{"value": "hello"}`))
 
 	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	assert.Equal(t, "my-value", w.Header().Get("My-Header"))
 	assert.JSONEq(t, `{"echo":"hello"}`, w.Body.String())
+
+	// We can also serialize a slice/map/struct and the content type is set
+	// automatically for us.
+	w = api.Put("/test/abc123?q=foo",
+		map[string]any{"value": "hello"})
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, "my-value", w.Header().Get("My-Header"))
+	assert.JSONEq(t, `{"echo":"hello"}`, w.Body.String())
+
+	assert.Panics(t, func() {
+		// Cannot JSON encode a function.
+		api.Put("/test/abc123?q=foo",
+			"Content-Type: application/json",
+			map[string]any{"value": func() {}})
+	})
 }
 
 func TestContext(t *testing.T) {


### PR DESCRIPTION
This PR:

- Simplifies `humatest` by removing the custom test context & adapter, instead exposing the context/adapter creation for `humachi` and piggybacking on that, which also improves the level of dog-fooding in the project.
- Enables the use of a slice/map/struct as input to the test API request functions, which will then automatically add a `Content-Type: application/json` header and serialize the input as JSON for the request body.
- Documentation updates & examples, which result in nice VSCode popups showing how to use the calls.

<img width="559" alt="Screenshot 2023-10-25 at 09 00 33" src="https://github.com/danielgtaylor/huma/assets/106826/de9c8821-95b2-459c-a093-4b3efa61ca31">

