### PR TITLE
fix: allow example/enum tags for custom schemas

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -112,6 +112,9 @@ func (r *mapRegistry) Schema(t reflect.Type, allowRef bool, hint string) *Schema
 }
 
 func (r *mapRegistry) SchemaFromRef(ref string) *Schema {
+	if !strings.HasPrefix(ref, r.prefix) {
+		return nil
+	}
 	return r.schemas[ref[len(r.prefix):]]
 }
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -960,11 +960,32 @@ var validateTests = []struct {
 		errs:  []string{"expected required property value to be present"},
 	},
 	{
-		name: "enum success",
+		name: "enum string success",
 		typ: reflect.TypeOf(struct {
 			Value string `json:"value" enum:"one,two"`
 		}{}),
 		input: map[string]any{"value": "one"},
+	},
+	{
+		name: "enum int success",
+		typ: reflect.TypeOf(struct {
+			Value int `json:"value" enum:"1,5,9"`
+		}{}),
+		input: map[string]any{"value": 1.0},
+	},
+	{
+		name: "enum uint16 success",
+		typ: reflect.TypeOf(struct {
+			Value uint16 `json:"value" enum:"1,5,9"`
+		}{}),
+		input: map[string]any{"value": 1.0},
+	},
+	{
+		name: "enum array success",
+		typ: reflect.TypeOf(struct {
+			Value []int `json:"value" enum:"1,5,9"`
+		}{}),
+		input: map[string]any{"value": []any{1.0}},
 	},
 	{
 		name: "expected enum",


### PR DESCRIPTION
This PR changes how the `example` and `enum` field tags are processed to enable using them for types which provide a custom schema, such as `OmittableNullable[int]`. The type checking now happens via the JSON Schema rather than the Go type, enabling a custom type which says it's an e.g. `integer` to match with enum values like `1,2,3`.

Note: this does **not** enable the use of defaults with type that provide custom schemas. Since defaults need to be type-cast to the Go type and assigned dynamically this is not currently possible with custom types.

Fixes #228 