### PR TITLE
feat: support time.Duration options

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/danielgtaylor/casing"
 	"github.com/spf13/cobra"
@@ -173,7 +174,13 @@ func (c *cli[O]) setupOptions(t reflect.Type, path []int) {
 		case reflect.Int, reflect.Int64:
 			var def int64
 			if defaultValue != "" {
-				def, err = strconv.ParseInt(defaultValue, 10, 64)
+				if field.Tag.Get("format") == "duration" {
+					var t time.Duration
+					t, err = time.ParseDuration(defaultValue)
+					def = int64(t)
+				} else {
+					def, err = strconv.ParseInt(defaultValue, 10, 64)
+				}
 				if err != nil {
 					panic(err)
 				}

--- a/cli_test.go
+++ b/cli_test.go
@@ -126,14 +126,16 @@ func TestCLIAdvanced(t *testing.T) {
 	type Options struct {
 		// Example of option composition via embedded type.
 		DebugOption
-		Host string `doc:"Hostname to listen on."`
-		Port int    `doc:"Port to listen on." short:"p" default:"8000"`
+		Host    string        `doc:"Hostname to listen on."`
+		Port    int           `doc:"Port to listen on." short:"p" default:"8000"`
+		Timeout time.Duration `doc:"Request timeout." default:"5s"`
 	}
 
 	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
 		assert.True(t, options.Debug)
 		assert.Equal(t, "localhost", options.Host)
 		assert.Equal(t, 8001, options.Port)
+		assert.Equal(t, 10*time.Second, options.Timeout)
 		hooks.OnStart(func() {
 			// Do nothing
 		})
@@ -145,7 +147,7 @@ func TestCLIAdvanced(t *testing.T) {
 		customPreRun = true
 	}
 
-	cli.Root().SetArgs([]string{"--debug", "--host", "localhost", "--port", "8001"})
+	cli.Root().SetArgs([]string{"--debug", "--host", "localhost", "--port", "8001", "--timeout", "10s"})
 	cli.Run()
 	assert.True(t, customPreRun)
 }
@@ -228,19 +230,6 @@ func TestCLIBadType(t *testing.T) {
 	assert.Panics(t, func() {
 		huma.NewCLI(func(hooks huma.Hooks, options *Options) {})
 	})
-}
-
-func TestCLIDefaultFormat(t *testing.T) {
-	type OptionsDuration struct {
-		Timeout time.Duration `default:"5s" format:"duration"`
-	}
-
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *OptionsDuration) {
-		assert.Equal(t, 5*time.Second, options.Timeout)
-	})
-
-	cli.Root().SetArgs([]string{})
-	cli.Run()
 }
 
 func TestCLIBadDefaults(t *testing.T) {

--- a/cli_test.go
+++ b/cli_test.go
@@ -230,6 +230,19 @@ func TestCLIBadType(t *testing.T) {
 	})
 }
 
+func TestCLIDefaultFormat(t *testing.T) {
+	type OptionsDuration struct {
+		Timeout time.Duration `default:"5s" format:"duration"`
+	}
+
+	cli := huma.NewCLI(func(hooks huma.Hooks, options *OptionsDuration) {
+		assert.Equal(t, 5*time.Second, options.Timeout)
+	})
+
+	cli.Root().SetArgs([]string{})
+	cli.Run()
+}
+
 func TestCLIBadDefaults(t *testing.T) {
 	type OptionsBool struct {
 		Debug bool `default:"notabool"`

--- a/docs/docs/features/cli.md
+++ b/docs/docs/features/cli.md
@@ -101,6 +101,7 @@ Custom options are defined by adding to your options struct. The following types
 | `bool`          | `true`, `false`                   |
 | `int` / `int64` | `1234`, `5`, `-1`                 |
 | `string`        | `prod`, `http://api.example.tld/` |
+| `time.Duration` | `500ms`, `3s`, `1h30m`            |
 
 The following struct tags are available:
 


### PR DESCRIPTION
This PR builds on #237 but provides auto-detection of `time.Duration` without the need for a special `format` field tag. Tests & docs are updated for the new type.

Fixes #237. Thanks @ddl-ebrown! :rocket: