### PR TITLE
Errors in OAuth2 how to examples

### DIFF
--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -147,7 +147,7 @@ func NewJWKSet(jwkUrl string) jwk.Set {
 
 // NewAuthMiddleware creates a middleware that will authorize requests based on
 // the required scopes for the operation.
-func NewAuthMiddleware(jwksURL string) func(ctx huma.Context, next func(huma.Context)) {
+func NewAuthMiddleware(api huma.API, jwksURL string) func(ctx huma.Context, next func(huma.Context)) {
 	keySet := NewJWKSet(jwksURL)
 
 	return func(ctx huma.Context, next func(huma.Context)) {
@@ -168,7 +168,7 @@ func NewAuthMiddleware(jwksURL string) func(ctx huma.Context, next func(huma.Con
 
 		token := strings.TrimPrefix(ctx.Header("Authorization"), "Bearer ")
 		if len(token) == 0 {
-			huma.WriteErr(ctx, http.StatusUnauthorized, "Unauthorized")
+			huma.WriteErr(api, ctx, http.StatusUnauthorized, "Unauthorized")
 			return
 		}
 
@@ -180,7 +180,7 @@ func NewAuthMiddleware(jwksURL string) func(ctx huma.Context, next func(huma.Con
 			jwt.WithAudience("my-audience"),
 		)
 		if err != nil {
-			huma.WriteErr(ctx, http.StatusUnauthorized, "Unauthorized")
+			huma.WriteErr(api, ctx, http.StatusUnauthorized, "Unauthorized")
 			return
 		}
 
@@ -195,7 +195,7 @@ func NewAuthMiddleware(jwksURL string) func(ctx huma.Context, next func(huma.Con
 			}
 		}
 
-		huma.WriteErr(ctx, http.StatusForbidden, "Forbidden")
+		huma.WriteErr(api, ctx, http.StatusForbidden, "Forbidden")
 	}
 }
 ```
@@ -203,7 +203,7 @@ func NewAuthMiddleware(jwksURL string) func(ctx huma.Context, next func(huma.Con
 Lastly, when configuring your API, be sure to include this middleware:
 
 ```go title="main.go"
-api.UseMiddleware(NewAuthMiddleware("https://example.com/.well-known/jwks.json"))
+api.UseMiddleware(NewAuthMiddleware(api, "https://example.com/.well-known/jwks.json"))
 ```
 
 ### Supporting different Token Formats

--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -185,11 +185,13 @@ func NewAuthMiddleware(jwksURL string) func(ctx huma.Context, next func(huma.Con
 		}
 
 		// Ensure the claims required for this operation are present.
-		scopes = parsed.Get("scopes").([]string)
-		for _ scope := range scopes {
-			if slices.Contains(anyOfNeededScopes, scope) {
-				next(ctx)
-				return
+		scopes, _ := parsed.Get("scopes")
+		if scopes, ok := scopes.([]string); ok {
+			for _, scope := range scopes {
+				if slices.Contains(anyOfNeededScopes, scope) {
+					next(ctx)
+					return
+				}
 			}
 		}
 

--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -147,7 +147,7 @@ func NewJWKSet(jwkUrl string) jwk.Set {
 
 // NewAuthMiddleware creates a middleware that will authorize requests based on
 // the required scopes for the operation.
-func NewAuthMiddleware(jwksURL string) {
+func NewAuthMiddleware(jwksURL string) func(ctx huma.Context, next func(huma.Context)) {
 	keySet := NewJWKSet(jwksURL)
 
 	return func(ctx huma.Context, next func(huma.Context)) {


### PR DESCRIPTION
Fix minor errors in OAuth2 how to, but huma.WriteErr requires huma.API as first argument and there no way to obtain it in middleware. I was thinking about replacing it with http.Error, but it requires http.ResponseWriter and huma.Context doesn't implement it. So i'm stuck there.