### PR TITLE
feat(config): allow to specify an optional API prefix to play well with chi router mounting

### DIFF
--- a/api.go
+++ b/api.go
@@ -229,6 +229,11 @@ type API interface {
 
 	// Middlewares returns a slice of middleware handler functions.
 	Middlewares() Middlewares
+
+	// Prefix return the potential huma router prefix. The prefix shall be managed
+	// by the router (chi.Mx.Mount(prefix, mx)).
+	// Prefix interface method is only used for OpenAPI documentation generation.
+	Prefix() string
 }
 
 // Format represents a request / response format. It is used to marshal and
@@ -248,7 +253,10 @@ type api struct {
 	formatKeys   []string
 	transformers []Transformer
 	middlewares  Middlewares
+	prefix       string
 }
+
+func (a *api) Prefix() string { return a.prefix }
 
 func (a *api) Adapter() Adapter {
 	return a.adapter
@@ -339,6 +347,7 @@ func NewAPI(config Config, a Adapter) API {
 		adapter:      a,
 		formats:      map[string]Format{},
 		transformers: config.Transformers,
+		prefix:       config.APIPrefix,
 	}
 
 	if config.OpenAPI == nil {

--- a/huma.go
+++ b/huma.go
@@ -754,7 +754,9 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 	}
 
 	if !op.Hidden {
-		oapi.AddOperation(&op)
+		_op := op
+		_op.Path = api.Prefix() + op.Path
+		oapi.AddOperation(&_op)
 	}
 
 	a := api.Adapter()


### PR DESCRIPTION
If the chi router attached to huma is mounted into another router (let say - to delimit the `/api` namespace), then the OpenAPI browser rendering is broken because of failure to fetch the served YAML documentation.

The MR add an extra `APIPrefix` to the huma.Config struct. The value is then prefixed to the documentation path in the template rendering.
  

```golang
rootMx, apiMx := chi.NewMux(), chi.NewMux()

prefix := "/api" 
rootMx.Use(RedirectToSwagger)
rootMx.Mount(prefix, apiMx)

cfg := huma.DefaultConfig("My API", "1.0.0")
cfg.APIPrefix = prefix

api := humachi.New(apiMx, cfg)

huma.Register(api, huma.Operation{
		OperationID: "get-greeting",
		Method:      http.MethodGet,
		Path:        "/greeting/{name}",
		Summary:     "Get a greeting",
		Description: "Get a greeting for a person by name.",
		Tags:        []string{"Greetings", "Utils"},
	}, rs.getGreeting)


return &http.Server{handler: rootMx}
```
```console
🗀 src/common/api/gopi/src  master-gopi-poc 🏷️  notag ※ 993237a +181 -471 *?!✘  via 🐹 v1.22 
11:58:14 ❯ http :4242/api/greeting/q                                                   🌿 zsh 🐏 (19%|6%)
HTTP/1.1 200 OK
Content-Encoding: gzip
Content-Length: 110
Content-Type: application/json
Date: Wed, 13 Mar 2024 10:58:20 GMT
Link: </schemas/GreetingOutputBody.json>; rel="describedBy"
Vary: Accept-Encoding

{
    "$schema": "http://localhost:4242/schemas/GreetingOutputBody.json",
    "message": "Hello, q!"
}
```
