### PR TITLE
fix: enhanced generic schema naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ mem.out
 docs/site
 docs/__pycache__
 docs/.cache
+.idea/

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/uptrace/bunrouter v1.0.21
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
 	golang.org/x/net v0.17.0
+	golang.org/x/text v0.14.0
 	google.golang.org/protobuf v1.30.0
 )
 
@@ -83,7 +84,6 @@ require (
 	golang.org/x/arch v0.3.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/registry.go
+++ b/registry.go
@@ -4,13 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"regexp"
 	"strings"
 )
-
-// reGenericName helps to convert `MyType[path/to.SubType]` to `MyTypeSubType`
-// when using the default schema namer.
-var reGenericName = regexp.MustCompile(`\[[^\]]+\]`)
 
 // Registry creates and stores schemas and their references, and supports
 // marshalling to JSON/YAML for use as an OpenAPI #/components/schemas object.
@@ -35,14 +30,14 @@ func DefaultSchemaNamer(t reflect.Type, hint string) string {
 	name := deref(t).Name()
 
 	// Fix up generics, if used, for nicer refs & URLs.
-	name = reGenericName.ReplaceAllStringFunc(name, func(s string) string {
-		// Convert `MyType[path/to.SubType]` to `MyType[SubType]`.
-		parts := strings.Split(s, ".")
-		return parts[len(parts)-1]
-	})
-	// Remove square brackets.
-	name = strings.ReplaceAll(name, "[", "")
-	name = strings.ReplaceAll(name, "]", "")
+	// Convert `MyType[path/to.SubType]` to `MyTypepathtoSubType`.
+	replaced := strings.Builder{}
+	for _, c := range name {
+		if !strings.ContainsRune("[*/.]", c) {
+			replaced.WriteRune(c)
+		}
+	}
+	name = replaced.String()
 
 	if name == "" {
 		name = hint

--- a/registry.go
+++ b/registry.go
@@ -46,7 +46,6 @@ func DefaultSchemaNamer(t reflect.Type, hint string) string {
 		base := fqn[len(fqn)-1]
 
 		// Add to result, and uppercase for better scalar support (`int` -> `Int`).
-		// Base is guaranteed to be at least one character long so `[1:]` is safe.
 		result += cases.Title(language.Und, cases.NoLower).String(base)
 	}
 	name = result

--- a/registry_test.go
+++ b/registry_test.go
@@ -9,18 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type Output[T any] struct {
-	data T
-}
+type Output[T any] struct{}
 
-type Embedded[P any] struct {
-	data P
-}
+type Embedded[P any] struct{}
 
-type EmbeddedTwo[P, V any] struct {
-	data   P
-	second V
-}
+type EmbeddedTwo[P, V any] struct{}
 
 type S struct{}
 

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,27 @@
+package huma
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2/examples/protodemo/protodemo"
+	"github.com/stretchr/testify/assert"
+)
+
+type Output[T any] struct {
+	data T
+}
+
+type Embedded[P any] struct {
+	data P
+}
+
+func TestDefaultSchemaNamer(t *testing.T) {
+	testUser := Output[*[]Embedded[protodemo.User]]{}
+
+	name := DefaultSchemaNamer(reflect.TypeOf(testUser), "hint")
+	fmt.Println(reflect.TypeOf(testUser))
+	fmt.Println(name)
+	assert.True(t, name == "Outputgithubcomdanielgtaylorhumav2Embeddedgithubcomdanielgtaylorhumav2examplesprotodemoprotodemoUser")
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -501,7 +501,7 @@ func TestSchemaGenericNaming(t *testing.T) {
 
 	b, _ := json.Marshal(s)
 	assert.JSONEq(t, `{
-		"$ref": "#/components/schemas/SchemaGenericint"
+		"$ref": "#/components/schemas/SchemaGenericInt"
 	}`, string(b))
 }
 


### PR DESCRIPTION
This builds on #199 to generate SDK-friendly names for a bunch of generics scenarios, including unicode support for individual components. Lots of new test cases added which should cover the gamut of possibilities.