### PR TITLE
log accurate error message when there's duplicate registry name

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -84,7 +84,8 @@ func (r *mapRegistry) Schema(t reflect.Type, allowRef bool, hint string) *Schema
 		if s, ok := r.schemas[name]; ok {
 			if _, ok := r.seen[t]; !ok {
 				// Name matches but type is different, so we have a dupe.
-				panic(fmt.Errorf("duplicate name %s does not match existing type. New type %s, have existing types %+v", name, t, r.seen))
+
+				panic(fmt.Errorf("duplicate name: %s, new type: %s, existing type: %s", name, t, r.types[name]))
 			}
 			if allowRef {
 				return &Schema{Ref: r.prefix + name}


### PR DESCRIPTION

print the exact conflict items:

```go
panic: duplicate name: ResponseGenericOrderData, new type: main.Response[my-app/module/submodule2.Generic[my-app/module/submodule2.OrderData]], existing type: main.Response[my-app/module/submodule.Generic[my-app/module/submodule.OrderData]]
```

the original log message is hard to read especially when there's tens of API entries:

```go
panic: duplicate name ResponseGenericOrderData does not match existing type. New type main.Response[my-app/module/submodule2.Generic[my-app/module/submodule2.OrderData]], have existing types map[submodule.Generic[my-app/module/submodule.BizData]:true submodule.Generic[my-app/module/submodule.OrderData]:true submodule.BizData:true submodule.OrderData:true huma.ErrorDetail:true main.Response[my-app/module/submodule.Generic[my-app/module/submodule.BizData]]:true main.Response[my-app/module/submodule.Generic[my-app/module/submodule.OrderData]]:true huma.ErrorModel:true]

```
