### PR TITLE
change elements try it credentials policy to same-origin

### DIFF
--- a/api.go
+++ b/api.go
@@ -377,6 +377,7 @@ func NewAPI(config Config, a Adapter) API {
       apiDescriptionUrl="` + config.OpenAPIPath + `.yaml"
       router="hash"
       layout="sidebar"
+      tryItCredentialsPolicy="same-origin"
     />
 
   </body>


### PR DESCRIPTION
Elements "Try It" feature defaults to omitting credentials cookies, which causes APIs authenticated with cookies not to work.

This PR changes [elements credentials policy](https://docs.stoplight.io/docs/elements/b074dc47b2826-elements-configuration-options) to `same-origin`, [just like the default for a fetch request](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials#same-origin) :
> Send user credentials (cookies, basic http auth, etc..) if the URL is on the same origin as the calling script. This is the default value.
