### PR TITLE
chore: add linter & rules config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,5 +10,9 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: "1.20"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.55.2
       - run: go test -coverprofile=coverage.txt -covermode=atomic ./...
       - uses: codecov/codecov-action@v1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+linters:
+  disable:
+    - errcheck
+  enable:
+    - misspell
+    - musttag
+    - nolintlint
+    - perfsprint
+    - prealloc
+    - testifylint
+    - unparam
+    - wastedassign

--- a/autopatch/autopatch.go
+++ b/autopatch/autopatch.go
@@ -91,7 +91,7 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 	jsonPatchSchema := oapi.Components.Schemas.Schema(jsonPatchType, true, "")
 
 	// Guess a name for this patch operation based on the GET operation.
-	name := ""
+	var name string
 	parts := casing.Split(get.OperationID)
 	if len(parts) > 1 && (strings.ToLower(parts[0]) == "get" || strings.ToLower(parts[0]) == "fetch") {
 		parts = parts[1:]

--- a/cli_test.go
+++ b/cli_test.go
@@ -75,10 +75,10 @@ func TestCLIPlain(t *testing.T) {
 	}
 
 	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
-		assert.Equal(t, true, options.Debug)
+		assert.True(t, options.Debug)
 		assert.Equal(t, "localhost", options.Host)
 		assert.Equal(t, 8001, options.Port)
-		assert.Equal(t, false, options.ingore)
+		assert.False(t, options.ingore)
 		hooks.OnStart(func() {
 			// Do nothing
 		})
@@ -101,7 +101,7 @@ func TestCLIAdvanced(t *testing.T) {
 	}
 
 	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
-		assert.Equal(t, true, options.Debug)
+		assert.True(t, options.Debug)
 		assert.Equal(t, "localhost", options.Host)
 		assert.Equal(t, 8001, options.Port)
 		hooks.OnStart(func() {

--- a/conditional/params_test.go
+++ b/conditional/params_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2/humatest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHasConditional(t *testing.T) {
@@ -37,15 +38,15 @@ func TestIfMatch(t *testing.T) {
 
 	p.IfMatch = []string{`"abc123"`, `W/"def456"`}
 	p.Resolve(ctx)
-	assert.NoError(t, p.PreconditionFailed("abc123", time.Time{}))
-	assert.NoError(t, p.PreconditionFailed("def456", time.Time{}))
+	require.NoError(t, p.PreconditionFailed("abc123", time.Time{}))
+	require.NoError(t, p.PreconditionFailed("def456", time.Time{}))
 
 	err := p.PreconditionFailed("bad", time.Time{})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, http.StatusNotModified, err.GetStatus())
 
 	err = p.PreconditionFailed("", time.Time{})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, http.StatusNotModified, err.GetStatus())
 
 	// Write request
@@ -55,10 +56,10 @@ func TestIfMatch(t *testing.T) {
 
 	p.IfMatch = []string{`"abc123"`, `W/"def456"`}
 	p.Resolve(ctx)
-	assert.NoError(t, p.PreconditionFailed("abc123", time.Time{}))
+	require.NoError(t, p.PreconditionFailed("abc123", time.Time{}))
 
 	err = p.PreconditionFailed("bad", time.Time{})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, http.StatusPreconditionFailed, err.GetStatus())
 }
 
@@ -72,15 +73,15 @@ func TestIfNoneMatch(t *testing.T) {
 
 	p.IfNoneMatch = []string{`"abc123"`, `W/"def456"`}
 	p.Resolve(ctx)
-	assert.NoError(t, p.PreconditionFailed("bad", time.Time{}))
-	assert.NoError(t, p.PreconditionFailed("", time.Time{}))
+	require.NoError(t, p.PreconditionFailed("bad", time.Time{}))
+	require.NoError(t, p.PreconditionFailed("", time.Time{}))
 
 	err := p.PreconditionFailed("abc123", time.Time{})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, http.StatusNotModified, err.GetStatus())
 
 	err = p.PreconditionFailed("def456", time.Time{})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, http.StatusNotModified, err.GetStatus())
 
 	// Write request
@@ -90,15 +91,15 @@ func TestIfNoneMatch(t *testing.T) {
 
 	p.IfNoneMatch = []string{`"abc123"`, `W/"def456"`}
 	p.Resolve(ctx)
-	assert.Error(t, p.PreconditionFailed("abc123", time.Time{}))
-	assert.NoError(t, p.PreconditionFailed("bad", time.Time{}))
+	require.Error(t, p.PreconditionFailed("abc123", time.Time{}))
+	require.NoError(t, p.PreconditionFailed("bad", time.Time{}))
 
 	// Write with special `*` syntax to match any.
 	p.IfNoneMatch = []string{"*"}
-	assert.NoError(t, p.PreconditionFailed("", time.Time{}))
+	require.NoError(t, p.PreconditionFailed("", time.Time{}))
 
 	err = p.PreconditionFailed("abc123", time.Time{})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, http.StatusPreconditionFailed, err.GetStatus())
 }
 
@@ -106,13 +107,13 @@ func TestIfModifiedSince(t *testing.T) {
 	p := Params{}
 
 	now, err := time.Parse(time.RFC3339, "2021-01-01T12:00:00Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	before, err := time.Parse(time.RFC3339, "2020-01-01T12:00:00Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	after, err := time.Parse(time.RFC3339, "2022-01-01T12:00:00Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Read request
 	r, _ := http.NewRequest(http.MethodGet, "https://example.com/resource", nil)
@@ -122,9 +123,9 @@ func TestIfModifiedSince(t *testing.T) {
 	p.IfModifiedSince = now
 
 	p.Resolve(ctx)
-	assert.Error(t, p.PreconditionFailed("", before))
-	assert.Error(t, p.PreconditionFailed("", now))
-	assert.NoError(t, p.PreconditionFailed("", after))
+	require.Error(t, p.PreconditionFailed("", before))
+	require.Error(t, p.PreconditionFailed("", now))
+	require.NoError(t, p.PreconditionFailed("", after))
 
 	// Write request
 	r, _ = http.NewRequest(http.MethodPut, "https://example.com/resource", nil)
@@ -135,7 +136,7 @@ func TestIfModifiedSince(t *testing.T) {
 
 	p.Resolve(ctx)
 	perr := p.PreconditionFailed("", before)
-	assert.Error(t, perr)
+	require.Error(t, perr)
 	assert.Equal(t, http.StatusPreconditionFailed, perr.GetStatus())
 }
 
@@ -143,13 +144,13 @@ func TestIfUnmodifiedSince(t *testing.T) {
 	p := Params{}
 
 	now, err := time.Parse(time.RFC3339, "2021-01-01T12:00:00Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	before, err := time.Parse(time.RFC3339, "2020-01-01T12:00:00Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	after, err := time.Parse(time.RFC3339, "2022-01-01T12:00:00Z")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Read request
 	r, _ := http.NewRequest(http.MethodGet, "https://example.com/resource", nil)
@@ -159,9 +160,9 @@ func TestIfUnmodifiedSince(t *testing.T) {
 	p.IfUnmodifiedSince = now
 
 	p.Resolve(ctx)
-	assert.NoError(t, p.PreconditionFailed("", before))
-	assert.NoError(t, p.PreconditionFailed("", now))
-	assert.Error(t, p.PreconditionFailed("", after))
+	require.NoError(t, p.PreconditionFailed("", before))
+	require.NoError(t, p.PreconditionFailed("", now))
+	require.Error(t, p.PreconditionFailed("", after))
 
 	// Write request
 	r, _ = http.NewRequest(http.MethodPut, "https://example.com/resource", nil)
@@ -172,6 +173,6 @@ func TestIfUnmodifiedSince(t *testing.T) {
 
 	p.Resolve(ctx)
 	perr := p.PreconditionFailed("", after)
-	assert.Error(t, perr)
+	require.Error(t, perr)
 	assert.Equal(t, http.StatusPreconditionFailed, perr.GetStatus())
 }

--- a/docs/asciinema-run/main.go
+++ b/docs/asciinema-run/main.go
@@ -249,7 +249,7 @@ func (s *Script) Execute() {
 	}
 }
 
-// echo prints out output continously.
+// echo prints out output continuously.
 func echo(r io.Reader) {
 	buf := make([]byte, 1024)
 	for {

--- a/error_test.go
+++ b/error_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/humatest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Ensure the default error models satisfy these interfaces.
@@ -81,7 +82,7 @@ func TestNegotiateError(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ctx := humatest.NewContext(nil, req, resp)
 
-	assert.Error(t, huma.WriteErr(api, ctx, 400, "bad request"))
+	require.Error(t, huma.WriteErr(api, ctx, 400, "bad request"))
 }
 
 func TestTransformError(t *testing.T) {
@@ -97,5 +98,5 @@ func TestTransformError(t *testing.T) {
 	resp := httptest.NewRecorder()
 	ctx := humatest.NewContext(nil, req, resp)
 
-	assert.Error(t, huma.WriteErr(api, ctx, 400, "bad request"))
+	require.Error(t, huma.WriteErr(api, ctx, 400, "bad request"))
 }

--- a/huma.go
+++ b/huma.go
@@ -112,7 +112,7 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 			pfi.Default = def
 		}
 
-		name := ""
+		var name string
 		var explode *bool
 		if p := f.Tag.Get("path"); p != "" {
 			pfi.Loc = "path"
@@ -560,7 +560,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 		if status == 0 {
 			status = http.StatusOK
 		}
-		statusStr := fmt.Sprintf("%d", status)
+		statusStr := strconv.Itoa(status)
 		if op.Responses[statusStr] == nil {
 			op.Responses[statusStr] = &Response{}
 		}
@@ -590,7 +590,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 			op.DefaultStatus = http.StatusNoContent
 		}
 	}
-	defaultStatusStr := fmt.Sprintf("%d", op.DefaultStatus)
+	defaultStatusStr := strconv.Itoa(op.DefaultStatus)
 	if op.Responses[defaultStatusStr] == nil {
 		op.Responses[defaultStatusStr] = &Response{
 			Description: http.StatusText(op.DefaultStatus),
@@ -624,7 +624,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 	errType := reflect.TypeOf(exampleErr)
 	errSchema := registry.Schema(errType, true, getHint(errType, "", "Error"))
 	for _, code := range op.Errors {
-		op.Responses[fmt.Sprintf("%d", code)] = &Response{
+		op.Responses[strconv.Itoa(code)] = &Response{
 			Description: http.StatusText(code),
 			Content: map[string]*MediaType{
 				errContentType: {

--- a/huma_test.go
+++ b/huma_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var NewExampleAdapter = humatest.NewAdapter
@@ -105,7 +106,7 @@ func TestFeatures(t *testing.T) {
 					assert.True(t, input.QueryBefore.Equal(time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)))
 					assert.True(t, input.QueryDate.Equal(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)))
 					assert.EqualValues(t, 1, input.QueryUint)
-					assert.Equal(t, true, input.QueryBool)
+					assert.True(t, input.QueryBool)
 					assert.Equal(t, []string{"foo", "bar"}, input.QueryStrings)
 					assert.Equal(t, "baz", input.HeaderString)
 					assert.Equal(t, 789, input.HeaderInt)
@@ -272,7 +273,7 @@ func TestFeatures(t *testing.T) {
 
 				// Ensure OpenAPI spec is listed as a binary upload. This enables
 				// generated documentation to show a file upload button.
-				assert.Equal(t, api.OpenAPI().Paths["/file"].Put.RequestBody.Content["application/foo"].Schema.Format, "binary")
+				assert.Equal(t, "binary", api.OpenAPI().Paths["/file"].Put.RequestBody.Content["application/foo"].Schema.Format)
 			},
 			Method:  http.MethodPut,
 			URL:     "/file",
@@ -567,7 +568,7 @@ func TestFeatures(t *testing.T) {
 					var parsed []struct {
 						Foo string `json:"foo"`
 					}
-					assert.NoError(t, json.Unmarshal(input.RawBody, &parsed))
+					require.NoError(t, json.Unmarshal(input.RawBody, &parsed))
 					assert.Len(t, parsed, 2)
 					assert.Equal(t, "first", parsed[0].Foo)
 					assert.Equal(t, "second", parsed[1].Foo)
@@ -633,7 +634,7 @@ func TestOpenAPI(t *testing.T) {
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 
-		assert.Equal(t, w.Code, 200, w.Body.String())
+		assert.Equal(t, 200, w.Code, w.Body.String())
 	}
 }
 
@@ -846,6 +847,7 @@ func TestPointerDefaultPanics(t *testing.T) {
 }
 
 func BenchmarkSecondDecode(b *testing.B) {
+	//nolint: musttag
 	type MediumSized struct {
 		ID   int      `json:"id"`
 		Name string   `json:"name"`
@@ -857,13 +859,13 @@ func BenchmarkSecondDecode(b *testing.B) {
 			ID    int    `json:"id"`
 			Name  string `json:"name"`
 			Email string `json:"email"`
-		}
+		} `json:"owner"`
 		Categories []struct {
 			Name    string   `json:"name"`
 			Order   int      `json:"order"`
 			Visible bool     `json:"visible"`
 			Aliases []string `json:"aliases"`
-		}
+		} `json:"categories"`
 	}
 
 	data := []byte(`{

--- a/openapi.go
+++ b/openapi.go
@@ -1102,7 +1102,7 @@ type Tag struct {
 type AddOpFunc func(oapi *OpenAPI, op *Operation)
 
 // OpenAPI is the root object of the OpenAPI document.
-type OpenAPI struct {
+type OpenAPI struct { //nolint: musttag
 	// OpenAPI is REQUIRED. This string MUST be the version number of the OpenAPI
 	// Specification that the OpenAPI document uses. The openapi field SHOULD be
 	// used by tooling to interpret the OpenAPI document. This is not related to

--- a/schema.go
+++ b/schema.go
@@ -56,7 +56,7 @@ func deref(t reflect.Type) reflect.Type {
 //	schema := huma.SchemaFromType(registry, reflect.TypeOf(MyType{}))
 //
 // Note that the registry may create references for your types.
-type Schema struct {
+type Schema struct { //nolint: musttag
 	Type                 string             `yaml:"type,omitempty"`
 	Title                string             `yaml:"title,omitempty"`
 	Description          string             `yaml:"description,omitempty"`
@@ -282,7 +282,7 @@ func jsonTagValue(f reflect.StructField, t reflect.Type, value string) any {
 
 // jsonTag returns a value of the schema's type for the given tag string.
 // Uses JSON parsing if the schema is not a string.
-func jsonTag(f reflect.StructField, name string, multi bool) any {
+func jsonTag(f reflect.StructField, name string) any {
 	t := f.Type
 	if value := f.Tag.Get(name); value != "" {
 		return jsonTagValue(f, t, value)
@@ -324,9 +324,9 @@ func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Sch
 	if enc := f.Tag.Get("encoding"); enc != "" {
 		fs.ContentEncoding = enc
 	}
-	fs.Default = jsonTag(f, "default", false)
+	fs.Default = jsonTag(f, "default")
 
-	if e := jsonTag(f, "example", false); e != nil {
+	if e := jsonTag(f, "example"); e != nil {
 		fs.Examples = []any{e}
 	}
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -3,20 +3,21 @@ package huma_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"math/bits"
 	"net"
 	"net/url"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type EmbeddedChild struct {
-	// This one should be ignored as it is overriden by `Embedded`.
+	// This one should be ignored as it is overridden by `Embedded`.
 	Value string `json:"value" doc:"old doc"`
 }
 
@@ -26,7 +27,7 @@ type Embedded struct {
 }
 
 func TestSchema(t *testing.T) {
-	bitSize := fmt.Sprint(bits.UintSize)
+	bitSize := strconv.Itoa(bits.UintSize)
 
 	cases := []struct {
 		name     string
@@ -470,7 +471,7 @@ func TestSchemaOld(t *testing.T) {
 	s := r.Schema(reflect.TypeOf(GreetingInput{}), false, "")
 	// fmt.Printf("%+v\n", s)
 	assert.Equal(t, "object", s.Type)
-	assert.Equal(t, 1, len(s.Properties))
+	assert.Len(t, s.Properties, 1)
 	assert.Equal(t, "string", s.Properties["ID"].Type)
 
 	r.Schema(reflect.TypeOf(RecursiveInput{}), false, "")
@@ -504,7 +505,7 @@ func TestSchemaGenericNaming(t *testing.T) {
 	}`, string(b))
 }
 
-type OmittableNullable[T any] struct {
+type OmittableNullable[T any] struct { //nolint: musttag
 	Sent  bool
 	Null  bool
 	Value T
@@ -542,21 +543,21 @@ func TestCustomUnmarshalType(t *testing.T) {
 	// Confirm the field works as expected when loading JSON.
 	o = O{}
 	err := json.Unmarshal([]byte(`{"field": 123}`), &o)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, o.Field.Sent)
 	assert.False(t, o.Field.Null)
 	assert.Equal(t, 123, o.Field.Value)
 
 	o = O{}
 	err = json.Unmarshal([]byte(`{"field": null}`), &o)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, o.Field.Sent)
 	assert.True(t, o.Field.Null)
 	assert.Equal(t, 0, o.Field.Value)
 
 	o = O{}
 	err = json.Unmarshal([]byte(`{}`), &o)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, o.Field.Sent)
 	assert.False(t, o.Field.Null)
 	assert.Equal(t, 0, o.Field.Value)

--- a/sse/sse_test.go
+++ b/sse/sse_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/danielgtaylor/huma/v2/humatest"
 	"github.com/danielgtaylor/huma/v2/sse"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type DefaultMessage struct {
@@ -69,7 +70,7 @@ func TestSSE(t *testing.T) {
 		send.Data("unknown event")
 
 		// Encode failure should return an error.
-		assert.Error(t, send(sse.Message{
+		require.Error(t, send(sse.Message{
 			Data: make(chan int),
 		}))
 	})


### PR DESCRIPTION
This adds support for [golangci-lint](https://golangci-lint.run/) if installed, and runs the linter on pull requests.

If using VSCode, you can use the following config line to enable linting whenever you save:

```json
"go.lintTool": "golangci-lint",
```