### PR TITLE
fix: return wrapped errors on transform or write failure

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -461,12 +461,12 @@ func transformAndWrite(api API, ctx Context, status int, ct string, body any) {
 	tval, terr := api.Transform(ctx, strconv.Itoa(status), body)
 	if terr != nil {
 		ctx.BodyWriter().Write([]byte("error transforming response"))
-		panic(fmt.Sprintf("error transforming response %+v for %s %s %d: %s\n", tval, ctx.Operation().Method, ctx.Operation().Path, status, terr.Error()))
+		panic(fmt.Errorf("error transforming response %+v for %s %s %d: %w\n", tval, ctx.Operation().Method, ctx.Operation().Path, status, terr))
 	}
 	ctx.SetStatus(status)
 	if merr := api.Marshal(ctx.BodyWriter(), ct, tval); merr != nil {
 		ctx.BodyWriter().Write([]byte("error marshaling response"))
-		panic(fmt.Sprintf("error marshaling response %+v for %s %s %d: %s\n", tval, ctx.Operation().Method, ctx.Operation().Path, status, merr.Error()))
+		panic(fmt.Errorf("error marshaling response %+v for %s %s %d: %w\n", tval, ctx.Operation().Method, ctx.Operation().Path, status, merr))
 	}
 }
 

--- a/huma_test.go
+++ b/huma_test.go
@@ -704,7 +704,7 @@ func TestFeatures(t *testing.T) {
 			Name: "response-transform-error",
 			Transformers: []huma.Transformer{
 				func(ctx huma.Context, status string, v any) (any, error) {
-					return nil, errors.ErrUnsupported
+					return nil, http.ErrNotSupported
 				},
 			},
 			Register: func(t *testing.T, api huma.API) {
@@ -714,7 +714,7 @@ func TestFeatures(t *testing.T) {
 						if err := recover(); err != nil {
 							// Ensure the error is the one we expect, possibly wrapped with
 							// additional info.
-							assert.ErrorIs(t, err.(error), errors.ErrUnsupported)
+							assert.ErrorIs(t, err.(error), http.ErrNotSupported)
 						}
 						called = true
 					}()

--- a/huma_test.go
+++ b/huma_test.go
@@ -704,10 +704,23 @@ func TestFeatures(t *testing.T) {
 			Name: "response-transform-error",
 			Transformers: []huma.Transformer{
 				func(ctx huma.Context, status string, v any) (any, error) {
-					return nil, errors.New("whoops")
+					return nil, errors.ErrUnsupported
 				},
 			},
 			Register: func(t *testing.T, api huma.API) {
+				api.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
+					called := false
+					defer func() {
+						if err := recover(); err != nil {
+							// Ensure the error is the one we expect, possibly wrapped with
+							// additional info.
+							assert.ErrorIs(t, err.(error), errors.ErrUnsupported)
+						}
+						called = true
+					}()
+					next(ctx)
+					assert.True(t, called)
+				})
 				huma.Register(api, huma.Operation{
 					Method: http.MethodGet,
 					Path:   "/response",


### PR DESCRIPTION
This PR ensures the underlying errors from transforms and/or writes are wrapped and work with `errors.Is(...)` rather than being converted to strings.

Fixes #272.