### PR TITLE
fix: length validation for utf8 strings

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 	"unsafe"
 )
 
@@ -412,12 +413,12 @@ func Validate(r Registry, s *Schema, path *PathBuffer, mode ValidateMode, v any,
 		}
 
 		if s.MinLength != nil {
-			if len(str) < *s.MinLength {
+			if utf8.RuneCountInString(str) < *s.MinLength {
 				res.Addf(path, str, s.msgMinLength)
 			}
 		}
 		if s.MaxLength != nil {
-			if len(str) > *s.MaxLength {
+			if utf8.RuneCountInString(str) > *s.MaxLength {
 				res.Add(path, str, s.msgMaxLength)
 			}
 		}

--- a/validate_test.go
+++ b/validate_test.go
@@ -235,6 +235,13 @@ var validateTests = []struct {
 		input: map[string]any{"value": "a"},
 	},
 	{
+		name: "non ascii max length success",
+		typ: reflect.TypeOf(struct {
+			Value string `json:"value" maxLength:"2"`
+		}{}),
+		input: map[string]any{"value": "аб"},
+	},
+	{
 		name: "max length fail",
 		typ: reflect.TypeOf(struct {
 			Value string `json:"value" maxLength:"1"`


### PR DESCRIPTION
Hi! Current string length validation made with go's standard `len` function works incorrectly with non ascii characters. So if there any non-english symbols `"maxLength"` validator will fail when it shouldn't.

In this PR I'v replaced `len` with `utf8.RuneCountInString`. Instead of number of bytes it will calculate number of runes. 

It will resolve most issues. But it don't take into account [unicode text segmentation](https://unicode.org/reports/tr29/). So if there will be symbols such as emojis, that consists of more than one unicode character it still will calculate length incorrectly. More info could be found [here](https://stackoverflow.com/a/12668840). 

So may be the next step is to add usage of https://github.com/rivo/uniseg. But considering it is a big change and new dependancy may be it is not worth it.