### PR TITLE
Support parsing default option value formats

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/danielgtaylor/casing"
 	"github.com/spf13/cobra"
@@ -173,7 +174,13 @@ func (c *cli[O]) setupOptions(t reflect.Type, path []int) {
 		case reflect.Int, reflect.Int64:
 			var def int64
 			if defaultValue != "" {
-				def, err = strconv.ParseInt(defaultValue, 10, 64)
+				if field.Tag.Get("format") == "duration" {
+					var t time.Duration
+					t, err = time.ParseDuration(defaultValue)
+					def = int64(t)
+				} else {
+					def, err = strconv.ParseInt(defaultValue, 10, 64)
+				}
 				if err != nil {
 					panic(err)
 				}

--- a/cli_test.go
+++ b/cli_test.go
@@ -230,6 +230,19 @@ func TestCLIBadType(t *testing.T) {
 	})
 }
 
+func TestCLIDefaultFormat(t *testing.T) {
+	type OptionsDuration struct {
+		Timeout time.Duration `default:"5s" format:"duration"`
+	}
+
+	cli := huma.NewCLI(func(hooks huma.Hooks, options *OptionsDuration) {
+		assert.Equal(t, 5*time.Second, options.Timeout)
+	})
+
+	cli.Root().SetArgs([]string{})
+	cli.Run()
+}
+
 func TestCLIBadDefaults(t *testing.T) {
 	type OptionsBool struct {
 		Debug bool `default:"notabool"`


### PR DESCRIPTION
 - This simple change allows for specifying a format struct tag in CLI options to influence how string -> primitive type conversion works.

   This is not exhaustive and only supports time.Duration parsing right now (since time.Duration is really an int64 but often is useful to represent using a time string like `5s`)