### PR TITLE
docs: Add OAuth 2.0 & JWT how-to

### DIFF
--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -4,7 +4,9 @@ description: Setting up OAuth2.0 JWT authentication for your API.
 
 ## Overview
 
-[OAuth 2.0](https://oauth.net/2/) is a popular open standard authentication & authorization framework that enables you to authorize requests to your API. There are three main pieces to using OAuth 2.0 with Huma:
+[OAuth 2.0](https://oauth.net/2/) is a popular open standard authorization framework that enables you to verify that incoming requests are authorized to use your API.
+
+There are three main pieces to using OAuth 2.0 with Huma:
 
 1. Issue a token (JWT) to a user
 2. Document the auth scheme and required permissions

--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -26,7 +26,9 @@ graph LR
 	Validate -->|5. Accept/reject| API
 	API --->|6. Success| Handler
 
-You will configure the third-party service to issue JWTs from OAuth 2.0 flows like Authorization Code or Client Credentials (among others) and will be given e.g. authorization and token URLs, which will be used later in the OpenAPI and to configure clients to fetch JWTs.
+The access token may be issued in different flavors & formats, but for the remainder of this document we will assume they are [JWTs](https://jwt.io/).
+
+You will configure the third-party service to issue access token from OAuth 2.0 flows like Authorization Code or Client Credentials (among others) and will be given e.g. authorization and token URLs, which will be used later in the OpenAPI and to configure clients to fetch access tokens.
 
 If **not** using a third-party service, you will need to set up a signing authority, publish your own JWKS, and issue short-lived tokens yourself. This is outside the scope of this guide, but take a look at [github.com/lestrrat-go/jwx](https://github.com/lestrrat-go/jwx) for a library that can help.
 

--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -1,5 +1,5 @@
 ---
-description: Setting up OAuth2.0 JWT authentication for your API.
+description: Setting up OAuth2.0 authorization for your API
 ---
 
 ## Overview

--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -8,7 +8,7 @@ description: Setting up OAuth2.0 authorization for your API
 
 There are three main pieces to using OAuth 2.0 with Huma:
 
-1. Issue a token (JWT) to a user
+1. Issue an access token to a client application
 2. Document the auth scheme and required permissions
 3. Authorize incoming requests
 

--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -12,20 +12,19 @@ There are three main pieces to using OAuth 2.0 with Huma:
 2. Document the auth scheme and required permissions
 3. Authorize incoming requests
 
-## Issue a Token (JWT)
+## Issue an Access Token
 
-Huma does not provide any built-in token issuing functionality. Instead, you can use any existing library or service to issue tokens. For simplicity sake, we will assume you are using a third-party service for managing users and issuing tokens, like [Auth0](https://auth0.com/) or [Okta](https://www.okta.com/). It looks something like this:
+Huma does not provide any built-in access token issuing functionality. Instead, you can use any existing library or service to issue tokens. For simplicity's sake, we will assume you are using a third-party service for managing users and issuing tokens, like [Auth0](https://auth0.com/) or [Okta](https://www.okta.com/).A simplified flow chart for OAuth2.0 authorization looks something like this:
 
 ```mermaid
 graph LR
 	User -->|1. Login| Auth0
-	Auth0 -->|2. Issue JWT| User
+	Auth0 -->|2. Issue access token| User
 	Auth0 -.->|Refresh JWKS| API
 	User --->|3. Make request| API
-	API -->|4. Verify JWT & Perms| Validate
+	API -->|4. Verify access token & roles| Validate
 	Validate -->|5. Accept/reject| API
 	API --->|6. Success| Handler
-```
 
 You will configure the third-party service to issue JWTs from OAuth 2.0 flows like Authorization Code or Client Credentials (among others) and will be given e.g. authorization and token URLs, which will be used later in the OpenAPI and to configure clients to fetch JWTs.
 

--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -84,9 +84,8 @@ huma.Register(api, huma.Operation{
 })
 ```
 
-!!! warning "Documentation Only"
-
-    This is documenting the auth mechanism and required scopes, but does not actually authorize incoming requests. See the next section for how to do that.
+> [!WARNING] 
+> So far, the code above is only documenting the authorization scheme and required scopes, but does not actually authorize incoming requests. The next section will explain  to achieve the latter.
 
 ## Authorize Incoming Requests
 

--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -14,7 +14,7 @@ There are three main pieces to using OAuth 2.0 with Huma:
 
 ## Issue an Access Token
 
-Huma does not provide any built-in access token issuing functionality. Instead, you can use any existing library or service to issue tokens. For simplicity's sake, we will assume you are using a third-party service for managing users and issuing tokens, like [Auth0](https://auth0.com/) or [Okta](https://www.okta.com/).A simplified flow chart for OAuth2.0 authorization looks something like this:
+Huma does not provide any built-in access token issuing functionality. Instead, you can use any existing library or service to issue tokens. For simplicity's sake, we will assume you are using a third-party service for managing users and issuing tokens, like [Auth0](https://auth0.com/) or [Okta](https://www.okta.com/). A simplified flow chart for OAuth2.0 authorization looks something like this:
 
 ```mermaid
 graph LR

--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -87,7 +87,7 @@ huma.Register(api, huma.Operation{
 ```
 
 > [!WARNING] 
-> So far, the code above is only documenting the authorization scheme and required scopes, but does not actually authorize incoming requests. The next section will explain  to achieve the latter.
+> So far, the code above is only documenting the authorization scheme and required scopes, but does not actually authorize incoming requests. The next section will explain how to achieve the latter.
 
 ## Authorize Incoming Requests
 

--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -106,7 +106,7 @@ graph LR
 	APIGateway --->|Forward| API
 ```
 
-In this case, you can skip this section as your service will never see unauthorized requests and the Huma code above acts mostly as documentation for your clients.
+In this case and depending on your security requirements, you may be able to skip this section since all incoming requests to your API will have already been vetted by the gateway. In this scenario, the Huma code frome the previous section serves mostly as documentation for your clients.
 
 ### Huma Auth Middleware
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - "Image Response": how-to/image-response.md
       - "Graceful Shutdown": how-to/graceful-shutdown.md
       - "Migrating From V1": how-to/migrate.md
+      - "OAuth 2.0 & JWT": how-to/oauth2-jwt.md
   - "Features":
       - "Features Overview": features/index.md
       - "The Server":


### PR DESCRIPTION
This takes some of the information from #202 and #186 and tries to put together a simple how-to for people wanting to add OAuth 2.0 based auth with JWTs to their API.