### PR TITLE
fix: skip param required check if SkipValidateParams is set

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -810,7 +810,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 				value = p.Default
 			}
 
-			if p.Required && value == "" {
+			if !op.SkipValidateParams && p.Required && value == "" {
 				// Path params are always required.
 				res.Add(pb, "", "required "+p.Loc+" parameter is missing")
 				return


### PR DESCRIPTION
Fixes a small miss where `op.SkipValidateParams` is set and we skipped most validation but not the required check.

Fixes #317.