### PR TITLE
feat: breaks infinite cycle when looking for fields in recursive structures.

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -370,11 +370,11 @@ func (r *findResult[T]) EveryPB(pb *PathBuffer, v reflect.Value, f func(reflect.
 
 func findInType[T comparable](t reflect.Type, onType func(reflect.Type, []int) T, onField func(reflect.StructField, []int) T, recurseFields bool, ignore ...string) *findResult[T] {
 	result := &findResult[T]{}
-	_findInType(t, []int{}, result, onType, onField, recurseFields, ignore...)
+	_findInType(t, []int{}, result, onType, onField, recurseFields, make(map[reflect.Type]bool), ignore...)
 	return result
 }
 
-func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T], onType func(reflect.Type, []int) T, onField func(reflect.StructField, []int) T, recurseFields bool, ignore ...string) {
+func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T], onType func(reflect.Type, []int) T, onField func(reflect.StructField, []int) T, recurseFields bool, visited map[reflect.Type]bool, ignore ...string) {
 	t = deref(t)
 	zero := reflect.Zero(reflect.TypeOf((*T)(nil)).Elem()).Interface()
 
@@ -392,6 +392,10 @@ func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T]
 
 	switch t.Kind() {
 	case reflect.Struct:
+		if visited[t] {
+			return
+		}
+		visited[t] = true
 		for i := 0; i < t.NumField(); i++ {
 			f := t.Field(i)
 			if !f.IsExported() {
@@ -414,13 +418,13 @@ func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T]
 				// Always process embedded structs and named fields which are not
 				// structs. If `recurseFields` is true then we also process named
 				// struct fields recursively.
-				_findInType(f.Type, fi, result, onType, onField, recurseFields, ignore...)
+				_findInType(f.Type, fi, result, onType, onField, recurseFields, visited, ignore...)
 			}
 		}
 	case reflect.Slice:
-		_findInType(t.Elem(), path, result, onType, onField, recurseFields, ignore...)
+		_findInType(t.Elem(), path, result, onType, onField, recurseFields, visited, ignore...)
 	case reflect.Map:
-		_findInType(t.Elem(), path, result, onType, onField, recurseFields, ignore...)
+		_findInType(t.Elem(), path, result, onType, onField, recurseFields, visited, ignore...)
 	}
 }
 

--- a/huma.go
+++ b/huma.go
@@ -370,11 +370,11 @@ func (r *findResult[T]) EveryPB(pb *PathBuffer, v reflect.Value, f func(reflect.
 
 func findInType[T comparable](t reflect.Type, onType func(reflect.Type, []int) T, onField func(reflect.StructField, []int) T, recurseFields bool, ignore ...string) *findResult[T] {
 	result := &findResult[T]{}
-	_findInType(t, []int{}, result, onType, onField, recurseFields, make(map[reflect.Type]bool), ignore...)
+	_findInType(t, []int{}, result, onType, onField, recurseFields, make(map[reflect.Type]struct{}), ignore...)
 	return result
 }
 
-func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T], onType func(reflect.Type, []int) T, onField func(reflect.StructField, []int) T, recurseFields bool, visited map[reflect.Type]bool, ignore ...string) {
+func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T], onType func(reflect.Type, []int) T, onField func(reflect.StructField, []int) T, recurseFields bool, visited map[reflect.Type]struct{}, ignore ...string) {
 	t = deref(t)
 	zero := reflect.Zero(reflect.TypeOf((*T)(nil)).Elem()).Interface()
 
@@ -392,10 +392,10 @@ func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T]
 
 	switch t.Kind() {
 	case reflect.Struct:
-		if visited[t] {
+		if _, ok := visited[t]; ok {
 			return
 		}
-		visited[t] = true
+		visited[t] = struct{}{}
 		for i := 0; i < t.NumField(); i++ {
 			f := t.Field(i)
 			if !f.IsExported() {


### PR DESCRIPTION
My machine has crashed when I've tried to use Huma for the new micro-service that I'm developing.
```
// Node is a custom type for testing recursive definition for huma.Register
type Node struct {
	Name  string          `json:"name"`
	Nodes []Node          `json:"nodes,omitempty"`
	Left  *Node           `json:"left,omitempty"`
	Named map[string]Node `json:"named,omitempty"`
}
```
This pr breaks the cycle in findInType by adding `visited map[reflect.Type]bool` as a parameter.
I haven't spent much time figuring out semantics and usage of findInType, so it might be a wrong solution. However I would like to hear your thoughts on the issue.