### PR TITLE
feat: split transform/marshal, reorg tests & dogfood humatest

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1,16 +1,69 @@
-package huma
+package huma_test
 
 import (
+	"net/http"
 	"testing"
 
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBlankConfig(t *testing.T) {
-	adapter := &testAdapter{chi.NewMux()}
+	adapter := humatest.NewAdapter(chi.NewMux())
 
 	assert.NotPanics(t, func() {
-		NewAPI(Config{}, adapter)
+		huma.NewAPI(huma.Config{}, adapter)
+	})
+}
+
+// ExampleAdapter_handle demonstrates how to use the adapter directly
+// instead of using the `huma.Register` convenience function to add a new
+// operation and handler to the API.
+//
+// Note that you are responsible for defining all of the operation details,
+// including the parameter and response definitions & schemas.
+func ExampleAdapter_handle() {
+	// Create an adapter for your chosen router.
+	adapter := NewExampleAdapter(chi.NewMux())
+
+	// Register an operation with a custom handler.
+	adapter.Handle(&huma.Operation{
+		OperationID: "example-operation",
+		Method:      "GET",
+		Path:        "/example/{name}",
+		Summary:     "Example operation",
+		Parameters: []*huma.Param{
+			{
+				Name:        "name",
+				In:          "path",
+				Description: "Name to return",
+				Required:    true,
+				Schema: &huma.Schema{
+					Type: "string",
+				},
+			},
+		},
+		Responses: map[string]*huma.Response{
+			"200": {
+				Description: "OK",
+				Content: map[string]*huma.MediaType{
+					"text/plain": {
+						Schema: &huma.Schema{
+							Type: "string",
+						},
+					},
+				},
+			},
+		},
+	}, func(ctx huma.Context) {
+		// Get the `name` path parameter.
+		name := ctx.Param("name")
+
+		// Set the response content type, status code, and body.
+		ctx.SetHeader("Content-Type", "text/plain; charset=utf-8")
+		ctx.SetStatus(http.StatusOK)
+		ctx.BodyWriter().Write([]byte("Hello, " + name))
 	})
 }

--- a/error.go
+++ b/error.go
@@ -217,7 +217,11 @@ func WriteErr(api API, ctx Context, status int, msg string, errs ...error) error
 
 	ctx.SetHeader("Content-Type", ct)
 	ctx.SetStatus(status)
-	return api.Marshal(ctx, strconv.Itoa(status), ct, err)
+	tval, terr := api.Transform(ctx, strconv.Itoa(status), err)
+	if terr != nil {
+		return terr
+	}
+	return api.Marshal(ctx.BodyWriter(), ct, tval)
 }
 
 // Status304NotModified returns a 304. This is not really an error, but

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,4 +1,4 @@
-package huma
+package huma_test
 
 import (
 	"bytes"
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/danielgtaylor/huma/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -431,7 +432,7 @@ func TestSchema(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			r := NewMapRegistry("#/components/schemas/", DefaultSchemaNamer)
+			r := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
 
 			if c.panics != "" {
 				assert.PanicsWithError(t, c.panics, func() {
@@ -464,7 +465,7 @@ type RecursiveInput struct {
 }
 
 func TestSchemaOld(t *testing.T) {
-	r := NewMapRegistry("#/components/schemas/", DefaultSchemaNamer)
+	r := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
 
 	s := r.Schema(reflect.TypeOf(GreetingInput{}), false, "")
 	// fmt.Printf("%+v\n", s)
@@ -475,9 +476,9 @@ func TestSchemaOld(t *testing.T) {
 	r.Schema(reflect.TypeOf(RecursiveInput{}), false, "")
 
 	s2 := r.Schema(reflect.TypeOf(TestInput{}), false, "")
-	pb := NewPathBuffer(make([]byte, 0, 128), 0)
-	res := ValidateResult{}
-	Validate(r, s2, pb, ModeReadFromServer, map[string]any{
+	pb := huma.NewPathBuffer(make([]byte, 0, 128), 0)
+	res := huma.ValidateResult{}
+	huma.Validate(r, s2, pb, huma.ModeReadFromServer, map[string]any{
 		"name": "foo",
 		"sub": map[string]any{
 			"num": 1.0,
@@ -494,7 +495,7 @@ func TestSchemaGenericNaming(t *testing.T) {
 		Value T `json:"value"`
 	}
 
-	r := NewMapRegistry("#/components/schemas/", DefaultSchemaNamer)
+	r := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
 	s := r.Schema(reflect.TypeOf(SchemaGeneric[int]{}), true, "")
 
 	b, _ := json.Marshal(s)
@@ -521,7 +522,7 @@ func (o *OmittableNullable[T]) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (o OmittableNullable[T]) Schema(r Registry) *Schema {
+func (o OmittableNullable[T]) Schema(r huma.Registry) *huma.Schema {
 	return r.Schema(reflect.TypeOf(o.Value), true, "")
 }
 
@@ -533,7 +534,7 @@ func TestCustomUnmarshalType(t *testing.T) {
 	var o O
 
 	// Confirm the schema is generated properly, including field constraints.
-	r := NewMapRegistry("#/components/schemas/", DefaultSchemaNamer)
+	r := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
 	s := r.Schema(reflect.TypeOf(o), false, "")
 	assert.Equal(t, "integer", s.Properties["field"].Type, s)
 	assert.Equal(t, Ptr(float64(10)), s.Properties["field"].Maximum, s)
@@ -577,7 +578,7 @@ type BenchStruct struct {
 }
 
 func BenchmarkSchema(b *testing.B) {
-	r := NewMapRegistry("#/components/schemas/", DefaultSchemaNamer)
+	r := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
 
 	s2 := r.Schema(reflect.TypeOf(BenchStruct{}), false, "")
 
@@ -596,9 +597,9 @@ func BenchmarkSchema(b *testing.B) {
 			"metrics": []any{1.0, 2.0, 3.0},
 		},
 	}
-	pb := NewPathBuffer(make([]byte, 0, 128), 0)
-	res := ValidateResult{}
-	Validate(r, s2, pb, ModeReadFromServer, input, &res)
+	pb := huma.NewPathBuffer(make([]byte, 0, 128), 0)
+	res := huma.ValidateResult{}
+	huma.Validate(r, s2, pb, huma.ModeReadFromServer, input, &res)
 	assert.Empty(b, res.Errors)
 
 	b.ResetTimer()
@@ -606,7 +607,7 @@ func BenchmarkSchema(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		pb.Reset()
 		res.Reset()
-		Validate(r, s2, pb, ModeReadFromServer, input, &res)
+		huma.Validate(r, s2, pb, huma.ModeReadFromServer, input, &res)
 		if len(res.Errors) > 0 {
 			b.Fatal(res.Errors)
 		}
@@ -614,7 +615,7 @@ func BenchmarkSchema(b *testing.B) {
 }
 
 func BenchmarkSchemaErrors(b *testing.B) {
-	r := NewMapRegistry("#/components/schemas/", DefaultSchemaNamer)
+	r := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
 
 	s2 := r.Schema(reflect.TypeOf(BenchStruct{}), false, "")
 
@@ -630,9 +631,9 @@ func BenchmarkSchemaErrors(b *testing.B) {
 			"unexpected": 2,
 		},
 	}
-	pb := NewPathBuffer(make([]byte, 0, 128), 0)
-	res := ValidateResult{}
-	Validate(r, s2, pb, ModeReadFromServer, input, &res)
+	pb := huma.NewPathBuffer(make([]byte, 0, 128), 0)
+	res := huma.ValidateResult{}
+	huma.Validate(r, s2, pb, huma.ModeReadFromServer, input, &res)
 	assert.NotEmpty(b, res.Errors)
 
 	b.ResetTimer()
@@ -640,7 +641,7 @@ func BenchmarkSchemaErrors(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		pb.Reset()
 		res.Reset()
-		Validate(r, s2, pb, ModeReadFromServer, input, &res)
+		huma.Validate(r, s2, pb, huma.ModeReadFromServer, input, &res)
 		if len(res.Errors) == 0 {
 			b.Fatal("expected error")
 		}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,4 +1,4 @@
-package huma
+package huma_test
 
 import (
 	"encoding/json"
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/danielgtaylor/huma/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,12 +16,20 @@ func Ptr[T any](v T) *T {
 	return &v
 }
 
+func mapTo[A, B any](s []A, f func(A) B) []B {
+	r := make([]B, len(s))
+	for i, v := range s {
+		r[i] = f(v)
+	}
+	return r
+}
+
 var validateTests = []struct {
 	name  string
 	typ   reflect.Type
-	s     *Schema
+	s     *huma.Schema
 	input any
-	mode  ValidateMode
+	mode  huma.ValidateMode
 	errs  []string
 	panic string
 }{
@@ -646,7 +655,7 @@ var validateTests = []struct {
 		typ: reflect.TypeOf(struct {
 			Value string `json:"value" readOnly:"true"`
 		}{}),
-		mode:  ModeWriteToServer,
+		mode:  huma.ModeWriteToServer,
 		input: map[string]any{"value": "whoops"},
 	},
 	{
@@ -654,7 +663,7 @@ var validateTests = []struct {
 		typ: reflect.TypeOf(struct {
 			Value string `json:"value" readOnly:"true"`
 		}{}),
-		mode:  ModeWriteToServer,
+		mode:  huma.ModeWriteToServer,
 		input: map[string]any{},
 	},
 	{
@@ -662,7 +671,7 @@ var validateTests = []struct {
 		typ: reflect.TypeOf(struct {
 			Value string `json:"value" readOnly:"true"`
 		}{}),
-		mode:  ModeReadFromServer,
+		mode:  huma.ModeReadFromServer,
 		input: map[string]any{},
 		errs:  []string{"expected required property value to be present"},
 	},
@@ -671,7 +680,7 @@ var validateTests = []struct {
 		typ: reflect.TypeOf(struct {
 			Value string `json:"value" writeOnly:"true"`
 		}{}),
-		mode:  ModeReadFromServer,
+		mode:  huma.ModeReadFromServer,
 		input: map[string]any{"value": "should not be set"},
 		errs:  []string{"write only property is non-zero"},
 	},
@@ -734,30 +743,30 @@ var validateTests = []struct {
 	},
 	{
 		name: "oneOf success bool",
-		s: &Schema{
-			OneOf: []*Schema{
-				{Type: TypeBoolean},
-				{Type: TypeString},
+		s: &huma.Schema{
+			OneOf: []*huma.Schema{
+				{Type: huma.TypeBoolean},
+				{Type: huma.TypeString},
 			},
 		},
 		input: true,
 	},
 	{
 		name: "oneOf success string",
-		s: &Schema{
-			OneOf: []*Schema{
-				{Type: TypeBoolean},
-				{Type: TypeString},
+		s: &huma.Schema{
+			OneOf: []*huma.Schema{
+				{Type: huma.TypeBoolean},
+				{Type: huma.TypeString},
 			},
 		},
 		input: "hello",
 	},
 	{
 		name: "oneOf fail zero",
-		s: &Schema{
-			OneOf: []*Schema{
-				{Type: TypeBoolean},
-				{Type: TypeString},
+		s: &huma.Schema{
+			OneOf: []*huma.Schema{
+				{Type: huma.TypeBoolean},
+				{Type: huma.TypeString},
 			},
 		},
 		input: 123,
@@ -765,10 +774,10 @@ var validateTests = []struct {
 	},
 	{
 		name: "oneOf fail multi",
-		s: &Schema{
-			OneOf: []*Schema{
-				{Type: TypeNumber, Minimum: Ptr(float64(5))},
-				{Type: TypeNumber, Maximum: Ptr(float64(10))},
+		s: &huma.Schema{
+			OneOf: []*huma.Schema{
+				{Type: huma.TypeNumber, Minimum: Ptr(float64(5))},
+				{Type: huma.TypeNumber, Maximum: Ptr(float64(10))},
 			},
 		},
 		input: 8,
@@ -776,20 +785,20 @@ var validateTests = []struct {
 	},
 	{
 		name: "anyOf success",
-		s: &Schema{
-			AnyOf: []*Schema{
-				{Type: TypeNumber, Minimum: Ptr(float64(5))},
-				{Type: TypeNumber, Maximum: Ptr(float64(10))},
+		s: &huma.Schema{
+			AnyOf: []*huma.Schema{
+				{Type: huma.TypeNumber, Minimum: Ptr(float64(5))},
+				{Type: huma.TypeNumber, Maximum: Ptr(float64(10))},
 			},
 		},
 		input: 8,
 	},
 	{
 		name: "anyOf fail",
-		s: &Schema{
-			AnyOf: []*Schema{
-				{Type: TypeNumber, Minimum: Ptr(float64(5))},
-				{Type: TypeNumber, Minimum: Ptr(float64(10))},
+		s: &huma.Schema{
+			AnyOf: []*huma.Schema{
+				{Type: huma.TypeNumber, Minimum: Ptr(float64(5))},
+				{Type: huma.TypeNumber, Minimum: Ptr(float64(10))},
 			},
 		},
 		input: 1,
@@ -797,20 +806,20 @@ var validateTests = []struct {
 	},
 	{
 		name: "allOf success",
-		s: &Schema{
-			AllOf: []*Schema{
-				{Type: TypeNumber, Minimum: Ptr(float64(5))},
-				{Type: TypeNumber, Maximum: Ptr(float64(10))},
+		s: &huma.Schema{
+			AllOf: []*huma.Schema{
+				{Type: huma.TypeNumber, Minimum: Ptr(float64(5))},
+				{Type: huma.TypeNumber, Maximum: Ptr(float64(10))},
 			},
 		},
 		input: 8,
 	},
 	{
 		name: "allOf fail",
-		s: &Schema{
-			AllOf: []*Schema{
-				{Type: TypeNumber, Minimum: Ptr(float64(5))},
-				{Type: TypeNumber, Maximum: Ptr(float64(10))},
+		s: &huma.Schema{
+			AllOf: []*huma.Schema{
+				{Type: huma.TypeNumber, Minimum: Ptr(float64(5))},
+				{Type: huma.TypeNumber, Maximum: Ptr(float64(10))},
 			},
 		},
 		input: 12,
@@ -818,15 +827,15 @@ var validateTests = []struct {
 	},
 	{
 		name: "not success",
-		s: &Schema{
-			Not: &Schema{Type: TypeNumber},
+		s: &huma.Schema{
+			Not: &huma.Schema{Type: huma.TypeNumber},
 		},
 		input: "hello",
 	},
 	{
 		name: "not fail",
-		s: &Schema{
-			Not: &Schema{Type: TypeNumber},
+		s: &huma.Schema{
+			Not: &huma.Schema{Type: huma.TypeNumber},
 		},
 		input: 5,
 		errs:  []string{"expected value to not match schema"},
@@ -834,14 +843,14 @@ var validateTests = []struct {
 }
 
 func TestValidate(t *testing.T) {
-	pb := NewPathBuffer([]byte(""), 0)
-	res := &ValidateResult{}
+	pb := huma.NewPathBuffer([]byte(""), 0)
+	res := &huma.ValidateResult{}
 
 	for _, test := range validateTests {
 		t.Run(test.name, func(t *testing.T) {
-			registry := NewMapRegistry("#/components/schemas/", DefaultSchemaNamer)
+			registry := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
 
-			var s *Schema
+			var s *huma.Schema
 			if test.panic != "" {
 				assert.Panics(t, func() {
 					registry.Schema(test.typ, false, "TestInput")
@@ -859,11 +868,11 @@ func TestValidate(t *testing.T) {
 			pb.Reset()
 			res.Reset()
 
-			Validate(registry, s, pb, test.mode, test.input, res)
+			huma.Validate(registry, s, pb, test.mode, test.input, res)
 
 			if len(test.errs) > 0 {
 				errs := mapTo(res.Errors, func(e error) string {
-					return e.(*ErrorDetail).Message
+					return e.(*huma.ErrorDetail).Message
 				})
 				schemaJSON, _ := json.MarshalIndent(registry.Map(), "", "  ")
 				for _, err := range test.errs {
@@ -891,7 +900,7 @@ func ExampleModelValidator() {
 	json.Unmarshal([]byte(`{"name": "abcdefg", "age": 1}`), &val)
 
 	// Validate the unmarshaled data against the type and print errors.
-	validator := NewModelValidator()
+	validator := huma.NewModelValidator()
 	errs := validator.Validate(typ, val)
 	fmt.Println(errs)
 
@@ -904,12 +913,12 @@ func ExampleModelValidator() {
 	// []
 }
 
-var BenchValidatePB *PathBuffer
-var BenchValidateRes *ValidateResult
+var BenchValidatePB *huma.PathBuffer
+var BenchValidateRes *huma.ValidateResult
 
 func BenchmarkValidate(b *testing.B) {
-	pb := NewPathBuffer([]byte(""), 0)
-	res := &ValidateResult{}
+	pb := huma.NewPathBuffer([]byte(""), 0)
+	res := &huma.ValidateResult{}
 	BenchValidatePB = pb
 	BenchValidateRes = res
 
@@ -919,11 +928,11 @@ func BenchmarkValidate(b *testing.B) {
 		}
 
 		b.Run(strings.TrimSuffix(test.name, " success"), func(b *testing.B) {
-			registry := NewMapRegistry("#/components/schemas/", DefaultSchemaNamer)
+			registry := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
 			s := registry.Schema(test.typ, false, "TestInput")
 
 			input := test.input
-			if s.Type == TypeObject && s.Properties["value"] != nil {
+			if s.Type == huma.TypeObject && s.Properties["value"] != nil {
 				s = s.Properties["value"]
 				input = input.(map[string]any)["value"]
 			}
@@ -933,7 +942,7 @@ func BenchmarkValidate(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				pb.Reset()
 				res.Reset()
-				Validate(registry, s, pb, test.mode, input, res)
+				huma.Validate(registry, s, pb, test.mode, input, res)
 			}
 		})
 	}


### PR DESCRIPTION
This PR does the following things:

1. Split the transform functionality out of `API.Marshal(...)` so that marshaling no longer needs access to the full request context.
2. Better handle failures with transforming or marshaling responses after a response status code has already been sent on the wire.
3. Rename test package from `huma` → `huma_test` and dogfood using `humatest` now that there is no more circular dependency requiring yet another adapter implementation.