### PR TITLE
feat: add convenience functions for summary and description

### DIFF
--- a/docs/docs/features/operations.md
+++ b/docs/docs/features/operations.md
@@ -71,7 +71,7 @@ huma.Get(api, "/things/{thing-id}", func(ctx context.Context, input *YourInput) 
 })
 ```
 
-The generated operation ID for the above example would be `get-things-by-thing-id`. Override `huma.GenerateOperationID(method, path string, response any)` to customize the generated operation IDs.
+In the example above, the generated operation ID is `get-things-by-thing-id` with a summary of `Get things by id`. To customize these, override `huma.GenerateOperationID(method, path string, response any)` for operation IDs and `huma.GenerateSummary(method, path string, response any)` for summaries.
 
 This makes it easy to get started, particularly if coming from other frameworks, and you can simply switch to using `huma.Register` if/when you need to set additional fields on the operation.
 

--- a/huma.go
+++ b/huma.go
@@ -1380,36 +1380,11 @@ var GenerateSummary = func(method, path string, response any) string {
 	return strings.ToUpper(phrase[:1]) + phrase[1:]
 }
 
-// GenerateDescription generates an operation description from the method,
-// path, and response type. The description is used to describe an operation
-// in the OpenAPI spec. The generated description is capitalized and includes
-// the method and path, with any path parameters replaced by their names.
-//
-// Examples:
-//
-//   - GET /things` -> `Lists the things.`
-//   - GET /things/{thing-id} -> `Gets the things by thing id.`
-//   - PUT /things/{thingId}/favorite -> `Puts the things by thing id favorite.`
-//
-// This function can be overridden to provide custom operation descriptions.
-var GenerateDescription = func(method, path string, response any) string {
-	action := method
-	body, hasBody := deref(reflect.TypeOf(response)).FieldByName("Body")
-	if hasBody && method == http.MethodGet && deref(body.Type).Kind() == reflect.Slice {
-		// Special case: GET with a slice response body is a list operation.
-		action = "list"
-	}
-	path = reRemoveIDs.ReplaceAllString(path, "by-$1")
-	phrase := strings.ReplaceAll(casing.Kebab(strings.ToLower(action)+"s the "+path, strings.ToLower, casing.Initialism), "-", " ") + "."
-	return strings.ToUpper(phrase[:1]) + phrase[1:]
-}
-
 func convenience[I, O any](api API, method, path string, handler func(context.Context, *I) (*O, error)) {
 	var o *O
 	Register(api, Operation{
 		OperationID: GenerateOperationID(method, path, o),
 		Summary:     GenerateSummary(method, path, o),
-		Description: GenerateDescription(method, path, o),
 		Method:      method,
 		Path:        path,
 	}, handler)

--- a/huma.go
+++ b/huma.go
@@ -1356,10 +1356,60 @@ var GenerateOperationID = func(method, path string, response any) string {
 	return casing.Kebab(action + "-" + reRemoveIDs.ReplaceAllString(path, "by-$1"))
 }
 
+// GenerateSummary generates an operation summary from the method, path,
+// and response type. The summary is used to describe an operation in the
+// OpenAPI spec. The generated summary is capitalized and includes the
+// method and path, with any path parameters replaced by their names.
+//
+// Examples:
+//
+//   - GET /things` -> `List things`
+//   - GET /things/{thing-id} -> `Get things by thing id`
+//   - PUT /things/{thingId}/favorite -> `Put things by thing id favorite`
+//
+// This function can be overridden to provide custom operation summaries.
+var GenerateSummary = func(method, path string, response any) string {
+	action := method
+	body, hasBody := deref(reflect.TypeOf(response)).FieldByName("Body")
+	if hasBody && method == http.MethodGet && deref(body.Type).Kind() == reflect.Slice {
+		// Special case: GET with a slice response body is a list operation.
+		action = "list"
+	}
+	path = reRemoveIDs.ReplaceAllString(path, "by-$1")
+	phrase := strings.ReplaceAll(casing.Kebab(strings.ToLower(action)+" "+path, strings.ToLower, casing.Initialism), "-", " ")
+	return strings.ToUpper(phrase[:1]) + phrase[1:]
+}
+
+// GenerateDescription generates an operation description from the method,
+// path, and response type. The description is used to describe an operation
+// in the OpenAPI spec. The generated description is capitalized and includes
+// the method and path, with any path parameters replaced by their names.
+//
+// Examples:
+//
+//   - GET /things` -> `Lists the things.`
+//   - GET /things/{thing-id} -> `Gets the things by thing id.`
+//   - PUT /things/{thingId}/favorite -> `Puts the things by thing id favorite.`
+//
+// This function can be overridden to provide custom operation descriptions.
+var GenerateDescription = func(method, path string, response any) string {
+	action := method
+	body, hasBody := deref(reflect.TypeOf(response)).FieldByName("Body")
+	if hasBody && method == http.MethodGet && deref(body.Type).Kind() == reflect.Slice {
+		// Special case: GET with a slice response body is a list operation.
+		action = "list"
+	}
+	path = reRemoveIDs.ReplaceAllString(path, "by-$1")
+	phrase := strings.ReplaceAll(casing.Kebab(strings.ToLower(action)+"s the "+path, strings.ToLower, casing.Initialism), "-", " ") + "."
+	return strings.ToUpper(phrase[:1]) + phrase[1:]
+}
+
 func convenience[I, O any](api API, method, path string, handler func(context.Context, *I) (*O, error)) {
 	var o *O
 	Register(api, Operation{
 		OperationID: GenerateOperationID(method, path, o),
+		Summary:     GenerateSummary(method, path, o),
+		Description: GenerateDescription(method, path, o),
 		Method:      method,
 		Path:        path,
 	}, handler)


### PR DESCRIPTION
This extends the convenience functions further by generating phrases and sentences for `Summary` and `Description` respectively.

I didn't want to add further dependencies like `cases` and whatnot since I'm not sure if you're fine with that or not. This looks a bit hacky but it does the trick for a basic implementation.

Tell me what you think :)