### PR TITLE
fix: document bunrouter support; remove incorrect benchmark

### DIFF
--- a/adapters/humabunrouter/humabunrouter_test.go
+++ b/adapters/humabunrouter/humabunrouter_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	humav1 "github.com/danielgtaylor/huma"
-	"github.com/danielgtaylor/huma/responses"
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/uptrace/bunrouter"
 )
@@ -318,52 +316,5 @@ func BenchmarkRawBunRouterFast(b *testing.B) {
 		reqBody.Seek(0, 0)
 		w.Body.Reset()
 		r.ServeHTTP(w, req)
-	}
-}
-
-func BenchmarkHumaV1BunRouter(t *testing.B) {
-	type GreetingInput struct {
-		ID          string `path:"id"`
-		ContentType string `header:"Content-Type"`
-		Num         int    `query:"num"`
-		Body        struct {
-			Suffix string `json:"suffix" maxLength:"5"`
-		}
-	}
-
-	type GreetingOutput struct {
-		Greeting    string `json:"greeting"`
-		Suffix      string `json:"suffix"`
-		Length      int    `json:"length"`
-		ContentType string `json:"content_type"`
-		Num         int    `json:"num"`
-	}
-
-	app := humav1.New("My API", "1.0.0")
-
-	app.Resource("/foo/{id}").Post("greet", "Get a greeting",
-		responses.OK().Model(&GreetingOutput{}).Headers("ETag", "Last-Modified"),
-	).Run(func(ctx humav1.Context, input GreetingInput) {
-		ctx.Header().Set("ETag", "abc123")
-		ctx.Header().Set("Last-Modified", lastModified.Format(http.TimeFormat))
-		resp := &GreetingOutput{}
-		resp.Greeting = "Hello, " + input.ID + input.Body.Suffix
-		resp.Suffix = input.Body.Suffix
-		resp.Length = len(resp.Greeting)
-		resp.ContentType = input.ContentType
-		resp.Num = input.Num
-		ctx.WriteModel(http.StatusOK, resp)
-	})
-
-	reqBody := strings.NewReader(`{"suffix": "!"}`)
-	req, _ := http.NewRequest(http.MethodPost, "/foo/123?num=5", reqBody)
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	t.ResetTimer()
-	t.ReportAllocs()
-	for i := 0; i < t.N; i++ {
-		reqBody.Seek(0, 0)
-		w.Body.Reset()
-		app.ServeHTTP(w, req)
 	}
 }

--- a/docs/docs/features/bring-your-own-router.md
+++ b/docs/docs/features/bring-your-own-router.md
@@ -8,8 +8,9 @@ description: Bring your own router & middleware to enable incremental adoption a
 
 Huma is designed to be router-agnostic to enable incremental adoption in existing and new services across a large number of organizations. This means you can use any router you want, or even write your own. The only requirement is an implementation of a small [`huma.Adapter`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Adapter) interface. This is how Huma integrates with your router.
 
-Adapters are in the [`adapters`](https://github.com/danielgtaylor/huma/tree/main/adapters) directory and named after the router they support. Many common routers are supported out of the box:
+Adapters are in the [`adapters`](https://github.com/danielgtaylor/huma/tree/main/adapters) directory and named after the router they support. Many common routers are supported out of the box (in alphabetical order):
 
+-   [BunRouter](https://bunrouter.uptrace.dev/) via [`humabunrouter`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2/adapters/humabunrouter)
 -   [chi](https://github.com/go-chi/chi) via [`humachi`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2/adapters/humachi)
 -   [gin](https://gin-gonic.com/) via [`humagin`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2/adapters/humagin)
 -   [gorilla/mux](https://github.com/gorilla/mux) via [`humamux`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2/adapters/humamux)


### PR DESCRIPTION
Adds docs about BunRouter support to https://huma.rocks/features/bring-your-own-router/ and removes a benchmark that was just testing Chi again since the older Huma v1 can't use any other router.