### PR TITLE
fix: avoid sending referrer header to unpkg

### DIFF
--- a/api.go
+++ b/api.go
@@ -362,12 +362,13 @@ func NewAPI(config Config, a Adapter) API {
 			ctx.BodyWriter().Write([]byte(`<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta charset="utf-8" />
+    <meta name="referrer" content="same-origin" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>Elements in HTML</title>
     <!-- Embed elements Elements via Web Component -->
     <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css" />
   </head>
   <body>
 


### PR DESCRIPTION
Sending the Referrer header is unnecessary and may leak some private data (unlikely to be highly-sensitive, but I think the point is still valid).