### PR TITLE
fix: add crossorigin config for sha integrity check

### DIFF
--- a/api.go
+++ b/api.go
@@ -369,7 +369,8 @@ func NewAPI(config Config, a Adapter) API {
     <!-- Embed elements Elements via Web Component -->
     <link href="https://unpkg.com/@stoplight/elements@8.0.0/styles.min.css" rel="stylesheet" />
     <script src="https://unpkg.com/@stoplight/elements@8.0.0/web-components.min.js"
-            integrity="sha256-yIhuSFMJJ6mp2XTUAb4SiSYneP3Qav8Uu+7NBhGJW5A="></script>
+            integrity="sha256-yIhuSFMJJ6mp2XTUAb4SiSYneP3Qav8Uu+7NBhGJW5A="
+            crossorigin="anonymous"></script>
   </head>
   <body>
 


### PR DESCRIPTION
This fixes #215 by allowing the integrity check to proceed via CORS request.

See also https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin