### PR TITLE
fix: better comparison of encoded payloads for patch, fixes #73

### DIFF
--- a/autopatch/autopatch.go
+++ b/autopatch/autopatch.go
@@ -277,7 +277,7 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 			return
 		}
 
-		if bytes.Equal(bytes.TrimSpace(patched), bytes.TrimSpace(origWriter.Body.Bytes())) {
+		if jsonpatch.Equal(patched, origWriter.Body.Bytes()) {
 			ctx.SetStatus(http.StatusNotModified)
 			return
 		}


### PR DESCRIPTION
This uses a function that compares the encoded JSONs and ignores whitespace differences.