### PR TITLE
fix ref name contains recursive brackets '[]'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ mem.out
 docs/site
 docs/__pycache__
 docs/.cache
+.idea/

--- a/registry.go
+++ b/registry.go
@@ -4,13 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"regexp"
 	"strings"
 )
-
-// reGenericName helps to convert `MyType[path/to.SubType]` to `MyTypeSubType`
-// when using the default schema namer.
-var reGenericName = regexp.MustCompile(`\[[^\]]+\]`)
 
 // Registry creates and stores schemas and their references, and supports
 // marshalling to JSON/YAML for use as an OpenAPI #/components/schemas object.
@@ -35,14 +30,14 @@ func DefaultSchemaNamer(t reflect.Type, hint string) string {
 	name := deref(t).Name()
 
 	// Fix up generics, if used, for nicer refs & URLs.
-	name = reGenericName.ReplaceAllStringFunc(name, func(s string) string {
-		// Convert `MyType[path/to.SubType]` to `MyType[SubType]`.
-		parts := strings.Split(s, ".")
-		return parts[len(parts)-1]
-	})
-	// Remove square brackets.
-	name = strings.ReplaceAll(name, "[", "")
-	name = strings.ReplaceAll(name, "]", "")
+	// Convert `MyType[path/to.SubType]` to `MyTypepathtoSubType`.
+	replaced := strings.Builder{}
+	for _, c := range name {
+		if !strings.ContainsRune("[*/.]", c) {
+			replaced.WriteRune(c)
+		}
+	}
+	name = replaced.String()
 
 	if name == "" {
 		name = hint

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,27 @@
+package huma
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2/examples/protodemo/protodemo"
+	"github.com/stretchr/testify/assert"
+)
+
+type Output[T any] struct {
+	data T
+}
+
+type Embedded[P any] struct {
+	data P
+}
+
+func TestDefaultSchemaNamer(t *testing.T) {
+	testUser := Output[*[]Embedded[protodemo.User]]{}
+
+	name := DefaultSchemaNamer(reflect.TypeOf(testUser), "hint")
+	fmt.Println(reflect.TypeOf(testUser))
+	fmt.Println(name)
+	assert.True(t, name == "Outputgithubcomdanielgtaylorhumav2Embeddedgithubcomdanielgtaylorhumav2examplesprotodemoprotodemoUser")
+}


### PR DESCRIPTION
PR #195 fixed ISSUE #189. But regex matched a shorter string when a generic parameter is an slice( that means there's embedded brackets). 

And the expression is more complex when the generic parameter is another generic type. 

Propose to use a full path name as  the name is used as an ID and reference in the yaml. Readability is trivial. 