### PR TITLE
fix: SSE oneOf schema contained null entries

### DIFF
--- a/sse/sse.go
+++ b/sse/sse.go
@@ -61,7 +61,7 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 	}
 
 	typeToEvent := make(map[reflect.Type]string, len(eventTypeMap))
-	dataSchemas := make([]*huma.Schema, len(eventTypeMap))
+	dataSchemas := make([]*huma.Schema, 0, len(eventTypeMap))
 	for k, v := range eventTypeMap {
 		vt := deref(reflect.TypeOf(v))
 		typeToEvent[vt] = k


### PR DESCRIPTION
This fixes a small issue where the generated SSE `oneOf` schema array contained empty `null` entries, one for each real entry in the array. The fix is to set the initial length of the Go slice to zero.

Fixes #207.