### PR TITLE
fix: trigger docs workflow on edits

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,8 +1,9 @@
 name: docs
 on:
+  workflow_dispatch: {}
   push:
     branches: [main]
-    paths: ["docs/**"]
+    paths: [".github/workflows/docs.yaml", "docs/**"]
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
Ensure this runs when the workflow file itself changes. Also add a manual trigger in case we need to rebuild from the latest.