### PR TITLE
chore: trigger CI on pulls and push-on-main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request: {}
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should ensure the PR checks run on pull requests from other users rather than just pushes from maintainers.