### PR TITLE
fix: mkdocs deploy path

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,4 +21,4 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install mkdocs-material mkdocs-macros-plugin
-      - run: mkdocs gh-deploy --force
+      - run: cd docs && mkdocs gh-deploy --force


### PR DESCRIPTION
Run in the correct directory when building/deploying.