### PR TITLE
fix: better validation of manual schemas

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -168,6 +168,28 @@ func (s *Schema) PrecomputeMessages() {
 		}
 	}
 
+	if s.propertyNames == nil {
+		s.propertyNames = make([]string, 0, len(s.Properties))
+		for name := range s.Properties {
+			s.propertyNames = append(s.propertyNames, name)
+		}
+	}
+
+	if s.requiredMap == nil {
+		s.requiredMap = map[string]bool{}
+		for _, name := range s.Required {
+			s.requiredMap[name] = true
+		}
+	}
+
+	if s.Items != nil {
+		s.Items.PrecomputeMessages()
+	}
+
+	for _, prop := range s.Properties {
+		prop.PrecomputeMessages()
+	}
+
 	for _, sub := range s.OneOf {
 		sub.PrecomputeMessages()
 	}

--- a/validate_test.go
+++ b/validate_test.go
@@ -894,6 +894,18 @@ var validateTests = []struct {
 		errs:  []string{"expected required property value to be present"},
 	},
 	{
+		name: "manual object property required",
+		s: &huma.Schema{
+			Type:     huma.TypeObject,
+			Required: []string{"value"},
+			Properties: map[string]*huma.Schema{
+				"value": {Type: huma.TypeString},
+			},
+		},
+		input: map[string]any{},
+		errs:  []string{"expected required property value to be present"},
+	},
+	{
 		name: "enum success",
 		typ: reflect.TypeOf(struct {
 			Value string `json:"value" enum:"one,two"`


### PR DESCRIPTION
Manually created schemas were not having `propertyNames` and `requiredMap` set up, which meant that validation of the inputs for those manual schemas was incomplete. This fixes it by backfilling any pre-computed data during the `PrecomputeMessages()` call, ensuring the validation works as expected.

This is related to some more complex scenarios described in #185 where schemas can't be generated from structs.