### PR TITLE
docs: fix a few links

### DIFF
--- a/docs/docs/features/bring-your-own-router.md
+++ b/docs/docs/features/bring-your-own-router.md
@@ -59,7 +59,7 @@ graph LR
 ```
 
 -   Features
-    -   [Registering operations](/features/operations/)
+    -   [Registering operations](./operations.md)
 -   Reference
     -   [`huma.Context`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Context) a router-agnostic request/response context
     -   [`huma.Adapter`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Adapter) the router-agnostic adapter interface

--- a/docs/docs/features/json-schema-registry.md
+++ b/docs/docs/features/json-schema-registry.md
@@ -51,4 +51,4 @@ You can create your own registry with custom behavior by implementing the [`huma
     -   [JSON Schema spec](https://json-schema.org/)
     -   [OpenAPI 3.1 Components Object](https://spec.openapis.org/oas/v3.1.0#components-object)
 -   See Also
-    -   [Model Validation](/features/model-validation/) utility to validate custom JSON objects
+    -   [Model Validation](./model-validation.md) utility to validate custom JSON objects

--- a/docs/docs/features/model-validation.md
+++ b/docs/docs/features/model-validation.md
@@ -32,4 +32,4 @@ if errs != nil {
     -   [JSON Schema spec](https://json-schema.org/)
     -   [OpenAPI 3.1 spec](https://spec.openapis.org/oas/v3.1.0)
 -   See Also
-    -   [Config & OpenAPI](/features/openapi-generation/)
+    -   [Config & OpenAPI](./openapi-generation.md)

--- a/docs/docs/features/openapi-generation.md
+++ b/docs/docs/features/openapi-generation.md
@@ -85,7 +85,7 @@ Anything in the `Extensions` map will be flattened during serialization so that 
 ## Dive Deeper
 
 -   Tutorial
-    -   [Your First API](/tutorial/your-first-api/) includes using the default config
+    -   [Your First API](../tutorial/your-first-api.md) includes using the default config
 -   Reference
     -   [`huma.Config`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Config) the API config
     -   [`huma.DefaultConfig`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#DefaultConfig) the default API config

--- a/docs/docs/features/operations.md
+++ b/docs/docs/features/operations.md
@@ -40,7 +40,7 @@ If your operation has no inputs or outputs, you can use `*struct{}` when registe
 ## Dive Deeper
 
 -   Tutorial
-    -   [Your First API](/tutorial/your-first-api/#operation) includes registering an operation
+    -   [Your First API](../tutorial/your-first-api.md#operation) includes registering an operation
 -   Reference
     -   [`huma.Register`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Register) registers new operations
     -   [`huma.Operation`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Operation) the operation

--- a/docs/docs/features/request-inputs.md
+++ b/docs/docs/features/request-inputs.md
@@ -102,7 +102,7 @@ huma.Register(api, huma.Operation{
 ## Dive Deeper
 
 -   Tutorial
-    -   [Your First API](/tutorial/your-first-api/) includes registering an operation with a path param
+    -   [Your First API](../tutorial/your-first-api.md) includes registering an operation with a path param
 -   Reference
     -   [`huma.Register`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Register) registers new operations
     -   [`huma.Operation`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Operation) the operation

--- a/docs/docs/features/request-validation.md
+++ b/docs/docs/features/request-validation.md
@@ -39,7 +39,7 @@ Parameters have some additional validation tags:
 ## Dive Deeper
 
 -   Tutorial
-    -   [Your First API](/tutorial/your-first-api/) includes string length validation
+    -   [Your First API](../tutorial/your-first-api.md) includes string length validation
 -   Reference
     -   [`huma.Register`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Register) registers new operations
     -   [`huma.Operation`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Operation) the operation

--- a/docs/docs/features/response-outputs.md
+++ b/docs/docs/features/response-outputs.md
@@ -76,7 +76,7 @@ type MyOutput struct {
 
 ## Body
 
-The special struct field `Body` will be treated as the response body and can refer to any other type or you can embed a struct or slice inline. Use a type of `[]byte` to bypass [serialization](/features/response-serialization/). A default `Content-Type` header will be set if none is present, selected via client-driven content negotiation with the server based on the registered serialization types.
+The special struct field `Body` will be treated as the response body and can refer to any other type or you can embed a struct or slice inline. Use a type of `[]byte` to bypass [serialization](./response-serialization.md). A default `Content-Type` header will be set if none is present, selected via client-driven content negotiation with the server based on the registered serialization types.
 
 Example:
 

--- a/docs/docs/features/response-serialization.md
+++ b/docs/docs/features/response-serialization.md
@@ -19,7 +19,7 @@ The default configuration for Huma includes support for JSON ([RFC 8259](https:/
 
 ## Custom Formats
 
-Huma supports custom serialization formats by implementing the [`huma.Format`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Format) interface. Serialization formats are set on the API configuration at API creation time and selected by client-driven [content negotiation](./#content-negotiation).
+Huma supports custom serialization formats by implementing the [`huma.Format`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Format) interface. Serialization formats are set on the API configuration at API creation time and selected by client-driven [content negotiation](#content-negotiation).
 
 Writing a new format can be very simple, by just providing a marshal and unmarshal function:
 

--- a/docs/docs/features/schema-customization.md
+++ b/docs/docs/features/schema-customization.md
@@ -97,4 +97,4 @@ See [https://github.com/danielgtaylor/huma/blob/main/examples/omit/main.go](http
     -   [JSON Schema spec](https://json-schema.org/)
     -   [OpenAPI 3.1 spec](https://spec.openapis.org/oas/v3.1.0)
 -   See Also
-    -   [Config & OpenAPI](/features/openapi-generation/)
+    -   [Config & OpenAPI](./openapi-generation.md)

--- a/docs/docs/features/test-utilities.md
+++ b/docs/docs/features/test-utilities.md
@@ -76,7 +76,7 @@ Use whatever assertion library you want to make these checks.
 ## Dive Deeper
 
 -   Tutorial
-    -   [Writing Tests](/tutorial/writing-tests/)
+    -   [Writing Tests](../tutorial/writing-tests.md)
 -   Reference
     -   [`humatest`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2/humatest)
 -   External Links

--- a/docs/docs/tutorial/cli-client.md
+++ b/docs/docs/tutorial/cli-client.md
@@ -49,13 +49,13 @@ Also consider setting up [shell command-line completion](https://rest.sh/#/guide
 
 Next, we need to tell Restish about your API and give it a short name, which we'll call `tutorial`. Do this using the `api configure` command. This only needs to be done one time.
 
-{{ asciinema("/terminal/restish-config.cast", rows="8") }}
+{{ asciinema("../../terminal/restish-config.cast", rows="8") }}
 
 ## Calling the API
 
 Once configured, you can call the API operations using high-level commands generated from the OpenAPI operation IDs:
 
-{{ asciinema("/terminal/restish-call.cast", rows="20") }}
+{{ asciinema("../../terminal/restish-call.cast", rows="20") }}
 
 See the help commands like `restish tutorial --help` or `restish tutorial get-greeting --help` for more details. If you set up command-line completion, you can also use tab to see all available commands.
 

--- a/docs/docs/tutorial/client-sdks.md
+++ b/docs/docs/tutorial/client-sdks.md
@@ -6,7 +6,7 @@
 
 First, grab the OpenAPI spec. Then install and use the generator to create the SDK.
 
-{{ asciinema("/terminal/build-sdk.cast", rows="14") }}
+{{ asciinema("../../terminal/build-sdk.cast", rows="14") }}
 
 ## Build the Client
 
@@ -47,7 +47,7 @@ func main() {
 
 Now you're ready to run the client:
 
-{{ asciinema("/terminal/sdk-client.cast", rows="8") }}
+{{ asciinema("../../terminal/sdk-client.cast", rows="8") }}
 
 ## Review
 

--- a/docs/docs/tutorial/installation.md
+++ b/docs/docs/tutorial/installation.md
@@ -8,7 +8,7 @@ Huma requires [Go 1.20 or newer](https://go.dev/dl/), so install that first. You
 
 Next, open a terminal and create a new Go project, then go get the Huma dependency to it's ready to be imported:
 
-{{ asciinema("/terminal/install.cast", rows="18") }}
+{{ asciinema("../../terminal/install.cast", rows="18") }}
 
 You should now have a directory structure like this:
 

--- a/docs/docs/tutorial/sending-data.md
+++ b/docs/docs/tutorial/sending-data.md
@@ -103,11 +103,11 @@ func main() {
 
 Make a request to the API:
 
-{{ asciinema("/terminal/post-review.cast", rows="8") }}
+{{ asciinema("../../terminal/post-review.cast", rows="8") }}
 
 You can also try sending invalid data, and see how you get exhaustive errors back from your API. Omit the `author` body field and use a rating outside the range of valid values:
 
-{{ asciinema("/terminal/post-review-error.cast", rows="28") }}
+{{ asciinema("../../terminal/post-review-error.cast", rows="28") }}
 
 ## Review
 
@@ -123,7 +123,7 @@ Congratulations! You just learned:
 
 Want to learn more about how sending data works? Check these out next:
 
--   [Request Inputs](/features/request-inputs/)
--   [Validation](/features/request-validation/)
--   [Resolvers](/features/request-resolvers/)
--   [Limits](/features/request-limits/)
+-   [Request Inputs](../features/request-inputs.md)
+-   [Validation](../features/request-validation.md)
+-   [Resolvers](../features/request-resolvers.md)
+-   [Limits](../features/request-limits.md)

--- a/docs/docs/tutorial/writing-tests.md
+++ b/docs/docs/tutorial/writing-tests.md
@@ -165,6 +165,6 @@ Congratulations! You just learned:
 
 Want to learn more about how testing works? Check these out next:
 
--   [Operations](/features/operations/)
--   [Test Utilities](/features/test-utilities/)
+-   [Operations](../features/operations.md)
+-   [Test Utilities](../features/test-utilities.md)
 -   [`humatest`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2/humatest) reference

--- a/docs/docs/tutorial/your-first-api.md
+++ b/docs/docs/tutorial/your-first-api.md
@@ -162,7 +162,7 @@ In another terminal window, make a request to the API using [Restish](../tutoria
 
 === "Restish"
 
-    {{ asciinema("/terminal/hello.cast", rows="13") }}
+    {{ asciinema("../../terminal/hello.cast", rows="13") }}
 
 === "Curl"
 

--- a/docs/docs/why/index.md
+++ b/docs/docs/why/index.md
@@ -5,9 +5,9 @@
 Huma is a proven production-ready technology that has been used by large successful companies and products for years including:
 
 <div style="text-align: center;">
-	<img src="/wbd.png" width="50%"/>
+	<img src="../wbd.png" width="50%"/>
 	<br/>
-	<img src="/max.png" width="22%" style="margin-right: 2%"/> <img src="/cnn.svg" width="6%" style="margin-right: 2%"/> <img src="/march-madness.svg" width="15%" style="margin-right: 2%"/> <img src="/br.svg" width="19%">
+	<img src="../max.png" width="22%" style="margin-right: 2%"/> <img src="../cnn.svg" width="6%" style="margin-right: 2%"/> <img src="../march-madness.svg" width="15%" style="margin-right: 2%"/> <img src="../br.svg" width="19%">
 </div>
 
 Huma is fast to learn, easy to use, performant, and lets your organization ship APIs and related tooling like interactive documentation, CLIs and SDKs faster and with fewer bugs caused by human-error and manual processes.
@@ -27,7 +27,7 @@ Well-known and understood standards means developers can get up to speed faster 
 [:material-arrow-right: Config & OpenAPI](../features/openapi-generation.md) <br/>
 [:material-arrow-right: JSON Schema & Registry](../features/json-schema-registry.md) <br/>
 [:material-arrow-right: Serialization](../features/response-serialization.md) <br/>
-[:material-arrow-right: PATCH formats](../features/autopatch.md)
+[:material-arrow-right: PATCH formats](../features/auto-patch.md)
 
 ### :fontawesome-brands-golang: Go is Awesome
 


### PR DESCRIPTION
While testing with gh-pages we need to support relative links as the site isn't hosted at the root of the domain. This also fixes a broken link to the auto-patch docs.