### PR TITLE
feat: make multipart form max memory configurable

### DIFF
--- a/adapters/humabunrouter/humabunrouter.go
+++ b/adapters/humabunrouter/humabunrouter.go
@@ -15,6 +15,10 @@ import (
 	"github.com/uptrace/bunrouter"
 )
 
+// MultipartMaxMemory is the maximum memory to use when parsing multipart
+// form data.
+var MultipartMaxMemory int64 = 8 * 1024
+
 type bunContext struct {
 	op *huma.Operation
 	r  bunrouter.Request
@@ -66,7 +70,7 @@ func (c *bunContext) BodyReader() io.Reader {
 }
 
 func (c *bunContext) GetMultipartForm() (*multipart.Form, error) {
-	err := c.r.ParseMultipartForm(8 * 1024)
+	err := c.r.ParseMultipartForm(MultipartMaxMemory)
 	return c.r.MultipartForm, err
 }
 

--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -14,6 +14,10 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// MultipartMaxMemory is the maximum memory to use when parsing multipart
+// form data.
+var MultipartMaxMemory int64 = 8 * 1024
+
 type chiContext struct {
 	op *huma.Operation
 	r  *http.Request
@@ -70,7 +74,7 @@ func (c *chiContext) BodyReader() io.Reader {
 }
 
 func (c *chiContext) GetMultipartForm() (*multipart.Form, error) {
-	err := c.r.ParseMultipartForm(8 * 1024)
+	err := c.r.ParseMultipartForm(MultipartMaxMemory)
 	return c.r.MultipartForm, err
 }
 

--- a/adapters/humaecho/humaecho.go
+++ b/adapters/humaecho/humaecho.go
@@ -13,6 +13,10 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// MultipartMaxMemory is the maximum memory to use when parsing multipart
+// form data.
+var MultipartMaxMemory int64 = 8 * 1024
+
 type echoCtx struct {
 	op   *huma.Operation
 	orig echo.Context
@@ -63,7 +67,7 @@ func (c *echoCtx) BodyReader() io.Reader {
 }
 
 func (c *echoCtx) GetMultipartForm() (*multipart.Form, error) {
-	err := c.orig.Request().ParseMultipartForm(8 * 1024)
+	err := c.orig.Request().ParseMultipartForm(MultipartMaxMemory)
 	return c.orig.Request().MultipartForm, err
 }
 

--- a/adapters/humagin/humagin.go
+++ b/adapters/humagin/humagin.go
@@ -13,6 +13,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// MultipartMaxMemory is the maximum memory to use when parsing multipart
+// form data.
+var MultipartMaxMemory int64 = 8 * 1024
+
 type ginCtx struct {
 	op   *huma.Operation
 	orig *gin.Context
@@ -63,7 +67,7 @@ func (c *ginCtx) BodyReader() io.Reader {
 }
 
 func (c *ginCtx) GetMultipartForm() (*multipart.Form, error) {
-	err := c.orig.Request.ParseMultipartForm(8 * 1024)
+	err := c.orig.Request.ParseMultipartForm(MultipartMaxMemory)
 	return c.orig.Request.MultipartForm, err
 }
 

--- a/adapters/humago/humago.go
+++ b/adapters/humago/humago.go
@@ -13,6 +13,10 @@ import (
 	"github.com/danielgtaylor/huma/v2/queryparam"
 )
 
+// MultipartMaxMemory is the maximum memory to use when parsing multipart
+// form data.
+var MultipartMaxMemory int64 = 8 * 1024
+
 type goContext struct {
 	op *huma.Operation
 	r  *http.Request
@@ -71,7 +75,7 @@ func (c *goContext) BodyReader() io.Reader {
 }
 
 func (c *goContext) GetMultipartForm() (*multipart.Form, error) {
-	err := c.r.ParseMultipartForm(8 * 1024)
+	err := c.r.ParseMultipartForm(MultipartMaxMemory)
 	return c.r.MultipartForm, err
 }
 

--- a/adapters/humahttprouter/humahttprouter.go
+++ b/adapters/humahttprouter/humahttprouter.go
@@ -14,6 +14,10 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+// MultipartMaxMemory is the maximum memory to use when parsing multipart
+// form data.
+var MultipartMaxMemory int64 = 8 * 1024
+
 type httprouterContext struct {
 	op *huma.Operation
 	r  *http.Request
@@ -66,7 +70,7 @@ func (c *httprouterContext) BodyReader() io.Reader {
 }
 
 func (c *httprouterContext) GetMultipartForm() (*multipart.Form, error) {
-	err := c.r.ParseMultipartForm(8 * 1024)
+	err := c.r.ParseMultipartForm(MultipartMaxMemory)
 	return c.r.MultipartForm, err
 }
 

--- a/adapters/humamux/humamux.go
+++ b/adapters/humamux/humamux.go
@@ -13,6 +13,10 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// MultipartMaxMemory is the maximum memory to use when parsing multipart
+// form data.
+var MultipartMaxMemory int64 = 8 * 1024
+
 type gmuxContext struct {
 	op *huma.Operation
 	r  *http.Request
@@ -64,7 +68,7 @@ func (c *gmuxContext) BodyReader() io.Reader {
 }
 
 func (c *gmuxContext) GetMultipartForm() (*multipart.Form, error) {
-	err := c.r.ParseMultipartForm(8 * 1024)
+	err := c.r.ParseMultipartForm(MultipartMaxMemory)
 	return c.r.MultipartForm, err
 }
 


### PR DESCRIPTION
This makes multipart form parsing max memory usage configurable for most routers (Fiber does not have a memory limit for this feature). For example:

```go
import "github.com/danielgtaylor/huma/v2/adapters/humachi"

// Allow up to 5 MiB per form submission.
humachi.MultipartMaxMemory = 5 * 1024 * 1024
```

Fixes #205.