### PR TITLE
fix: schema naming for generics + package types

### DIFF
--- a/schema_test.go
+++ b/schema_test.go
@@ -505,6 +505,20 @@ func TestSchemaGenericNaming(t *testing.T) {
 	}`, string(b))
 }
 
+func TestSchemaGenericNamingFromModule(t *testing.T) {
+	type SchemaGeneric[T any] struct {
+		Value T `json:"value"`
+	}
+
+	r := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
+	s := r.Schema(reflect.TypeOf(SchemaGeneric[time.Time]{}), true, "")
+
+	b, _ := json.Marshal(s)
+	assert.JSONEq(t, `{
+		"$ref": "#/components/schemas/SchemaGenericTime"
+	}`, string(b))
+}
+
 type OmittableNullable[T any] struct { //nolint: musttag
 	Sent  bool
 	Null  bool


### PR DESCRIPTION
Updates the default schema naming function to support generics using types defined in other packages, such as the included test example using `SchemaGeneric[time.Time]`. The JSON names and paths generated in the schema are now valid and documentation renders correctly.

Fixes #189 