### PR TITLE
proposal: switch to versioned spotlight and add integrity check

### DIFF
--- a/api.go
+++ b/api.go
@@ -367,8 +367,9 @@ func NewAPI(config Config, a Adapter) API {
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>Elements in HTML</title>
     <!-- Embed elements Elements via Web Component -->
-    <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css" />
+    <link href="https://unpkg.com/@stoplight/elements@8.0.0/styles.min.css" rel="stylesheet" />
+    <script src="https://unpkg.com/@stoplight/elements@8.0.0/web-components.min.js"
+            integrity="sha256-yIhuSFMJJ6mp2XTUAb4SiSYneP3Qav8Uu+7NBhGJW5A="></script>
   </head>
   <body>
 


### PR DESCRIPTION
Using an unversioned import can become a security issue in case of compromised npm repositories or compromised unpkg.
To make the situation a bit safer-by-default, I propose a switch to versioned imports + the use of [subresource integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) to ensure users have a comparable level of security for the JS side as they do for the go side.

IMHO the trade-off between "bleeding-edge" and "security" seems to fall in favor of security, especially since uses who want the bleeding-edge can still override the docs handler.

WDYT?