### PR TITLE
fix: Set body height to 100% of the viewport height

### DIFF
--- a/api.go
+++ b/api.go
@@ -371,7 +371,7 @@ func NewAPI(config Config, a Adapter) API {
             integrity="sha256-yIhuSFMJJ6mp2XTUAb4SiSYneP3Qav8Uu+7NBhGJW5A="
             crossorigin="anonymous"></script>
   </head>
-  <body>
+  <body style="height: 100vh;">
 
     <elements-api
       apiDescriptionUrl="` + config.OpenAPIPath + `.yaml"


### PR DESCRIPTION
Thank you for the fantastic work your team has done. When I use huma for a demo, I noticed that the documentation does not display correctly on my extended screen, as follows:
![image](https://github.com/danielgtaylor/huma/assets/5282978/cf060a9c-2067-4811-8cdd-eb562225b285)

I found a solution on the Stoplight documentation website that suggests resolving the issue by adding a style configuration to the body.
```html
<body style="height: 100vh;">
    <stoplight-api />
</body>
```
[Stoplight Layout](https://docs.stoplight.io/docs/elements/d536b917a4e1d-layout)

Hope this issue can be fixed!