### PR TITLE
fix: better paths for resolvers, prevent subtle mistakes

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -1,5 +1,7 @@
 package huma
 
+// Middlewares is a list of middleware functions that can be attached to an
+// API and will be called for all incoming requests.
 type Middlewares []func(ctx Context, next func(Context))
 
 // Handler builds and returns a handler func from the chain of middlewares,


### PR DESCRIPTION
This fixes the path buffer value for path/query/header params when used with/as resolvers. It also panics on invalid combinations like pointer+param or pointer+default, to help prevent common but very difficult to track down subtle bugs like values not getting set as expected. Some of that could be made possible later, but shouldn't block v2.0.0 from being released.