### PR TITLE
docs: remove experimental flag for Go 1.22+

### DIFF
--- a/docs/docs/why/index.md
+++ b/docs/docs/why/index.md
@@ -54,7 +54,7 @@ Huma is router-agnostic and includes support for a handful of popular routers an
 -   [BunRouter](https://bunrouter.uptrace.dev/)
 -   [chi](https://github.com/go-chi/chi)
 -   [gin](https://gin-gonic.com/)
--   [Go 1.22+ `http.ServeMux` (experimental)](https://pkg.go.dev/net/http@master#ServeMux)
+-   [Go 1.22+ `http.ServeMux`](https://pkg.go.dev/net/http@master#ServeMux)
 -   [gorilla/mux](https://github.com/gorilla/mux)
 -   [httprouter](https://github.com/julienschmidt/httprouter)
 -   [Fiber](https://gofiber.io/)


### PR DESCRIPTION
This is no longer experimental.