### PR TITLE
fix: move CLI to its own package, deprecate huma.NewCLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -103,7 +104,7 @@ type GreetingOutput struct {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))
@@ -159,7 +160,7 @@ Official Go package documentation can always be found at https://pkg.go.dev/gith
 - [APIs in Go with Huma 2.0](https://dgt.hashnode.dev/apis-in-go-with-huma-20)
 - [Reducing Go Dependencies: A case study of dependency reduction in Huma](https://dgt.hashnode.dev/reducing-go-dependencies)
 - [Golang News & Libs & Jobs shared on Twitter/X](https://twitter.com/golangch/status/1752175499701264532)
-- Featured in [Go Weekly #495](https://golangweekly.com/issues/495)
+- Featured in Go Weekly [#495](https://golangweekly.com/issues/495) & [#498](https://golangweekly.com/issues/498)
 - [Bump.sh Deploying Docs from Huma](https://docs.bump.sh/guides/bump-sh-tutorials/huma/)
 - Mentioned in [Composable HTTP Handlers Using Generics](https://www.willem.dev/articles/generic-http-handlers/)
 

--- a/cli.go
+++ b/cli.go
@@ -78,6 +78,6 @@ func WithOptions[Options any](f func(cmd *cobra.Command, args []string, options 
 //
 // Deprecated: use `humacli.New` instead.
 func NewCLI[O any](onParsed func(Hooks, *O)) CLI {
-	log.Print("huma.NewCLI is deprecated, use humacli.New instead")
+	log.Println("huma.NewCLI is deprecated, use humacli.New instead")
 	return humacli.New(onParsed)
 }

--- a/cli.go
+++ b/cli.go
@@ -1,3 +1,6 @@
+//go:build !humanewclipackage
+// +build !humanewclipackage
+
 package huma
 
 import (

--- a/cli.go
+++ b/cli.go
@@ -32,7 +32,7 @@ type Hooks = humacli.Hooks
 //
 // Deprecated: use `humacli.WithOptions` instead.
 func WithOptions[Options any](f func(cmd *cobra.Command, args []string, options *Options)) func(*cobra.Command, []string) {
-	log.Print("huma.WithOptions is deprecated, use humacli.WithOptions instead")
+	log.Println("huma.WithOptions is deprecated, use humacli.WithOptions instead")
 	return humacli.WithOptions(f)
 }
 

--- a/cli.go
+++ b/cli.go
@@ -1,18 +1,9 @@
 package huma
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"os/signal"
-	"path/filepath"
-	"reflect"
-	"strconv"
-	"strings"
-	"syscall"
-	"time"
+	"log"
 
-	"github.com/danielgtaylor/casing"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/spf13/cobra"
 )
 
@@ -20,38 +11,15 @@ import (
 // as a convenience for quickly building a service with configuration from
 // the environment and/or command-line options, all tied to a simple type-safe
 // Go struct.
-type CLI interface {
-	// Run the CLI. This will parse the command-line arguments and environment
-	// variables and then run the appropriate command. If no command is given,
-	// the default command will call the `OnStart` function to start a server.
-	Run()
-
-	// Root returns the root Cobra command. This can be used to add additional
-	// commands or flags. Customize it however you like.
-	Root() *cobra.Command
-}
+//
+// Deprecated: use `humacli.CLI` instead.
+type CLI = humacli.CLI
 
 // Hooks is an interface for setting up callbacks for the CLI. It is used to
 // start and stop the service.
-type Hooks interface {
-	// OnStart sets a function to call when the service should be started. This
-	// is called by the default command if no command is given. The callback
-	// should take whatever steps are necessary to start the server, such as
-	// `httpServer.ListenAndServer(...)`.
-	OnStart(func())
-
-	// OnStop sets a function to call when the service should be stopped. This
-	// is called by the default command if no command is given. The callback
-	// should take whatever steps are necessary to stop the server, such as
-	// `httpServer.Shutdown(...)`.
-	OnStop(func())
-}
-
-type contextKey string
-
-var optionsKey contextKey = "huma/cli/options"
-
-var durationType = reflect.TypeOf((*time.Duration)(nil)).Elem()
+//
+// Deprecated: use `humacli.Hooks` instead.
+type Hooks = humacli.Hooks
 
 // WithOptions is a helper for custom commands that need to access the options.
 //
@@ -61,156 +29,11 @@ var durationType = reflect.TypeOf((*time.Duration)(nil)).Elem()
 //			fmt.Println("Hello " + opts.Name)
 //		}),
 //	})
+//
+// Deprecated: use `humacli.WithOptions` instead.
 func WithOptions[Options any](f func(cmd *cobra.Command, args []string, options *Options)) func(*cobra.Command, []string) {
-	return func(cmd *cobra.Command, s []string) {
-		var options *Options = cmd.Context().Value(optionsKey).(*Options)
-		f(cmd, s, options)
-	}
-}
-
-type option struct {
-	name string
-	typ  reflect.Type
-	path []int
-}
-
-type cli[Options any] struct {
-	root     *cobra.Command
-	optInfo  []option
-	onParsed func(Hooks, *Options)
-	start    func()
-	stop     func()
-}
-
-func (c *cli[Options]) Run() {
-	var o Options
-
-	existing := c.root.PersistentPreRun
-	c.root.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-		// Load config from args/env/files
-		v := reflect.ValueOf(&o).Elem()
-		flags := c.root.PersistentFlags()
-		for _, opt := range c.optInfo {
-			f := v
-			for _, i := range opt.path {
-				f = f.Field(i)
-			}
-			switch opt.typ.Kind() {
-			case reflect.String:
-				s, _ := flags.GetString(opt.name)
-				f.Set(reflect.ValueOf(s))
-			case reflect.Int, reflect.Int64:
-				var i any
-				if opt.typ == durationType {
-					i, _ = flags.GetDuration(opt.name)
-				} else {
-					i, _ = flags.GetInt64(opt.name)
-				}
-				f.Set(reflect.ValueOf(i).Convert(opt.typ))
-			case reflect.Bool:
-				b, _ := flags.GetBool(opt.name)
-				f.Set(reflect.ValueOf(b))
-			}
-		}
-
-		// Run the parsed callback.
-		c.onParsed(c, &o)
-
-		if existing != nil {
-			existing(cmd, args)
-		}
-
-		// Set options in context, so custom commands can access it.
-		cmd.SetContext(context.WithValue(cmd.Context(), optionsKey, &o))
-	}
-
-	// Run the command!
-	c.root.Execute()
-}
-
-func (c *cli[O]) Root() *cobra.Command {
-	return c.root
-}
-
-func (c *cli[O]) OnStart(fn func()) {
-	c.start = fn
-}
-
-func (c *cli[O]) OnStop(fn func()) {
-	c.stop = fn
-}
-
-func (c *cli[O]) setupOptions(t reflect.Type, path []int) {
-	var err error
-	flags := c.root.PersistentFlags()
-	for i := 0; i < t.NumField(); i++ {
-		field := t.Field(i)
-
-		if !field.IsExported() {
-			// This isn't a public field, so we cannot use reflect.Value.Set with
-			// it. This is usually a struct field with a lowercase name.
-			fmt.Println("warning: ignoring unexported options field", field.Name)
-			continue
-		}
-
-		currentPath := append([]int{}, path...)
-		currentPath = append(currentPath, i)
-
-		if field.Anonymous {
-			// Embedded struct. This enables composition from e.g. company defaults.
-			c.setupOptions(deref(field.Type), currentPath)
-			continue
-		}
-
-		name := field.Tag.Get("name")
-		if name == "" {
-			name = casing.Kebab(field.Name)
-		}
-
-		envName := "SERVICE_" + casing.Snake(name, strings.ToUpper)
-		defaultValue := field.Tag.Get("default")
-		if v := os.Getenv(envName); v != "" {
-			// Env vars will override the default value, which is used to document
-			// what the value is if no options are passed.
-			defaultValue = v
-		}
-
-		c.optInfo = append(c.optInfo, option{name, field.Type, currentPath})
-		switch field.Type.Kind() {
-		case reflect.String:
-			flags.StringP(name, field.Tag.Get("short"), defaultValue, field.Tag.Get("doc"))
-		case reflect.Int, reflect.Int64:
-			var def int64
-			if defaultValue != "" {
-				if field.Type == durationType {
-					var t time.Duration
-					t, err = time.ParseDuration(defaultValue)
-					def = int64(t)
-				} else {
-					def, err = strconv.ParseInt(defaultValue, 10, 64)
-				}
-				if err != nil {
-					panic(err)
-				}
-			}
-			if field.Type == durationType {
-				flags.DurationP(name, field.Tag.Get("short"), time.Duration(def), field.Tag.Get("doc"))
-			} else {
-				flags.Int64P(name, field.Tag.Get("short"), def, field.Tag.Get("doc"))
-			}
-		case reflect.Bool:
-			var def bool
-			if defaultValue != "" {
-				def, err = strconv.ParseBool(defaultValue)
-				if err != nil {
-					panic(err)
-				}
-			}
-			flags.BoolP(name, field.Tag.Get("short"), def, field.Tag.Get("doc"))
-		default:
-			panic("Unsupported option type: " + field.Type.Kind().String())
-		}
-	}
+	log.Print("huma.WithOptions is deprecated, use humacli.WithOptions instead")
+	return humacli.WithOptions(f)
 }
 
 // NewCLI creates a new CLI. The `onParsed` callback is called after the command
@@ -252,40 +75,9 @@ func (c *cli[O]) setupOptions(t reflect.Type, path []int) {
 //
 //	// Run the thing!
 //	cli.Run()
+//
+// Deprecated: use `humacli.New` instead.
 func NewCLI[O any](onParsed func(Hooks, *O)) CLI {
-	c := &cli[O]{
-		root: &cobra.Command{
-			Use: filepath.Base(os.Args[0]),
-		},
-		onParsed: onParsed,
-	}
-
-	var o O
-	c.setupOptions(reflect.TypeOf(o), []int{})
-
-	c.root.Run = func(cmd *cobra.Command, args []string) {
-		done := make(chan struct{}, 1)
-		if c.start != nil {
-			go func() {
-				c.start()
-				done <- struct{}{}
-			}()
-		}
-
-		// Handle graceful shutdown.
-		quit := make(chan os.Signal, 1)
-		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-
-		select {
-		case <-done:
-			// Server is done, just exit.
-		case <-quit:
-			if c.stop != nil {
-				fmt.Println("Gracefully shutting down the server...")
-				c.stop()
-			}
-		}
-
-	}
-	return c
+	log.Print("huma.NewCLI is deprecated, use humacli.New instead")
+	return humacli.New(onParsed)
 }

--- a/docs/docs/features/cli.md
+++ b/docs/docs/features/cli.md
@@ -20,7 +20,7 @@ type Options struct {
 
 func main() {
 	// Then, create the CLI.
-	cli := huma.NewCLI(func(hooks huma.Hooks, opts *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, opts *Options) {
 		fmt.Printf("I was run with debug:%v host:%v port%v\n",
 			opts.Debug, opts.Host, opts.Port)
 	})
@@ -45,7 +45,7 @@ I was run with debug:true host:localhost port:8000
 To do useful work, you will want to register a handler for the default start command and optionally a way to gracefully shutdown the server:
 
 ```go title="main.go"
-cli := huma.NewCLI(func(hooks huma.Hooks, opts *Options) {
+cli := humacli.New(func(hooks humacli.Hooks, opts *Options) {
 	// Set up the router and API
 	// ...
 
@@ -162,7 +162,7 @@ If you want to access your custom options struct with custom commands, use the [
 You can set the app name and version to be used in the help output and version command. By default, the app name is the name of the binary and the version is unset. You can set them using the root [`cobra.Command`](https://pkg.go.dev/github.com/spf13/cobra#Command)'s `Use` and `Version` fields:
 
 ```go title="main.go"
-// cli := huma.NewCLI(...)
+// cli := humacli.New(...)
 
 cmd := cli.Root()
 cmd.Use = "appname"
@@ -194,10 +194,10 @@ appname version 1.0.1
 -   How-To
     -   [Graceful Shutdown](../how-to/graceful-shutdown.md) on service stop
 -   Reference
-    -   [`huma.CLI`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#CLI) the CLI instance
-    -   [`huma.NewCLI`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#NewCLI) creates a new CLI instance
-    -   [`huma.Hooks`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Hooks) for startup / shutdown
-    -   [`huma.WithOptions`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#WithOptions) wraps a command with options parsing
+    -   [`humacli.CLI`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2/humacli#CLI) the CLI instance
+    -   [`humacli.New`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2/humacli#New) creates a new CLI instance
+    -   [`humacli.Hooks`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2/humacli#Hooks) for startup / shutdown
+    -   [`humacli.WithOptions`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2/humacli#WithOptions) wraps a command with options parsing
     -   [`huma.API`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#API) the API instance
 -   External Links
     -   [Cobra](https://cobra.dev/) CLI library

--- a/docs/docs/how-to/custom-validation.md
+++ b/docs/docs/how-to/custom-validation.md
@@ -67,6 +67,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -100,7 +101,7 @@ var _ huma.ResolverWithPath = (*IntNot3)(nil)
 func main() {
 	// Create the CLI, passing a function to be called with your custom options
 	// after they have been parsed.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		router := chi.NewMux()
 
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/docs/docs/how-to/graceful-shutdown.md
+++ b/docs/docs/how-to/graceful-shutdown.md
@@ -23,6 +23,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -45,7 +46,7 @@ type GreetingOutput struct {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/docs/docs/how-to/image-response.md
+++ b/docs/docs/how-to/image-response.md
@@ -20,6 +20,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -36,7 +37,7 @@ type ImageOutput struct {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/docs/docs/how-to/migrate.md
+++ b/docs/docs/how-to/migrate.md
@@ -11,6 +11,6 @@ description: Migrate your code from Huma v1 to Huma v2 in a few simple steps.
 1. Rewrite handlers to be like `func(context.Context, *Input) (*Output, error)`
     1. Return errors instead of `ctx.WriteError(...)`
     1. Return instances instead of `ctx.WriteModel(...)`
-1. Define options via a struct and use `huma.NewCLI` to wrap the service
+1. Define options via a struct and use `humacli.New` to wrap the service
 
 Note that GraphQL support from Huma v1 has been removed. Take a look at alternative tools like [https://www.npmjs.com/package/openapi-to-graphql](https://www.npmjs.com/package/openapi-to-graphql) which will automatically generate a GraphQL endpoint from Huma's generated OpenAPI spec.

--- a/docs/docs/tutorial/sending-data.md
+++ b/docs/docs/tutorial/sending-data.md
@@ -32,6 +32,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -58,7 +59,7 @@ type ReviewInput struct {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/docs/docs/tutorial/service-configuration.md
+++ b/docs/docs/tutorial/service-configuration.md
@@ -20,6 +20,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -37,7 +38,7 @@ type GreetingOutput struct {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/docs/docs/tutorial/writing-tests.md
+++ b/docs/docs/tutorial/writing-tests.md
@@ -20,6 +20,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -77,7 +78,7 @@ func addRoutes(api huma.API) {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/docs/docs/why/what-about-design-first.md
+++ b/docs/docs/why/what-about-design-first.md
@@ -51,6 +51,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 	"github.com/spf13/cobra"
 )
@@ -81,7 +82,7 @@ type PetID struct {
 func main() {
 	var api huma.API
 
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *struct{}) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *struct{}) {
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("Pet Store", "1.0.0"))
 

--- a/examples/cookies/main.go
+++ b/examples/cookies/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -32,7 +33,7 @@ type GreetingOutput struct {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/examples/greet/main.go
+++ b/examples/greet/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -29,7 +30,7 @@ type GreetingOutput struct {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/examples/omit/main.go
+++ b/examples/omit/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -68,7 +69,7 @@ type MyResponse struct {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/examples/oneof-response/main.go
+++ b/examples/oneof-response/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -47,7 +48,7 @@ type GreetingBodyOld struct {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/examples/param-reuse/main.go
+++ b/examples/param-reuse/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -34,7 +35,7 @@ type MyResponse struct {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/examples/resolver/main.go
+++ b/examples/resolver/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -48,7 +49,7 @@ var _ huma.ResolverWithPath = (*IntNot3)(nil)
 func main() {
 	// Create the CLI, passing a function to be called with your custom options
 	// after they have been parsed.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		router := chi.NewMux()
 
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/examples/spec-cmd/main.go
+++ b/examples/spec-cmd/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi/v5"
 	"github.com/spf13/cobra"
 )
@@ -41,7 +42,7 @@ func main() {
 	var api huma.API
 
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api = humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/danielgtaylor/huma/v2/sse"
 	"github.com/go-chi/chi/v5"
 )
@@ -121,7 +122,7 @@ func (p *Producer) emit(data any) {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, options *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		// Create a new router & API
 		router := chi.NewMux()
 		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))

--- a/examples/v1-middleware/main.go
+++ b/examples/v1-middleware/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/danielgtaylor/huma/middleware"
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
 	"github.com/go-chi/chi"
 )
 
@@ -32,7 +33,7 @@ type GreetingOutput struct {
 
 func main() {
 	// Create a CLI app which takes a port option.
-	cli := huma.NewCLI(func(hooks huma.Hooks, opts *Options) {
+	cli := humacli.New(func(hooks humacli.Hooks, opts *Options) {
 		// Create a Chi v4.x.x router instance.
 		router := chi.NewMux()
 

--- a/humacli/humacli.go
+++ b/humacli/humacli.go
@@ -186,7 +186,7 @@ func (c *cli[O]) setupOptions(t reflect.Type, path []int) {
 
 		envName := "SERVICE_" + casing.Snake(name, strings.ToUpper)
 		defaultValue := field.Tag.Get("default")
-		if v := os.Getenv(envName); v != "" {
+		if v, ok := os.LookupEnv(envName); ok {
 			// Env vars will override the default value, which is used to document
 			// what the value is if no options are passed.
 			defaultValue = v

--- a/humacli/humacli.go
+++ b/humacli/humacli.go
@@ -1,0 +1,308 @@
+package humacli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/danielgtaylor/casing"
+	"github.com/spf13/cobra"
+)
+
+func deref(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t
+}
+
+// CLI is an optional command-line interface for a Huma service. It is provided
+// as a convenience for quickly building a service with configuration from
+// the environment and/or command-line options, all tied to a simple type-safe
+// Go struct.
+type CLI interface {
+	// Run the CLI. This will parse the command-line arguments and environment
+	// variables and then run the appropriate command. If no command is given,
+	// the default command will call the `OnStart` function to start a server.
+	Run()
+
+	// Root returns the root Cobra command. This can be used to add additional
+	// commands or flags. Customize it however you like.
+	Root() *cobra.Command
+}
+
+// Hooks is an interface for setting up callbacks for the CLI. It is used to
+// start and stop the service.
+type Hooks interface {
+	// OnStart sets a function to call when the service should be started. This
+	// is called by the default command if no command is given. The callback
+	// should take whatever steps are necessary to start the server, such as
+	// `httpServer.ListenAndServer(...)`.
+	OnStart(func())
+
+	// OnStop sets a function to call when the service should be stopped. This
+	// is called by the default command if no command is given. The callback
+	// should take whatever steps are necessary to stop the server, such as
+	// `httpServer.Shutdown(...)`.
+	OnStop(func())
+}
+
+type contextKey string
+
+var optionsKey contextKey = "huma/cli/options"
+
+var durationType = reflect.TypeOf((*time.Duration)(nil)).Elem()
+
+// WithOptions is a helper for custom commands that need to access the options.
+//
+//	cli.Root().AddCommand(&cobra.Command{
+//		Use: "my-custom-command",
+//		Run: huma.WithOptions(func(cmd *cobra.Command, args []string, opts *Options) {
+//			fmt.Println("Hello " + opts.Name)
+//		}),
+//	})
+func WithOptions[Options any](f func(cmd *cobra.Command, args []string, options *Options)) func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, s []string) {
+		var options *Options = cmd.Context().Value(optionsKey).(*Options)
+		f(cmd, s, options)
+	}
+}
+
+type option struct {
+	name string
+	typ  reflect.Type
+	path []int
+}
+
+type cli[Options any] struct {
+	root     *cobra.Command
+	optInfo  []option
+	onParsed func(Hooks, *Options)
+	start    func()
+	stop     func()
+}
+
+func (c *cli[Options]) Run() {
+	var o Options
+
+	existing := c.root.PersistentPreRun
+	c.root.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		// Load config from args/env/files
+		v := reflect.ValueOf(&o).Elem()
+		flags := c.root.PersistentFlags()
+		for _, opt := range c.optInfo {
+			f := v
+			for _, i := range opt.path {
+				f = f.Field(i)
+			}
+			var fv reflect.Value
+			switch deref(opt.typ).Kind() {
+			case reflect.String:
+				s, _ := flags.GetString(opt.name)
+				fv = reflect.ValueOf(s)
+			case reflect.Int, reflect.Int64:
+				var i any
+				if opt.typ == durationType {
+					i, _ = flags.GetDuration(opt.name)
+				} else {
+					i, _ = flags.GetInt64(opt.name)
+				}
+				fv = reflect.ValueOf(i).Convert(deref(opt.typ))
+			case reflect.Bool:
+				b, _ := flags.GetBool(opt.name)
+				fv = reflect.ValueOf(b)
+			}
+
+			if opt.typ.Kind() == reflect.Ptr {
+				ptr := reflect.New(fv.Type())
+				ptr.Elem().Set(fv)
+				fv = ptr
+			}
+
+			f.Set(fv)
+		}
+
+		// Run the parsed callback.
+		c.onParsed(c, &o)
+
+		if existing != nil {
+			existing(cmd, args)
+		}
+
+		// Set options in context, so custom commands can access it.
+		cmd.SetContext(context.WithValue(cmd.Context(), optionsKey, &o))
+	}
+
+	// Run the command!
+	c.root.Execute()
+}
+
+func (c *cli[O]) Root() *cobra.Command {
+	return c.root
+}
+
+func (c *cli[O]) OnStart(fn func()) {
+	c.start = fn
+}
+
+func (c *cli[O]) OnStop(fn func()) {
+	c.stop = fn
+}
+
+func (c *cli[O]) setupOptions(t reflect.Type, path []int) {
+	var err error
+	flags := c.root.PersistentFlags()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		if !field.IsExported() {
+			// This isn't a public field, so we cannot use reflect.Value.Set with
+			// it. This is usually a struct field with a lowercase name.
+			fmt.Println("warning: ignoring unexported options field", field.Name)
+			continue
+		}
+
+		currentPath := append([]int{}, path...)
+		currentPath = append(currentPath, i)
+
+		fieldType := deref(field.Type)
+		if field.Anonymous {
+			// Embedded struct. This enables composition from e.g. company defaults.
+			c.setupOptions(fieldType, currentPath)
+			continue
+		}
+
+		name := field.Tag.Get("name")
+		if name == "" {
+			name = casing.Kebab(field.Name)
+		}
+
+		envName := "SERVICE_" + casing.Snake(name, strings.ToUpper)
+		defaultValue := field.Tag.Get("default")
+		if v := os.Getenv(envName); v != "" {
+			// Env vars will override the default value, which is used to document
+			// what the value is if no options are passed.
+			defaultValue = v
+		}
+
+		c.optInfo = append(c.optInfo, option{name, field.Type, currentPath})
+		switch fieldType.Kind() {
+		case reflect.String:
+			flags.StringP(name, field.Tag.Get("short"), defaultValue, field.Tag.Get("doc"))
+		case reflect.Int, reflect.Int64:
+			var def int64
+			if defaultValue != "" {
+				if fieldType == durationType {
+					var t time.Duration
+					t, err = time.ParseDuration(defaultValue)
+					def = int64(t)
+				} else {
+					def, err = strconv.ParseInt(defaultValue, 10, 64)
+				}
+				if err != nil {
+					panic(err)
+				}
+			}
+			if fieldType == durationType {
+				flags.DurationP(name, field.Tag.Get("short"), time.Duration(def), field.Tag.Get("doc"))
+			} else {
+				flags.Int64P(name, field.Tag.Get("short"), def, field.Tag.Get("doc"))
+			}
+		case reflect.Bool:
+			var def bool
+			if defaultValue != "" {
+				def, err = strconv.ParseBool(defaultValue)
+				if err != nil {
+					panic(err)
+				}
+			}
+			flags.BoolP(name, field.Tag.Get("short"), def, field.Tag.Get("doc"))
+		default:
+			panic("Unsupported option type: " + field.Type.Kind().String())
+		}
+	}
+}
+
+// New creates a new CLI. The `onParsed` callback is called after the command
+// options have been parsed and the options struct has been populated. You
+// should set up a `hooks.OnStart` callback to start the server with your
+// chosen router.
+//
+//	// First, define your input options.
+//	type Options struct {
+//		Debug bool   `doc:"Enable debug logging"`
+//		Host  string `doc:"Hostname to listen on."`
+//		Port  int    `doc:"Port to listen on." short:"p" default:"8888"`
+//	}
+//
+//	// Then, create the CLI.
+//	cli := humacli.CLI(func(hooks humacli.Hooks, opts *Options) {
+//		fmt.Printf("Options are debug:%v host:%v port%v\n",
+//			opts.Debug, opts.Host, opts.Port)
+//
+//		// Set up the router & API
+//		router := chi.NewRouter()
+//		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))
+//		srv := &http.Server{
+//			Addr: fmt.Sprintf("%s:%d", opts.Host, opts.Port),
+//			Handler: router,
+//			// TODO: Set up timeouts!
+//		}
+//
+//		hooks.OnStart(func() {
+//			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+//				log.Fatalf("listen: %s\n", err)
+//			}
+//		})
+//
+//		hooks.OnStop(func() {
+//			srv.Shutdown(context.Background())
+//		})
+//	})
+//
+//	// Run the thing!
+//	cli.Run()
+func New[O any](onParsed func(Hooks, *O)) CLI {
+	c := &cli[O]{
+		root: &cobra.Command{
+			Use: filepath.Base(os.Args[0]),
+		},
+		onParsed: onParsed,
+	}
+
+	var o O
+	c.setupOptions(reflect.TypeOf(o), []int{})
+
+	c.root.Run = func(cmd *cobra.Command, args []string) {
+		done := make(chan struct{}, 1)
+		if c.start != nil {
+			go func() {
+				c.start()
+				done <- struct{}{}
+			}()
+		}
+
+		// Handle graceful shutdown.
+		quit := make(chan os.Signal, 1)
+		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+		select {
+		case <-done:
+			// Server is done, just exit.
+		case <-quit:
+			if c.stop != nil {
+				fmt.Println("Gracefully shutting down the server...")
+				c.stop()
+			}
+		}
+
+	}
+	return c
+}

--- a/humacli/humacli_test.go
+++ b/humacli/humacli_test.go
@@ -1,0 +1,253 @@
+package humacli_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/humacli"
+	"github.com/go-chi/chi/v5"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func ExampleCLI() {
+	// First, define your input options.
+	type Options struct {
+		Debug bool   `doc:"Enable debug logging"`
+		Host  string `doc:"Hostname to listen on."`
+		Port  int    `doc:"Port to listen on." short:"p" default:"8888"`
+	}
+
+	// Then, create the CLI.
+	cli := humacli.New(func(hooks humacli.Hooks, opts *Options) {
+		fmt.Printf("Options are debug:%v host:%v port%v\n",
+			opts.Debug, opts.Host, opts.Port)
+
+		// Set up the router & API
+		router := chi.NewRouter()
+		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))
+
+		huma.Register(api, huma.Operation{
+			OperationID: "hello",
+			Method:      http.MethodGet,
+			Path:        "/hello",
+		}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+			// TODO: implement handler
+			return nil, nil
+		})
+
+		srv := &http.Server{
+			Addr:    fmt.Sprintf("%s:%d", opts.Host, opts.Port),
+			Handler: router,
+			// TODO: Set up timeouts!
+		}
+
+		hooks.OnStart(func() {
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Fatalf("listen: %s\n", err)
+			}
+		})
+
+		hooks.OnStop(func() {
+			srv.Shutdown(context.Background())
+		})
+	})
+
+	// Run the thing!
+	cli.Run()
+}
+
+func TestCLIPlain(t *testing.T) {
+	type Options struct {
+		Debug bool
+		Host  string
+		Port  int
+
+		// ignore private fields, should not crash.
+		ingore bool
+	}
+
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
+		assert.True(t, options.Debug)
+		assert.Equal(t, "localhost", options.Host)
+		assert.Equal(t, 8001, options.Port)
+		assert.False(t, options.ingore)
+		hooks.OnStart(func() {
+			// Do nothing
+		})
+	})
+
+	cli.Root().SetArgs([]string{"--debug", "--host", "localhost", "--port", "8001"})
+	cli.Run()
+}
+
+func TestCLIEnv(t *testing.T) {
+	type Options struct {
+		Debug bool
+		Host  string
+		Port  int
+	}
+
+	os.Setenv("SERVICE_DEBUG", "true")
+	os.Setenv("SERVICE_HOST", "localhost")
+	os.Setenv("SERVICE_PORT", "8001")
+	defer func() {
+		os.Unsetenv("SERVICE_DEBUG")
+		os.Unsetenv("SERVICE_HOST")
+		os.Unsetenv("SERVICE_PORT")
+	}()
+
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
+		assert.True(t, options.Debug)
+		assert.Equal(t, "localhost", options.Host)
+		assert.Equal(t, 8001, options.Port)
+		hooks.OnStart(func() {
+			// Do nothing
+		})
+	})
+
+	cli.Root().SetArgs([]string{})
+	cli.Run()
+}
+
+func TestCLIAdvanced(t *testing.T) {
+	type DebugOption struct {
+		Debug bool `doc:"Enable debug mode." default:"false"`
+	}
+
+	type Options struct {
+		// Example of option composition via embedded type.
+		DebugOption
+		Host    string        `doc:"Hostname to listen on."`
+		Port    *int          `doc:"Port to listen on." short:"p" default:"8000"`
+		Timeout time.Duration `doc:"Request timeout." default:"5s"`
+	}
+
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
+		assert.True(t, options.Debug)
+		assert.Equal(t, "localhost", options.Host)
+		assert.Equal(t, 8001, *options.Port)
+		assert.Equal(t, 10*time.Second, options.Timeout)
+		hooks.OnStart(func() {
+			// Do nothing
+		})
+	})
+
+	// A custom pre-run isn't overwritten and should still work!
+	customPreRun := false
+	cli.Root().PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		customPreRun = true
+	}
+
+	cli.Root().SetArgs([]string{"--debug", "--host", "localhost", "--port", "8001", "--timeout", "10s"})
+	cli.Run()
+	assert.True(t, customPreRun)
+}
+
+func TestCLIHelp(t *testing.T) {
+	type Options struct {
+		Debug bool
+		Host  string
+		Port  int
+	}
+
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
+		// Do nothing
+	})
+
+	cli.Root().Use = "myapp"
+	cli.Root().SetArgs([]string{"--help"})
+	buf := bytes.NewBuffer(nil)
+	cli.Root().SetOut(buf)
+	cli.Root().SetErr(buf)
+	cli.Run()
+
+	assert.Equal(t, "Usage:\n  myapp [flags]\n\nFlags:\n      --debug         \n  -h, --help          help for myapp\n      --host string   \n      --port int\n", buf.String())
+}
+
+func TestCLICommandWithOptions(t *testing.T) {
+	type Options struct {
+		Debug bool
+	}
+
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
+		// Do nothing
+	})
+
+	wasSet := false
+	cli.Root().AddCommand(&cobra.Command{
+		Use: "custom",
+		Run: humacli.WithOptions(func(cmd *cobra.Command, args []string, options *Options) {
+			if options.Debug {
+				wasSet = true
+			}
+		}),
+	})
+
+	cli.Root().SetArgs([]string{"custom", "--debug"})
+	cli.Run()
+
+	assert.True(t, wasSet)
+}
+
+func TestCLIShutdown(t *testing.T) {
+	type Options struct{}
+
+	started := false
+	stopping := make(chan bool, 1)
+	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
+		hooks.OnStart(func() {
+			started = true
+			<-stopping
+		})
+		hooks.OnStop(func() {
+			stopping <- true
+		})
+	})
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+	}()
+
+	cli.Root().SetArgs([]string{})
+	cli.Run()
+	assert.True(t, started)
+}
+
+func TestCLIBadType(t *testing.T) {
+	type Options struct {
+		Debug []struct{}
+	}
+
+	assert.Panics(t, func() {
+		humacli.New(func(hooks humacli.Hooks, options *Options) {})
+	})
+}
+
+func TestCLIBadDefaults(t *testing.T) {
+	type OptionsBool struct {
+		Debug bool `default:"notabool"`
+	}
+
+	type OptionsInt struct {
+		Debug int `default:"notanint"`
+	}
+
+	assert.Panics(t, func() {
+		humacli.New(func(hooks humacli.Hooks, options *OptionsBool) {})
+	})
+
+	assert.Panics(t, func() {
+		humacli.New(func(hooks humacli.Hooks, options *OptionsInt) {})
+	})
+}


### PR DESCRIPTION
This PR moves the built-in optional CLI functionality into its own `humacli` package and updates all examples & docs. The existing CLI functionality stays but is marked as deprecated to give people time to move to the new package. Switching is fairly easy:

- `huma.NewCLI` → `humacli.New`
- `huma.CLI` → `humacli.CLI`
- `huma.Hooks` → `humacli.Hooks`
- `huma.WithOptions` → `humacli.WithOptions`

The plan is to **remove the old functionality a few releases from now**. This will be a small breaking change to facilitate the removal of some dependencies that are not used by everyone, but will be treated as a bug fix.

Related to #290. This doesn't fix it yet, but sets us on the track to doing so soon.