### PR TITLE
docs: lots of docs updates, a few more tests/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This project was inspired by [FastAPI](https://fastapi.tiangolo.com/). Logo & br
 
 # Install
 
+Install via `go get`. Note that Go 1.20 or newer is required.
+
 ```sh
 # After: go mod init ...
 go get -u github.com/danielgtaylor/huma/v2
@@ -1112,6 +1114,7 @@ type Context interface {
 	Header(name string) string
 	EachHeader(cb func(name, value string))
 	BodyReader() io.Reader
+	GetMultipartForm() (*multipart.Form, error)
 	SetReadDeadline(time.Time) error
 	SetStatus(code int)
 	SetHeader(name, value string)

--- a/api.go
+++ b/api.go
@@ -41,7 +41,12 @@ var resolverWithPathType = reflect.TypeOf((*ResolverWithPath)(nil)).Elem()
 // routers and frameworks. It is designed to work with the standard library
 // `http.Request` and `http.ResponseWriter` types as well as types like
 // `gin.Context` or `fiber.Ctx` that provide both request and response
-// functionality in one place.
+// functionality in one place, by using the `huma.Context` interface which
+// abstracts away those router-specific differences.
+//
+// The handler function takes uses the context to get request information like
+// path / query / header params, the input body, and provide response data
+// like a status code, response headers, and a response body.
 type Adapter interface {
 	Handle(op *Operation, handler func(ctx Context))
 	ServeHTTP(http.ResponseWriter, *http.Request)
@@ -50,21 +55,54 @@ type Adapter interface {
 // Context is the current request/response context. It provides a generic
 // interface to get request information and write responses.
 type Context interface {
+	// Operation returns the OpenAPI operation that matched the request.
 	Operation() *Operation
+
+	// Context returns the underlying request context.
 	Context() context.Context
+
+	// Method returns the HTTP method for the request.
 	Method() string
+
+	// Host returns the HTTP host for the request.
 	Host() string
+
+	// URL returns the full URL for the request.
 	URL() url.URL
+
+	// Param returns the value for the given path parameter.
 	Param(name string) string
+
+	// Query returns the value for the given query parameter.
 	Query(name string) string
+
+	// Header returns the value for the given header.
 	Header(name string) string
+
+	// EachHeader iterates over all headers and calls the given callback with
+	// the header name and value.
 	EachHeader(cb func(name, value string))
+
+	// BodyReader returns the request body reader.
 	BodyReader() io.Reader
+
+	// GetMultipartForm returns the parsed multipart form, if any.
 	GetMultipartForm() (*multipart.Form, error)
+
+	// SetReadDeadline sets the read deadline for the request body.
 	SetReadDeadline(time.Time) error
+
+	// SetStatus sets the HTTP status code for the response.
 	SetStatus(code int)
+
+	// SetHeader sets the given header to the given value, overwriting any
+	// existing value. Use `AppendHeader` to append a value instead.
 	SetHeader(name, value string)
+
+	// AppendHeader appends the given value to the given header.
 	AppendHeader(name, value string)
+
+	// BodyWriter returns the response body writer.
 	BodyWriter() io.Writer
 }
 
@@ -85,7 +123,16 @@ type Config struct {
 	// to `/openapi` it will allow clients to get `/openapi.json` or
 	// `/openapi.yaml`, for example.
 	OpenAPIPath string
-	DocsPath    string
+
+	// DocsPath is the path to the API documentation. If set to `/docs` it will
+	// allow clients to get `/docs` to view the documentation in a browser. If
+	// you wish to provide your own documentation renderer, you can leave this
+	// blank and attach it directly to the router or adapter.
+	DocsPath string
+
+	// SchemasPath is the path to the API schemas. If set to `/schemas` it will
+	// allow clients to get `/schemas/{schema}` to view the schema in a browser
+	// or for use in editors like VSCode to provide autocomplete & validation.
 	SchemasPath string
 
 	// Formats defines the supported request/response formats by content type or
@@ -229,6 +276,20 @@ func (a *api) Middlewares() Middlewares {
 	return a.middlewares
 }
 
+// NewAPI creates a new API with the given configuration and router adapter.
+// You usually don't need to use this function directly, and can instead use
+// the `New(...)` function provided by the adapter packages which call this
+// function internally.
+//
+// When the API is created, this function will ensure a schema registry exists
+// (or create a new map registry if not), will set a default format if not
+// set, and will set up the handlers for the OpenAPI spec, documentation, and
+// JSON schema routes if the paths are set in the config.
+//
+//	router := chi.NewMux()
+//	adapter := humachi.NewAdapter(router)
+//	config := huma.DefaultConfig("Example API", "1.0.0")
+//	api := huma.NewAPI(config, adapter)
 func NewAPI(config Config, a Adapter) API {
 	newAPI := &api{
 		config:       config,

--- a/autopatch/autopatch.go
+++ b/autopatch/autopatch.go
@@ -1,3 +1,11 @@
+// Package autopatch provides a way to automatically generate PATCH operations
+// for resources which have a GET & PUT but no PATCH. This is useful for
+// resources which are large and have many fields, but where the majority of
+// updates are only to a few fields. This allows clients to send a partial
+// update to the server without having to send the entire resource.
+//
+// JSON Merge Patch, JSON Patch, and Shorthand Merge Patch are supported as
+// input formats.
 package autopatch
 
 import (
@@ -27,11 +35,12 @@ type jsonPatchOp struct {
 
 var jsonPatchType = reflect.TypeOf([]jsonPatchOp{})
 
-// AutoPatch generates HTTP PATCH operations for any resource which has a
-// GET & PUT but no pre-existing PATCH operation. Generated PATCH operations
-// will call GET, apply either `application/merge-patch+json` or
-// `application/json-patch+json` patches, then call PUT with the updated
-// resource. This method may be safely called multiple times.
+// AutoPatch generates HTTP PATCH operations for any resource which has a GET &
+// PUT but no pre-existing PATCH operation. Generated PATCH operations will call
+// GET, apply either `application/merge-patch+json`,
+// `application/json-patch+json`, or `application/merge-patch+shorthand`
+// patches, then call PUT with the updated resource. This method may be safely
+// called multiple times.
 func AutoPatch(api huma.API) {
 	oapi := api.OpenAPI()
 	registry := oapi.Components.Schemas

--- a/autopatch/autopatch_test.go
+++ b/autopatch/autopatch_test.go
@@ -128,6 +128,15 @@ func TestPatch(t *testing.T) {
 	)
 	assert.Equal(t, http.StatusNotModified, w.Code, w.Body.String())
 
+	// Extra headers should not be a problem, including `Accept`.
+	w = api.Patch("/things/test",
+		"Content-Type: application/merge-patch+json",
+		"Accept: application/json",
+		"X-Some-Other: value",
+		strings.NewReader(`{"price": 1.23}`),
+	)
+	assert.Equal(t, http.StatusNotModified, w.Code, w.Body.String())
+
 	app := api.Adapter()
 	// New change but with wrong manual ETag, should fail!
 	w = httptest.NewRecorder()

--- a/autoregister_test.go
+++ b/autoregister_test.go
@@ -1,0 +1,53 @@
+package huma_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/go-chi/chi/v5"
+)
+
+// Item represents a single item with a unique ID.
+type Item struct {
+	ID string `json:"id"`
+}
+
+// ItemsResponse is a response containing a list of items.
+type ItemsResponse struct {
+	Body []Item `json:"body"`
+}
+
+// ItemsHandler handles item-related CRUD operations.
+type ItemsHandler struct{}
+
+// RegisterListItems registers the `list-items` operation with the given API.
+// Because the method starts with `Register` it will be automatically called
+// by `huma.AutoRegister` down below.
+func (s *ItemsHandler) RegisterListItems(api huma.API) {
+	// Register a list operation to get all the items.
+	huma.Register(api, huma.Operation{
+		OperationID: "list-items",
+		Method:      http.MethodGet,
+		Path:        "/items",
+	}, func(ctx context.Context, input *struct{}) (*ItemsResponse, error) {
+		resp := &ItemsResponse{}
+		resp.Body = []Item{{ID: "123"}}
+		return resp, nil
+	})
+}
+
+func ExampleAutoRegister() {
+	// Create the router and API.
+	router := chi.NewMux()
+	api := NewExampleAPI(router, huma.DefaultConfig("My Service", "1.0.0"))
+
+	// Create the item handler and register all of its operations.
+	itemsHandler := &ItemsHandler{}
+	huma.AutoRegister(api, itemsHandler)
+
+	// Confirm the list operation was registered.
+	fmt.Println(api.OpenAPI().Paths["/items"].Get.OperationID)
+	// Output: list-items
+}

--- a/conditional/params.go
+++ b/conditional/params.go
@@ -1,3 +1,14 @@
+// Package conditional provides utilities for working with HTTP conditional
+// requests using the `If-Match`, `If-None-Match`, `If-Modified-Since`, and
+// `If-Unmodified-Since` headers along with ETags and last modified times.
+//
+// In general, conditional requests with tight integration into your data
+// store will be preferred as they are more efficient. However, this package
+// provides a simple way to get started with conditional requests and once
+// the functionality is in place the performance can be improved later. You
+// still get the benefits of not sending extra data over the wire and
+// distributed write protections that prevent different users from
+// overwriting each other's changes.
 package conditional
 
 import (

--- a/error_test.go
+++ b/error_test.go
@@ -83,3 +83,19 @@ func TestNegotiateError(t *testing.T) {
 
 	assert.Error(t, huma.WriteErr(api, ctx, 400, "bad request"))
 }
+
+func TestTransformError(t *testing.T) {
+	config := huma.DefaultConfig("Test API", "1.0.0")
+	config.Transformers = []huma.Transformer{
+		func(ctx huma.Context, status string, v any) (any, error) {
+			return nil, fmt.Errorf("whoops")
+		},
+	}
+	_, api := humatest.New(t, config)
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	resp := httptest.NewRecorder()
+	ctx := humatest.NewContext(nil, req, resp)
+
+	assert.Error(t, huma.WriteErr(api, ctx, 400, "bad request"))
+}

--- a/examples/param-reuse/main.go
+++ b/examples/param-reuse/main.go
@@ -22,7 +22,7 @@ type Options struct {
 // ReusableParam is a reusable parameter that can go in the path or the body
 // of a request or response. The same validation applies to both places.
 type ReusableParam struct {
-	User string `json:"user" path:"user" maxLength:"10"`
+	User string `path:"user" json:"user" maxLength:"10"`
 }
 
 type MyResponse struct {

--- a/huma.go
+++ b/huma.go
@@ -1,3 +1,10 @@
+// Package huma provides a framework for building REST APIs in Go. It is
+// designed to be simple, fast, and easy to use. It is also designed to
+// generate OpenAPI 3.1 specifications and JSON Schema documents
+// describing the API and providing a quick & easy way to generate
+// docs, mocks, SDKs, CLI clients, and more.
+//
+// https://huma.rocks/
 package huma
 
 import (

--- a/negotiation/negotiation.go
+++ b/negotiation/negotiation.go
@@ -1,3 +1,6 @@
+// Package negotiation provides utilities for working with HTTP client-
+// driven content negotiation. It provides a zero-allocation utility for
+// determining the best content type for the server to encode a response.
 package negotiation
 
 import (

--- a/openapi.go
+++ b/openapi.go
@@ -9,6 +9,10 @@ import (
 )
 
 // Contact information to get support for the API.
+//
+//	name: API Support
+//	url: https://www.example.com/support
+//	email: support@example.com
 type Contact struct {
 	// Name of the contact person/organization.
 	Name string `yaml:"name,omitempty"`
@@ -25,6 +29,9 @@ type Contact struct {
 }
 
 // License name & link for using the API.
+//
+//	name: Apache 2.0
+//	identifier: Apache-2.0
 type License struct {
 	// Name of the license.
 	Name string `yaml:"name"`
@@ -42,7 +49,22 @@ type License struct {
 	Extensions map[string]any `yaml:",inline"`
 }
 
-// Info object that provides metadata about the API. The metadata MAY be used by the clients if needed, and MAY be presented in editing or documentation generation tools for convenience.
+// Info object that provides metadata about the API. The metadata MAY be used by
+// the clients if needed, and MAY be presented in editing or documentation
+// generation tools for convenience.
+//
+//	title: Sample Pet Store App
+//	summary: A pet store manager.
+//	description: This is a sample server for a pet store.
+//	termsOfService: https://example.com/terms/
+//	contact:
+//	  name: API Support
+//	  url: https://www.example.com/support
+//	  email: support@example.com
+//	license:
+//	  name: Apache 2.0
+//	  url: https://www.apache.org/licenses/LICENSE-2.0.html
+//	version: 1.0.1
 type Info struct {
 	// Title of the API.
 	Title string `yaml:"title"`
@@ -84,6 +106,14 @@ type ServerVariable struct {
 }
 
 // Server URL, optionally with variables.
+//
+//	servers:
+//	- url: https://development.gigantic-server.com/v1
+//	  description: Development server
+//	- url: https://staging.gigantic-server.com/v1
+//	  description: Staging server
+//	- url: https://api.gigantic-server.com/v1
+//	  description: Production server
 type Server struct {
 	// URL to the target host. This URL supports Server Variables and MAY be relative, to indicate that the host location is relative to the location where the OpenAPI document is being served. Variable substitutions will be made when a variable is named in {brackets}.
 	URL string `yaml:"url"`
@@ -99,80 +129,503 @@ type Server struct {
 	Extensions map[string]any `yaml:",inline"`
 }
 
+// Example value of a request param or body or response header or body.
+//
+//	requestBody:
+//	  content:
+//	    'application/json':
+//	      schema:
+//	        $ref: '#/components/schemas/Address'
+//	      examples:
+//	        foo:
+//	          summary: A foo example
+//	          value: {"foo": "bar"}
+//	        bar:
+//	          summary: A bar example
+//	          value: {"bar": "baz"}
 type Example struct {
-	Ref           string         `yaml:"$ref,omitempty"`
-	Summary       string         `yaml:"summary,omitempty"`
-	Description   string         `yaml:"description,omitempty"`
-	Value         any            `yaml:"value,omitempty"`
-	ExternalValue string         `yaml:"externalValue,omitempty"`
-	Extensions    map[string]any `yaml:",inline"`
+	// Ref is a reference to another example. This field is mutually exclusive
+	// with the other fields.
+	Ref string `yaml:"$ref,omitempty"`
+
+	// Summary is a short summary of the example.
+	Summary string `yaml:"summary,omitempty"`
+
+	// Description is a long description of the example. CommonMark syntax MAY
+	// be used for rich text representation.
+	Description string `yaml:"description,omitempty"`
+
+	// Value is an embedded literal example. The `value` field and `externalValue`
+	// field are mutually exclusive. To represent examples of media types that
+	// cannot naturally represented in JSON or YAML, use a string value to contain
+	// the example, escaping where necessary.
+	Value any `yaml:"value,omitempty"`
+
+	// ExternalValue is a URI that points to the literal example. This provides
+	// the capability to reference examples that cannot easily be included in JSON
+	// or YAML documents. The `value` field and `externalValue` field are mutually
+	// exclusive. See the rules for resolving Relative References.
+	ExternalValue string `yaml:"externalValue,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// Encoding is a single encoding definition applied to a single schema property.
+//
+//	requestBody:
+//	  content:
+//	    multipart/form-data:
+//	      schema:
+//	        type: object
+//	        properties:
+//	          id:
+//	            # default is text/plain
+//	            type: string
+//	            format: uuid
+//	          address:
+//	            # default is application/json
+//	            type: object
+//	            properties: {}
+//	          historyMetadata:
+//	            # need to declare XML format!
+//	            description: metadata in XML format
+//	            type: object
+//	            properties: {}
+//	          profileImage: {}
+//	      encoding:
+//	        historyMetadata:
+//	          # require XML Content-Type in utf-8 encoding
+//	          contentType: application/xml; charset=utf-8
+//	        profileImage:
+//	          # only accept png/jpeg
+//	          contentType: image/png, image/jpeg
+//	          headers:
+//	            X-Rate-Limit-Limit:
+//	              description: The number of allowed requests in the current period
+//	              schema:
+//	                type: integer
 type Encoding struct {
-	ContentType   string             `yaml:"contentType,omitempty"`
-	Headers       map[string]*Header `yaml:"headers,omitempty"`
-	Style         string             `yaml:"style,omitempty"`
-	Explode       *bool              `yaml:"explode,omitempty"`
-	AllowReserved bool               `yaml:"allowReserved,omitempty"`
-	Extensions    map[string]any     `yaml:",inline"`
+	// ContentType for encoding a specific property. Default value depends on the
+	// property type: for object - application/json; for array – the default is
+	// defined based on the inner type; for all other cases the default is
+	// application/octet-stream. The value can be a specific media type (e.g.
+	// application/json), a wildcard media type (e.g. image/*), or a
+	// comma-separated list of the two types.
+	ContentType string `yaml:"contentType,omitempty"`
+
+	// Headers is a map allowing additional information to be provided as headers,
+	// for example Content-Disposition. Content-Type is described separately and
+	// SHALL be ignored in this section. This property SHALL be ignored if the
+	// request body media type is not a multipart.
+	Headers map[string]*Header `yaml:"headers,omitempty"`
+
+	// Style describes how a specific property value will be serialized depending
+	// on its type. See Parameter Object for details on the style property. The
+	// behavior follows the same values as query parameters, including default
+	// values. This property SHALL be ignored if the request body media type is
+	// not application/x-www-form-urlencoded or multipart/form-data. If a value is
+	// explicitly defined, then the value of contentType (implicit or explicit)
+	// SHALL be ignored.
+	Style string `yaml:"style,omitempty"`
+
+	// Explode, when true, property values of type array or object generate
+	// separate parameters for each value of the array, or key-value-pair of the
+	// map. For other types of properties this property has no effect. When style
+	// is form, the default value is true. For all other styles, the default value
+	// is false. This property SHALL be ignored if the request body media type is
+	// not application/x-www-form-urlencoded or multipart/form-data. If a value is
+	// explicitly defined, then the value of contentType (implicit or explicit)
+	// SHALL be ignored.
+	Explode *bool `yaml:"explode,omitempty"`
+
+	// AllowReserved determines whether the parameter value SHOULD allow reserved
+	// characters, as defined by [RFC3986] :/?#[]@!$&'()*+,;= to be included
+	// without percent-encoding. The default value is false. This property SHALL
+	// be ignored if the request body media type is not
+	// application/x-www-form-urlencoded or multipart/form-data. If a value is
+	// explicitly defined, then the value of contentType (implicit or explicit)
+	// SHALL be ignored.
+	AllowReserved bool `yaml:"allowReserved,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// MediaType object provides schema and examples for the media type identified
+// by its key.
+//
+//	application/json:
+//	  schema:
+//	    $ref: "#/components/schemas/Pet"
+//	  examples:
+//	    cat:
+//	      summary: An example of a cat
+//	      value:
+//	        name: Fluffy
+//	        petType: Cat
+//	        color: White
+//	        gender: male
+//	        breed: Persian
 type MediaType struct {
-	Schema     *Schema              `yaml:"schema,omitempty"`
-	Example    any                  `yaml:"example,omitempty"`
-	Examples   map[string]*Example  `yaml:"examples,omitempty"`
-	Encoding   map[string]*Encoding `yaml:"encoding,omitempty"`
-	Extensions map[string]any       `yaml:",inline"`
+	// Schema defining the content of the request, response, or parameter.
+	Schema *Schema `yaml:"schema,omitempty"`
+
+	// Example of the media type. The example object SHOULD be in the correct
+	// format as specified by the media type. The example field is mutually
+	// exclusive of the examples field. Furthermore, if referencing a schema which
+	// contains an example, the example value SHALL override the example provided
+	// by the schema.
+	Example any `yaml:"example,omitempty"`
+
+	// Examples of the media type. Each example object SHOULD match the media type
+	// and specified schema if present. The examples field is mutually exclusive
+	// of the example field. Furthermore, if referencing a schema which contains
+	// an example, the examples value SHALL override the example provided by the
+	// schema.
+	Examples map[string]*Example `yaml:"examples,omitempty"`
+
+	// Encoding is a map between a property name and its encoding information. The
+	// key, being the property name, MUST exist in the schema as a property. The
+	// encoding object SHALL only apply to requestBody objects when the media type
+	// is multipart or application/x-www-form-urlencoded.
+	Encoding map[string]*Encoding `yaml:"encoding,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// Param Describes a single operation parameter.
+//
+// A unique parameter is defined by a combination of a name and location.
+//
+//	name: username
+//	in: path
+//	description: username to fetch
+//	required: true
+//	schema:
+//	  type: string
 type Param struct {
-	Ref           string              `yaml:"$ref,omitempty"`
-	Name          string              `yaml:"name,omitempty"`
-	In            string              `yaml:"in,omitempty"`
-	Description   string              `yaml:"description,omitempty"`
-	Required      bool                `yaml:"required,omitempty"`
-	Deprecated    bool                `yaml:"deprecated,omitempty"`
-	Style         string              `yaml:"style,omitempty"`
-	Explode       *bool               `yaml:"explode,omitempty"`
-	AllowReserved bool                `yaml:"allowReserved,omitempty"`
-	Schema        *Schema             `yaml:"schema,omitempty"`
-	Example       any                 `yaml:"example,omitempty"`
-	Examples      map[string]*Example `yaml:"examples,omitempty"`
-	Extensions    map[string]any      `yaml:",inline"`
+	// Ref is a reference to another example. This field is mutually exclusive
+	// with the other fields.
+	Ref string `yaml:"$ref,omitempty"`
+
+	// Name is REQUIRED. The name of the parameter. Parameter names are case
+	// sensitive.
+	//
+	//   - If in is "path", the name field MUST correspond to a template expression
+	//     occurring within the path field in the Paths Object. See Path Templating
+	//     for further information.
+	//
+	//   - If in is "header" and the name field is "Accept", "Content-Type" or
+	//     "Authorization", the parameter definition SHALL be ignored.
+	//
+	//   - For all other cases, the name corresponds to the parameter name used by
+	//     the in property.
+	Name string `yaml:"name,omitempty"`
+
+	// In is REQUIRED. The location of the parameter. Possible values are "query",
+	// "header", "path" or "cookie".
+	In string `yaml:"in,omitempty"`
+
+	// Description of the parameter. This could contain examples of use.
+	// CommonMark syntax MAY be used for rich text representation.
+	Description string `yaml:"description,omitempty"`
+
+	// Required determines whether this parameter is mandatory. If the parameter
+	// location is "path", this property is REQUIRED and its value MUST be true.
+	// Otherwise, the property MAY be included and its default value is false.
+	Required bool `yaml:"required,omitempty"`
+
+	// Deprecated specifies that a parameter is deprecated and SHOULD be
+	// transitioned out of usage. Default value is false.
+	Deprecated bool `yaml:"deprecated,omitempty"`
+
+	// AllowEmptyValue sets the ability to pass empty-valued parameters. This is
+	// valid only for query parameters and allows sending a parameter with an
+	// empty value. Default value is false. If style is used, and if behavior is
+	// n/a (cannot be serialized), the value of allowEmptyValue SHALL be ignored.
+	// Use of this property is NOT RECOMMENDED, as it is likely to be removed in a
+	// later revision.
+	AllowEmptyValue bool `yaml:"allowEmptyValue,omitempty"`
+
+	// Style describes how the parameter value will be serialized depending on the
+	// type of the parameter value. Default values (based on value of in): for
+	// query - form; for path - simple; for header - simple; for cookie - form.
+	Style string `yaml:"style,omitempty"`
+
+	// Explode, when true, makes parameter values of type array or object generate
+	// separate parameters for each value of the array or key-value pair of the
+	// map. For other types of parameters this property has no effect. When style
+	// is form, the default value is true. For all other styles, the default value
+	// is false.
+	Explode *bool `yaml:"explode,omitempty"`
+
+	// AllowReserved determines whether the parameter value SHOULD allow reserved
+	// characters, as defined by [RFC3986] :/?#[]@!$&'()*+,;= to be included
+	// without percent-encoding. This property only applies to parameters with an
+	// in value of query. The default value is false.
+	AllowReserved bool `yaml:"allowReserved,omitempty"`
+
+	// Schema defining the type used for the parameter.
+	Schema *Schema `yaml:"schema,omitempty"`
+
+	// Example of the parameter’s potential value. The example SHOULD match the
+	// specified schema and encoding properties if present. The example field is
+	// mutually exclusive of the examples field. Furthermore, if referencing a
+	// schema that contains an example, the example value SHALL override the
+	// example provided by the schema. To represent examples of media types that
+	// cannot naturally be represented in JSON or YAML, a string value can contain
+	// the example with escaping where necessary.
+	Example any `yaml:"example,omitempty"`
+
+	// Examples of the parameter’s potential value. Each example SHOULD contain a
+	// value in the correct format as specified in the parameter encoding. The
+	// examples field is mutually exclusive of the example field. Furthermore, if
+	// referencing a schema that contains an example, the examples value SHALL
+	// override the example provided by the schema.
+	Examples map[string]*Example `yaml:"examples,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// Header object follows the structure of the Parameter Object with the
+// following changes:
+//
+//   - name MUST NOT be specified, it is given in the corresponding headers map.
+//
+//   - in MUST NOT be specified, it is implicitly in header.
+//
+//   - All traits that are affected by the location MUST be applicable to a
+//     location of header (for example, style).
+//
+// Example:
+//
+//	description: The number of allowed requests in the current period
+//	schema:
+//	  type: integer
 type Header = Param
 
+// RequestBody describes a single request body.
+//
+//	description: user to add to the system
+//	content:
+//	  'application/json':
+//	    schema:
+//	      $ref: '#/components/schemas/User'
+//	    examples:
+//	      user:
+//	        summary: User Example
+//	        externalValue: 'https://foo.bar/examples/user-example.json'
 type RequestBody struct {
-	Ref         string                `yaml:"$ref,omitempty"`
-	Description string                `yaml:"description,omitempty"`
-	Content     map[string]*MediaType `yaml:"content"`
-	Required    bool                  `yaml:"required,omitempty"`
-	Extensions  map[string]any        `yaml:",inline"`
+	// Ref is a reference to another example. This field is mutually exclusive
+	// with the other fields.
+	Ref string `yaml:"$ref,omitempty"`
+
+	// Description of the request body. This could contain examples of use.
+	// CommonMark syntax MAY be used for rich text representation.
+	Description string `yaml:"description,omitempty"`
+
+	// Content is REQUIRED. The content of the request body. The key is a media
+	// type or media type range and the value describes it. For requests that
+	// match multiple keys, only the most specific key is applicable. e.g.
+	// text/plain overrides text/*
+	Content map[string]*MediaType `yaml:"content"`
+
+	// Required Determines if the request body is required in the request.
+	// Defaults to false.
+	Required bool `yaml:"required,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// Link object represents a possible design-time link for a response. The
+// presence of a link does not guarantee the caller’s ability to successfully
+// invoke it, rather it provides a known relationship and traversal mechanism
+// between responses and other operations.
+//
+// Unlike dynamic links (i.e. links provided in the response payload), the OAS
+// linking mechanism does not require link information in the runtime response.
+//
+// For computing links, and providing instructions to execute them, a runtime
+// expression is used for accessing values in an operation and using them as
+// parameters while invoking the linked operation.
+//
+//	paths:
+//	  /users/{id}:
+//	    parameters:
+//	    - name: id
+//	      in: path
+//	      required: true
+//	      description: the user identifier, as userId
+//	      schema:
+//	        type: string
+//	    get:
+//	      responses:
+//	        '200':
+//	          description: the user being returned
+//	          content:
+//	            application/json:
+//	              schema:
+//	                type: object
+//	                properties:
+//	                  uuid: # the unique user id
+//	                    type: string
+//	                    format: uuid
+//	          links:
+//	            address:
+//	              # the target link operationId
+//	              operationId: getUserAddress
+//	              parameters:
+//	                # get the `id` field from the request path parameter named `id`
+//	                userId: $request.path.id
+//	  # the path item of the linked operation
+//	  /users/{userid}/address:
+//	    parameters:
+//	    - name: userid
+//	      in: path
+//	      required: true
+//	      description: the user identifier, as userId
+//	      schema:
+//	        type: string
+//	    # linked operation
+//	    get:
+//	      operationId: getUserAddress
+//	      responses:
+//	        '200':
+//	          description: the user's address
 type Link struct {
-	Ref          string         `yaml:"$ref,omitempty"`
-	OperationRef string         `yaml:"operationRef,omitempty"`
-	OperationID  string         `yaml:"operationId,omitempty"`
-	Parameters   map[string]any `yaml:"parameters,omitempty"`
-	RequestBody  any            `yaml:"requestBody,omitempty"`
-	Description  string         `yaml:"description,omitempty"`
-	Server       *Server        `yaml:"server,omitempty"`
-	Extensions   map[string]any `yaml:",inline"`
+	// Ref is a reference to another example. This field is mutually exclusive
+	// with the other fields.
+	Ref string `yaml:"$ref,omitempty"`
+
+	// OperationRef is a relative or absolute URI reference to an OAS operation.
+	// This field is mutually exclusive of the operationId field, and MUST point
+	// to an Operation Object. Relative operationRef values MAY be used to locate
+	// an existing Operation Object in the OpenAPI definition. See the rules for
+	// resolving Relative References.
+	OperationRef string `yaml:"operationRef,omitempty"`
+
+	// OperationID is the name of an existing, resolvable OAS operation, as
+	// defined with a unique operationId. This field is mutually exclusive of the
+	// operationRef field.
+	OperationID string `yaml:"operationId,omitempty"`
+
+	// Parameters is a map representing parameters to pass to an operation as
+	// specified with operationId or identified via operationRef. The key is the
+	// parameter name to be used, whereas the value can be a constant or an
+	// expression to be evaluated and passed to the linked operation. The
+	// parameter name can be qualified using the parameter location [{in}.]{name}
+	// for operations that use the same parameter name in different locations
+	// (e.g. path.id).
+	Parameters map[string]any `yaml:"parameters,omitempty"`
+
+	// RequestBody is a literal value or {expression} to use as a request body
+	// when calling the target operation.
+	RequestBody any `yaml:"requestBody,omitempty"`
+
+	// Description of the link. CommonMark syntax MAY be used for rich text representation.
+	Description string `yaml:"description,omitempty"`
+
+	// Server object to be used by the target operation.
+	Server *Server `yaml:"server,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// Response describes a single response from an API Operation, including
+// design-time, static links to operations based on the response.
+//
+//	description: A complex object array response
+//	content:
+//	  application/json:
+//	    schema:
+//	      type: array
+//	      items:
+//	        $ref: '#/components/schemas/VeryComplexType'
 type Response struct {
-	Ref         string                `yaml:"$ref,omitempty"`
-	Description string                `yaml:"description,omitempty"`
-	Headers     map[string]*Param     `yaml:"headers,omitempty"`
-	Content     map[string]*MediaType `yaml:"content,omitempty"`
-	Links       map[string]*Link      `yaml:"links,omitempty"`
-	Extensions  map[string]any        `yaml:",inline"`
+	// Ref is a reference to another example. This field is mutually exclusive
+	// with the other fields.
+	Ref string `yaml:"$ref,omitempty"`
+
+	// Description is REQUIRED. A description of the response. CommonMark syntax
+	// MAY be used for rich text representation.
+	Description string `yaml:"description,omitempty"`
+
+	// Headers maps a header name to its definition. [RFC7230] states header names
+	// are case insensitive. If a response header is defined with the name
+	// "Content-Type", it SHALL be ignored.
+	Headers map[string]*Param `yaml:"headers,omitempty"`
+
+	// Content is a map containing descriptions of potential response payloads.
+	// The key is a media type or media type range and the value describes it. For
+	// responses that match multiple keys, only the most specific key is
+	// applicable. e.g. text/plain overrides text/*
+	Content map[string]*MediaType `yaml:"content,omitempty"`
+
+	// Links is a map of operations links that can be followed from the response.
+	// The key of the map is a short name for the link, following the naming
+	// constraints of the names for Component Objects.
+	Links map[string]*Link `yaml:"links,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// Operation describes a single API operation on a path.
+//
+//	tags:
+//	- pet
+//	summary: Updates a pet in the store with form data
+//	operationId: updatePetWithForm
+//	parameters:
+//	- name: petId
+//	  in: path
+//	  description: ID of pet that needs to be updated
+//	  required: true
+//	  schema:
+//	    type: string
+//	requestBody:
+//	  content:
+//	    'application/x-www-form-urlencoded':
+//	      schema:
+//	       type: object
+//	       properties:
+//	          name:
+//	            description: Updated name of the pet
+//	            type: string
+//	          status:
+//	            description: Updated status of the pet
+//	            type: string
+//	       required:
+//	         - status
+//	responses:
+//	  '200':
+//	    description: Pet updated.
+//	    content:
+//	      'application/json': {}
+//	      'application/xml': {}
+//	  '405':
+//	    description: Method Not Allowed
+//	    content:
+//	      'application/json': {}
+//	      'application/xml': {}
+//	security:
+//	- petstore_auth:
+//	  - write:pets
+//	  - read:pets
 type Operation struct {
-	// Huma-specific fields
+	// --- Huma-specific fields ---
 
 	// Method is the HTTP method for this operation
 	Method string `yaml:"-"`
@@ -216,109 +669,488 @@ type Operation struct {
 	// you'd still like the benefits of using Huma. Generally not recommended.
 	Hidden bool `yaml:"-"`
 
-	// OpenAPI fields
+	// --- OpenAPI fields ---
 
-	Tags         []string              `yaml:"tags,omitempty"`
-	Summary      string                `yaml:"summary,omitempty"`
-	Description  string                `yaml:"description,omitempty"`
-	ExternalDocs *ExternalDocs         `yaml:"externalDocs,omitempty"`
-	OperationID  string                `yaml:"operationId,omitempty"`
-	Parameters   []*Param              `yaml:"parameters,omitempty"`
-	RequestBody  *RequestBody          `yaml:"requestBody,omitempty"`
-	Responses    map[string]*Response  `yaml:"responses,omitempty"`
-	Callbacks    map[string]*PathItem  `yaml:"callbacks,omitempty"`
-	Deprecated   bool                  `yaml:"deprecated,omitempty"`
-	Security     []map[string][]string `yaml:"security,omitempty"`
-	Servers      []*Server             `yaml:"servers,omitempty"`
-	Extensions   map[string]any        `yaml:",inline"`
+	// Tags is a list of tags for API documentation control. Tags can be used for
+	// logical grouping of operations by resources or any other qualifier.
+	Tags []string `yaml:"tags,omitempty"`
+
+	// Summary is a short summary of what the operation does.
+	Summary string `yaml:"summary,omitempty"`
+
+	// Description is a verbose explanation of the operation behavior. CommonMark
+	// syntax MAY be used for rich text representation.
+	Description string `yaml:"description,omitempty"`
+
+	// ExternalDocs describes additional external documentation for this
+	// operation.
+	ExternalDocs *ExternalDocs `yaml:"externalDocs,omitempty"`
+
+	// OperationID is a unique string used to identify the operation. The id MUST
+	// be unique among all operations described in the API. The operationId value
+	// is case-sensitive. Tools and libraries MAY use the operationId to uniquely
+	// identify an operation, therefore, it is RECOMMENDED to follow common
+	// programming naming conventions.
+	OperationID string `yaml:"operationId,omitempty"`
+
+	// Parameters is a list of parameters that are applicable for this operation.
+	// If a parameter is already defined at the Path Item, the new definition will
+	// override it but can never remove it. The list MUST NOT include duplicated
+	// parameters. A unique parameter is defined by a combination of a name and
+	// location. The list can use the Reference Object to link to parameters that
+	// are defined at the OpenAPI Object’s components/parameters.
+	Parameters []*Param `yaml:"parameters,omitempty"`
+
+	// RequestBody applicable for this operation. The requestBody is fully
+	// supported in HTTP methods where the HTTP 1.1 specification [RFC7231] has
+	// explicitly defined semantics for request bodies. In other cases where the
+	// HTTP spec is vague (such as GET, HEAD and DELETE), requestBody is permitted
+	// but does not have well-defined semantics and SHOULD be avoided if possible.
+	RequestBody *RequestBody `yaml:"requestBody,omitempty"`
+
+	// Responses is the list of possible responses as they are returned from
+	// executing this operation.
+	Responses map[string]*Response `yaml:"responses,omitempty"`
+
+	// Callbacks is a map of possible out-of band callbacks related to the parent
+	// operation. The key is a unique identifier for the Callback Object. Each
+	// value in the map is a Callback Object that describes a request that may be
+	// initiated by the API provider and the expected responses.
+	Callbacks map[string]*PathItem `yaml:"callbacks,omitempty"`
+
+	// Deprecated declares this operation to be deprecated. Consumers SHOULD
+	// refrain from usage of the declared operation. Default value is false.
+	Deprecated bool `yaml:"deprecated,omitempty"`
+
+	// Security is a declaration of which security mechanisms can be used for this
+	// operation. The list of values includes alternative security requirement
+	// objects that can be used. Only one of the security requirement objects need
+	// to be satisfied to authorize a request. To make security optional, an empty
+	// security requirement ({}) can be included in the array. This definition
+	// overrides any declared top-level security. To remove a top-level security
+	// declaration, an empty array can be used.
+	Security []map[string][]string `yaml:"security,omitempty"`
+
+	// Servers is an alternative server array to service this operation. If an
+	// alternative server object is specified at the Path Item Object or Root
+	// level, it will be overridden by this value.
+	Servers []*Server `yaml:"servers,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// PathItem describes the operations available on a single path. A Path Item MAY
+// be empty, due to ACL constraints. The path itself is still exposed to the
+// documentation viewer but they will not know which operations and parameters
+// are available.
+//
+//	get:
+//	  description: Returns pets based on ID
+//	  summary: Find pets by ID
+//	  operationId: getPetsById
+//	  responses:
+//	    '200':
+//	      description: pet response
+//	      content:
+//	        '*/*' :
+//	          schema:
+//	            type: array
+//	            items:
+//	              $ref: '#/components/schemas/Pet'
+//	    default:
+//	      description: error payload
+//	      content:
+//	        'text/html':
+//	          schema:
+//	            $ref: '#/components/schemas/ErrorModel'
+//	parameters:
+//	- name: id
+//	  in: path
+//	  description: ID of pet to use
+//	  required: true
+//	  schema:
+//	    type: array
+//	    items:
+//	      type: string
+//	  style: simple
 type PathItem struct {
-	Ref         string         `yaml:"$ref,omitempty"`
-	Summary     string         `yaml:"summary,omitempty"`
-	Description string         `yaml:"description,omitempty"`
-	Get         *Operation     `yaml:"get,omitempty"`
-	Put         *Operation     `yaml:"put,omitempty"`
-	Post        *Operation     `yaml:"post,omitempty"`
-	Delete      *Operation     `yaml:"delete,omitempty"`
-	Options     *Operation     `yaml:"options,omitempty"`
-	Head        *Operation     `yaml:"head,omitempty"`
-	Patch       *Operation     `yaml:"patch,omitempty"`
-	Trace       *Operation     `yaml:"trace,omitempty"`
-	Servers     []*Server      `yaml:"servers,omitempty"`
-	Parameters  []*Param       `yaml:"parameters,omitempty"`
-	Extensions  map[string]any `yaml:",inline"`
+	// Ref is a reference to another example. This field is mutually exclusive
+	// with the other fields.
+	Ref string `yaml:"$ref,omitempty"`
+
+	// Summary is an optional, string summary, intended to apply to all operations
+	// in this path.
+	Summary string `yaml:"summary,omitempty"`
+
+	// Description is an optional, string description, intended to apply to all
+	// operations in this path. CommonMark syntax MAY be used for rich text
+	// representation.
+	Description string `yaml:"description,omitempty"`
+
+	// Get is a definition of a GET operation on this path.
+	Get *Operation `yaml:"get,omitempty"`
+
+	// Put is a definition of a PUT operation on this path.
+	Put *Operation `yaml:"put,omitempty"`
+
+	// Post is a definition of a POST operation on this path.
+	Post *Operation `yaml:"post,omitempty"`
+
+	// Delete is a definition of a DELETE operation on this path.
+	Delete *Operation `yaml:"delete,omitempty"`
+
+	// Options is a definition of a OPTIONS operation on this path.
+	Options *Operation `yaml:"options,omitempty"`
+
+	// Head is a definition of a HEAD operation on this path.
+	Head *Operation `yaml:"head,omitempty"`
+
+	// Patch is a definition of a PATCH operation on this path.
+	Patch *Operation `yaml:"patch,omitempty"`
+
+	// Trace is a definition of a TRACE operation on this path.
+	Trace *Operation `yaml:"trace,omitempty"`
+
+	// Servers is an alternative server array to service all operations in this
+	// path.
+	Servers []*Server `yaml:"servers,omitempty"`
+
+	// Parameters is a list of parameters that are applicable for all the
+	// operations described under this path. These parameters can be overridden at
+	// the operation level, but cannot be removed there. The list MUST NOT include
+	// duplicated parameters. A unique parameter is defined by a combination of a
+	// name and location. The list can use the Reference Object to link to
+	// parameters that are defined at the OpenAPI Object’s components/parameters.
+	Parameters []*Param `yaml:"parameters,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// OAuthFlow stores configuration details for a supported OAuth Flow.
+//
+//	type: oauth2
+//	flows:
+//	  implicit:
+//	    authorizationUrl: https://example.com/api/oauth/dialog
+//	    scopes:
+//	      write:pets: modify pets in your account
+//	      read:pets: read your pets
+//	  authorizationCode:
+//	    authorizationUrl: https://example.com/api/oauth/dialog
+//	    tokenUrl: https://example.com/api/oauth/token
+//	    scopes:
+//	      write:pets: modify pets in your account
+//	      read:pets: read your pets
 type OAuthFlow struct {
-	AuthorizationURL string            `yaml:"authorizationUrl"`
-	TokenURL         string            `yaml:"tokenUrl"`
-	RefreshURL       string            `yaml:"refreshUrl,omitempty"`
-	Scopes           map[string]string `yaml:"scopes"`
-	Extensions       map[string]any    `yaml:",inline"`
+	// AuthorizationURL is REQUIRED. The authorization URL to be used for this
+	// flow. This MUST be in the form of a URL. The OAuth2 standard requires the
+	// use of TLS.
+	AuthorizationURL string `yaml:"authorizationUrl"`
+
+	// TokenURL is REQUIRED. The token URL to be used for this flow. This MUST be
+	// in the form of a URL. The OAuth2 standard requires the use of TLS.
+	TokenURL string `yaml:"tokenUrl"`
+
+	// RefreshURL is the URL to be used for obtaining refresh tokens. This MUST be
+	// in the form of a URL. The OAuth2 standard requires the use of TLS.
+	RefreshURL string `yaml:"refreshUrl,omitempty"`
+
+	// Scopes are REQUIRED. The available scopes for the OAuth2 security scheme. A
+	// map between the scope name and a short description for it. The map MAY be
+	// empty.
+	Scopes map[string]string `yaml:"scopes"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// OAuthFlows allows configuration of the supported OAuth Flows.
 type OAuthFlows struct {
-	Implicit          *OAuthFlow     `yaml:"implicit,omitempty"`
-	Password          *OAuthFlow     `yaml:"password,omitempty"`
-	ClientCredentials *OAuthFlow     `yaml:"clientCredentials,omitempty"`
-	AuthorizationCode *OAuthFlow     `yaml:"authorizationCode,omitempty"`
-	Extensions        map[string]any `yaml:",inline"`
+	// Implicit is the configuration for the OAuth Implicit flow.
+	Implicit *OAuthFlow `yaml:"implicit,omitempty"`
+
+	// Password is the configuration for the OAuth Resource Owner Password flow.
+	Password *OAuthFlow `yaml:"password,omitempty"`
+
+	// ClientCredentials is the configuration for the OAuth Client Credentials
+	// flow. Previously called application in OpenAPI 2.0.
+	ClientCredentials *OAuthFlow `yaml:"clientCredentials,omitempty"`
+
+	// AuthorizationCode is the configuration for the OAuth Authorization Code
+	// flow. Previously called accessCode in OpenAPI 2.0.
+	AuthorizationCode *OAuthFlow `yaml:"authorizationCode,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// SecurityScheme defines a security scheme that can be used by the operations.
+//
+// Supported schemes are HTTP authentication, an API key (either as a header, a
+// cookie parameter or as a query parameter), mutual TLS (use of a client
+// certificate), OAuth2’s common flows (implicit, password, client credentials
+// and authorization code) as defined in [RFC6749], and OpenID Connect
+// Discovery. Please note that as of 2020, the implicit flow is about to be
+// deprecated by OAuth 2.0 Security Best Current Practice. Recommended for most
+// use case is Authorization Code Grant flow with PKCE.
+//
+//	type: http
+//	scheme: bearer
+//	bearerFormat: JWT
 type SecurityScheme struct {
-	Type             string         `yaml:"type"`
-	Description      string         `yaml:"description,omitempty"`
-	Name             string         `yaml:"name,omitempty"`
-	In               string         `yaml:"in,omitempty"`
-	Scheme           string         `yaml:"scheme,omitempty"`
-	BearerFormat     string         `yaml:"bearerFormat,omitempty"`
-	Flows            *OAuthFlows    `yaml:"flows,omitempty"`
-	OpenIDConnectURL string         `yaml:"openIdConnectUrl,omitempty"`
-	Extensions       map[string]any `yaml:",inline"`
+	// Type is REQUIRED. The type of the security scheme. Valid values are
+	// "apiKey", "http", "mutualTLS", "oauth2", "openIdConnect".
+	Type string `yaml:"type"`
+
+	// Description for security scheme. CommonMark syntax MAY be used for rich
+	// text representation.
+	Description string `yaml:"description,omitempty"`
+
+	// Name is REQUIRED. The name of the header, query or cookie parameter to be
+	// used.
+	Name string `yaml:"name,omitempty"`
+
+	// In is REQUIRED. The location of the API key. Valid values are "query",
+	// "header" or "cookie".
+	In string `yaml:"in,omitempty"`
+
+	// Scheme is REQUIRED. The name of the HTTP Authorization scheme to be used in
+	// the Authorization header as defined in [RFC7235]. The values used SHOULD be
+	// registered in the IANA Authentication Scheme registry.
+	Scheme string `yaml:"scheme,omitempty"`
+
+	// BearerFormat is a hint to the client to identify how the bearer token is
+	// formatted. Bearer tokens are usually generated by an authorization server,
+	// so this information is primarily for documentation purposes.
+	BearerFormat string `yaml:"bearerFormat,omitempty"`
+
+	// Flows is REQUIRED. An object containing configuration information for the
+	// flow types supported.
+	Flows *OAuthFlows `yaml:"flows,omitempty"`
+
+	// OpenIDConnectURL is REQUIRED. OpenId Connect URL to discover OAuth2
+	// configuration values. This MUST be in the form of a URL. The OpenID Connect
+	// standard requires the use of TLS.
+	OpenIDConnectURL string `yaml:"openIdConnectUrl,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// Components holds a set of reusable objects for different aspects of the OAS.
+// All objects defined within the components object will have no effect on the
+// API unless they are explicitly referenced from properties outside the
+// components object.
+//
+//	components:
+//	  schemas:
+//	    GeneralError:
+//	      type: object
+//	      properties:
+//	        code:
+//	          type: integer
+//	          format: int32
+//	        message:
+//	          type: string
+//	    Category:
+//	      type: object
+//	      properties:
+//	        id:
+//	          type: integer
+//	          format: int64
+//	        name:
+//	          type: string
+//	    Tag:
+//	      type: object
+//	      properties:
+//	        id:
+//	          type: integer
+//	          format: int64
+//	        name:
+//	          type: string
+//	  parameters:
+//	    skipParam:
+//	      name: skip
+//	      in: query
+//	      description: number of items to skip
+//	      required: true
+//	      schema:
+//	        type: integer
+//	        format: int32
+//	    limitParam:
+//	      name: limit
+//	      in: query
+//	      description: max records to return
+//	      required: true
+//	      schema:
+//	        type: integer
+//	        format: int32
+//	  responses:
+//	    NotFound:
+//	      description: Entity not found.
+//	    IllegalInput:
+//	      description: Illegal input for operation.
+//	    GeneralError:
+//	      description: General Error
+//	      content:
+//	        application/json:
+//	          schema:
+//	            $ref: '#/components/schemas/GeneralError'
+//	  securitySchemes:
+//	    api_key:
+//	      type: apiKey
+//	      name: api_key
+//	      in: header
+//	    petstore_auth:
+//	      type: oauth2
+//	      flows:
+//	        implicit:
+//	          authorizationUrl: https://example.org/api/oauth/dialog
+//	          scopes:
+//	            write:pets: modify pets in your account
+//	            read:pets: read your pets
 type Components struct {
-	Schemas         Registry                   `yaml:"schemas,omitempty"`
-	Responses       map[string]*Response       `yaml:"responses,omitempty"`
-	Parameters      map[string]*Param          `yaml:"parameters,omitempty"`
-	Examples        map[string]*Example        `yaml:"examples,omitempty"`
-	RequestBodies   map[string]*RequestBody    `yaml:"requestBodies,omitempty"`
-	Headers         map[string]*Header         `yaml:"headers,omitempty"`
+	// Schemas is an object to hold reusable Schema Objects.
+	Schemas Registry `yaml:"schemas,omitempty"`
+
+	// Responses is an object to hold reusable Response Objects.
+	Responses map[string]*Response `yaml:"responses,omitempty"`
+
+	// Parameters is an object to hold reusable Parameter Objects.
+	Parameters map[string]*Param `yaml:"parameters,omitempty"`
+
+	// Examples is an object to hold reusable Example Objects.
+	Examples map[string]*Example `yaml:"examples,omitempty"`
+
+	// RequestBodies is an object to hold reusable Request Body Objects.
+	RequestBodies map[string]*RequestBody `yaml:"requestBodies,omitempty"`
+
+	// Headers is an object to hold reusable Header Objects.
+	Headers map[string]*Header `yaml:"headers,omitempty"`
+
+	// SecuritySchemes is an object to hold reusable Security Scheme Objects.
 	SecuritySchemes map[string]*SecurityScheme `yaml:"securitySchemes,omitempty"`
-	Links           map[string]*Link           `yaml:"links,omitempty"`
-	Callbacks       map[string]*PathItem       `yaml:"callbacks,omitempty"`
-	PathItems       map[string]*PathItem       `yaml:"pathItems,omitempty"`
-	Extensions      map[string]any             `yaml:",inline"`
+
+	// Links is an object to hold reusable Link Objects.
+	Links map[string]*Link `yaml:"links,omitempty"`
+
+	// Callbacks is an object to hold reusable Callback Objects.
+	Callbacks map[string]*PathItem `yaml:"callbacks,omitempty"`
+
+	// PathItems is an object to hold reusable Path Item Objects.
+	PathItems map[string]*PathItem `yaml:"pathItems,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// ExternalDocs allows referencing an external resource for extended
+// documentation.
+//
+//	description: Find more info here
+//	url: https://example.com
 type ExternalDocs struct {
-	Description string         `yaml:"description,omitempty"`
-	URL         string         `yaml:"url"`
-	Extensions  map[string]any `yaml:",inline"`
+	// Description of the target documentation. CommonMark syntax MAY be used for
+	// rich text representation.
+	Description string `yaml:"description,omitempty"`
+
+	// URL is REQUIRED. The URL for the target documentation. Value MUST be in the
+	// format of a URL.
+	URL string `yaml:"url"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
+// Tag adds metadata to a single tag that is used by the Operation Object. It is
+// not mandatory to have a Tag Object per tag defined in the Operation Object
+// instances.
 type Tag struct {
-	Name         string         `yaml:"name"`
-	Description  string         `yaml:"description,omitempty"`
-	ExternalDocs *ExternalDocs  `yaml:"externalDocs,omitempty"`
-	Extensions   map[string]any `yaml:",inline"`
+	// Name is REQUIRED. The name of the tag.
+	Name string `yaml:"name"`
+
+	// Description for the tag. CommonMark syntax MAY be used for rich text
+	// representation.
+	Description string `yaml:"description,omitempty"`
+
+	// ExternalDocs is additional external documentation for this tag.
+	ExternalDocs *ExternalDocs `yaml:"externalDocs,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 }
 
 type AddOpFunc func(oapi *OpenAPI, op *Operation)
 
+// OpenAPI is the root object of the OpenAPI document.
 type OpenAPI struct {
-	OpenAPI           string                `yaml:"openapi"`
-	Info              *Info                 `yaml:"info"`
-	Servers           []*Server             `yaml:"servers,omitempty"`
-	JSONSchemaDialect string                `yaml:"jsonSchemaDialect,omitempty"`
-	Paths             map[string]*PathItem  `yaml:"paths,omitempty"`
-	Webhooks          map[string]*PathItem  `yaml:"webhooks,omitempty"`
-	Components        *Components           `yaml:"components,omitempty"`
-	Security          []map[string][]string `yaml:"security,omitempty"`
-	Tags              []*Tag                `yaml:"tags,omitempty"`
-	ExternalDocs      *ExternalDocs         `yaml:"externalDocs,omitempty"`
-	Extensions        map[string]any        `yaml:",inline"`
+	// OpenAPI is REQUIRED. This string MUST be the version number of the OpenAPI
+	// Specification that the OpenAPI document uses. The openapi field SHOULD be
+	// used by tooling to interpret the OpenAPI document. This is not related to
+	// the API info.version string.
+	OpenAPI string `yaml:"openapi"`
+
+	// Info is REQUIRED. Provides metadata about the API. The metadata MAY be used
+	// by tooling as required.
+	Info *Info `yaml:"info"`
+
+	// JSONSchemaDialect is he default value for the $schema keyword within Schema
+	// Objects contained within this OAS document. This MUST be in the form of a
+	// URI.
+	JSONSchemaDialect string `yaml:"jsonSchemaDialect,omitempty"`
+
+	// Servers is an array of Server Objects, which provide connectivity
+	// information to a target server. If the servers property is not provided, or
+	// is an empty array, the default value would be a Server Object with a url
+	// value of /.
+	Servers []*Server `yaml:"servers,omitempty"`
+
+	// Paths are the available paths and operations for the API.
+	Paths map[string]*PathItem `yaml:"paths,omitempty"`
+
+	// Webhooks that MAY be received as part of this API and that the API consumer
+	// MAY choose to implement. Closely related to the callbacks feature, this
+	// section describes requests initiated other than by an API call, for example
+	// by an out of band registration. The key name is a unique string to refer to
+	// each webhook, while the (optionally referenced) Path Item Object describes
+	// a request that may be initiated by the API provider and the expected
+	// responses. An example is available.
+	Webhooks map[string]*PathItem `yaml:"webhooks,omitempty"`
+
+	// Components is an element to hold various schemas for the document.
+	Components *Components `yaml:"components,omitempty"`
+
+	// Security is a declaration of which security mechanisms can be used across
+	// the API. The list of values includes alternative security requirement
+	// objects that can be used. Only one of the security requirement objects need
+	// to be satisfied to authorize a request. Individual operations can override
+	// this definition. To make security optional, an empty security requirement
+	// ({}) can be included in the array.
+	Security []map[string][]string `yaml:"security,omitempty"`
+
+	// Tags are a list of tags used by the document with additional metadata. The
+	// order of the tags can be used to reflect on their order by the parsing
+	// tools. Not all tags that are used by the Operation Object must be declared.
+	// The tags that are not declared MAY be organized randomly or based on the
+	// tools’ logic. Each tag name in the list MUST be unique.
+	Tags []*Tag `yaml:"tags,omitempty"`
+
+	// ExternalDocs is additional external documentation.
+	ExternalDocs *ExternalDocs `yaml:"externalDocs,omitempty"`
+
+	// Extensions (user-defined properties), if any. Values in this map will
+	// be marshalled as siblings of the other properties above.
+	Extensions map[string]any `yaml:",inline"`
 
 	// OnAddOperation is called when an operation is added to the OpenAPI via
 	// `AddOperation`. You may bypass this by directly writing to the `Paths`
@@ -326,6 +1158,10 @@ type OpenAPI struct {
 	OnAddOperation []AddOpFunc `yaml:"-"`
 }
 
+// AddOperation adds an operation to the OpenAPI. This is the preferred way to
+// add operations to the OpenAPI, as it will ensure that the operation is
+// properly added to the Paths map, and will call any registered OnAddOperation
+// functions.
 func (o *OpenAPI) AddOperation(op *Operation) {
 	if o.Paths == nil {
 		o.Paths = map[string]*PathItem{}

--- a/queryparam/queryparam.go
+++ b/queryparam/queryparam.go
@@ -6,6 +6,9 @@
 //		// Get the value of the `key` query parameter.
 //		value := queryparam.Get(r.URL.RawQuery, "key")
 //	}
+//
+// Note that this method does not support multiple values for the same key,
+// so using `val=1,2,3` is preferable to `val=1&val=2&val=3`.
 package queryparam
 
 import (

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,0 +1,79 @@
+package huma_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/go-chi/chi/v5"
+)
+
+// Step 1: Create your input struct where you want to do additional validation.
+// This struct must implement the `huma.Resolver` interface.
+type ExampleInputBody struct {
+	Count int `json:"count" minimum:"0"`
+}
+
+func (b *ExampleInputBody) Resolve(ctx huma.Context, prefix *huma.PathBuffer) []error {
+	// Return an error if some arbitrary rule is broken. In this case, if it's
+	// a multiple of 30 we return an error.
+	if b.Count%30 == 0 {
+		return []error{&huma.ErrorDetail{
+			Location: prefix.With("count"),
+			Message:  "multiples of 30 are not allowed",
+			Value:    b.Count,
+		}}
+	}
+
+	return nil
+}
+
+func ExampleResolver() {
+	// Create the API.
+	r := chi.NewRouter()
+	api := NewExampleAPI(r, huma.DefaultConfig("Example API", "1.0.0"))
+
+	huma.Register(api, huma.Operation{
+		OperationID: "resolver-example",
+		Method:      http.MethodPut,
+		Path:        "/resolver",
+	}, func(ctx context.Context, input *struct {
+		// Step 2: Use your custom struct with the resolver as a field in the
+		// request input. Here we use it as the body of the request.
+		Body ExampleInputBody
+	}) (*struct{}, error) {
+		// Do nothing. Validation should catch the error!
+		return nil, nil
+	})
+
+	// Make an example request showing the validation error response.
+	req, _ := http.NewRequest(http.MethodPut, "/resolver", strings.NewReader(`{"count": 30}`))
+	req.Host = "example.com"
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	out := bytes.NewBuffer(nil)
+	json.Indent(out, w.Body.Bytes(), "", "  ")
+	fmt.Println(out.String())
+	// Output: {
+	//   "$schema": "https://example.com/schemas/ErrorModel.json",
+	//   "title": "Unprocessable Entity",
+	//   "status": 422,
+	//   "detail": "validation failed",
+	//   "errors": [
+	//     {
+	//       "message": "multiples of 30 are not allowed",
+	//       "location": "body.count",
+	//       "value": 30
+	//     }
+	//   ]
+	// }
+}

--- a/sse/sse_example_test.go
+++ b/sse/sse_example_test.go
@@ -1,0 +1,62 @@
+package sse_test
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/sse"
+	"github.com/go-chi/chi/v5"
+)
+
+func ExampleRegister_sse() {
+	// 1. Define some message types.
+	type DefaultMessage struct {
+		Message string `json:"message"`
+	}
+
+	type UserEvent struct {
+		UserID   int    `json:"user_id"`
+		Username string `json:"username"`
+	}
+
+	type UserCreatedEvent UserEvent
+	type UserDeletedEvent UserEvent
+
+	// 2. Set up the API.
+	router := chi.NewMux()
+	api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))
+
+	// 3. Register an SSE operation.
+	sse.Register(api, huma.Operation{
+		OperationID: "sse",
+		Method:      http.MethodGet,
+		Path:        "/sse",
+	}, map[string]any{
+		// Map each event name to a message type.
+		"message":    &DefaultMessage{},
+		"userCreate": UserCreatedEvent{},
+		"userDelete": UserDeletedEvent{},
+	}, func(ctx context.Context, input *struct{}, send sse.Sender) {
+		// Use `send.Data` to send a message with the event type set to the
+		// corresponding registered type from the map above. For this example,
+		// it will send "message" as the type.
+		send.Data(DefaultMessage{Message: "Hello, world!"})
+
+		// Use `send` for more control, letting you set an ID and retry interval.
+		// The event type is still controlled by the map above and type passed
+		// as data below, in this case "userCreate" is sent.
+		send(sse.Message{
+			ID:    5,
+			Retry: 1000,
+			Data:  UserCreatedEvent{UserID: 1, Username: "foo"},
+		})
+
+		// Example "userDelete" event type.
+		send.Data(UserDeletedEvent{UserID: 2, Username: "bar"})
+
+		// Unknown event type gets sent as the default. Still uses JSON encoding!
+		send.Data("unknown event")
+	})
+}


### PR DESCRIPTION
This PR includes a ton of documentation updates, including adding the rest of the OpenAPI 3.1 spec descriptions to the corresponding Go structs/fields and including some examples from the spec. Some tests are updated as well and a few new examples are included that render in the Go docs.