### PR TITLE
fix: set CLI name from executable, add docs for name/version

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -254,7 +255,7 @@ func (c *cli[O]) setupOptions(t reflect.Type, path []int) {
 func NewCLI[O any](onParsed func(Hooks, *O)) CLI {
 	c := &cli[O]{
 		root: &cobra.Command{
-			Use: "myapp",
+			Use: filepath.Base(os.Args[0]),
 		},
 		onParsed: onParsed,
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -163,6 +163,7 @@ func TestCLIHelp(t *testing.T) {
 		// Do nothing
 	})
 
+	cli.Root().Use = "myapp"
 	cli.Root().SetArgs([]string{"--help"})
 	buf := bytes.NewBuffer(nil)
 	cli.Root().SetOut(buf)

--- a/docs/docs/features/cli.md
+++ b/docs/docs/features/cli.md
@@ -157,6 +157,36 @@ If you want to access your custom options struct with custom commands, use the [
 
     You can also overwite `cli.Root().Run` to completely customize how you run the server. Or just ditch the `cli` package altogether!
 
+## App Name & Version
+
+You can set the app name and version to be used in the help output and version command. By default, the app name is the name of the binary and the version is unset. You can set them using the root [`cobra.Command`](https://pkg.go.dev/github.com/spf13/cobra#Command)'s `Use` and `Version` fields:
+
+```go title="main.go"
+// cli := huma.NewCLI(...)
+
+cmd := cli.Root()
+cmd.Use = "appname"
+cmd.Version = "1.0.1"
+
+cmd.Run()
+```
+
+Then you will see something like this:
+
+```sh title="Terminal"
+$ go run ./demo --help
+Usage:
+  appname [flags]
+
+Flags:
+  -h, --help            help for appname
+  -p, --port int         (default 8888)
+  -v, --version         version for appname
+
+$ go run ./demo --version
+appname version 1.0.1
+```
+
 ## Dive Deeper
 
 -   Tutorial


### PR DESCRIPTION
This PR fixes the default CLI name to use the name of the executable being called, and adds documentation about how to manually set both the app name and version, if desired.

Fixes #264.