### PR TITLE
 feat(validation): flexible validation messages for pattern tag

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -142,6 +142,7 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 		{"minLength", s.MinLength, omitEmpty},
 		{"maxLength", s.MaxLength, omitEmpty},
 		{"pattern", s.Pattern, omitEmpty},
+		{"patternDescription", s.PatternDescription, omitEmpty},
 		{"minItems", s.MinItems, omitEmpty},
 		{"maxItems", s.MaxItems, omitEmpty},
 		{"uniqueItems", s.UniqueItems, omitEmpty},

--- a/schema.go
+++ b/schema.go
@@ -77,6 +77,7 @@ type Schema struct {
 	MinLength            *int                `yaml:"minLength,omitempty"`
 	MaxLength            *int                `yaml:"maxLength,omitempty"`
 	Pattern              string              `yaml:"pattern,omitempty"`
+	PatternDescription   string              `yaml:"patternDescription,omitempty"`
 	MinItems             *int                `yaml:"minItems,omitempty"`
 	MaxItems             *int                `yaml:"maxItems,omitempty"`
 	UniqueItems          bool                `yaml:"uniqueItems,omitempty"`
@@ -187,7 +188,11 @@ func (s *Schema) PrecomputeMessages() {
 	}
 	if s.Pattern != "" {
 		s.patternRe = regexp.MustCompile(s.Pattern)
-		s.msgPattern = "expected string to match pattern " + s.Pattern
+		if s.PatternDescription != "" {
+			s.msgPattern = "expected string to be " + s.PatternDescription
+		} else {
+			s.msgPattern = "expected string to match pattern " + s.Pattern
+		}
 	}
 	if s.MinItems != nil {
 		s.msgMinItems = fmt.Sprintf("expected array length >= %d", *s.MinItems)
@@ -498,6 +503,7 @@ func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Sch
 	fs.MinLength = intTag(f, "minLength")
 	fs.MaxLength = intTag(f, "maxLength")
 	fs.Pattern = f.Tag.Get("pattern")
+	fs.PatternDescription = f.Tag.Get("patternDescription")
 	fs.MinItems = intTag(f, "minItems")
 	fs.MaxItems = intTag(f, "maxItems")
 	fs.UniqueItems = boolTag(f, "uniqueItems")

--- a/validate_test.go
+++ b/validate_test.go
@@ -266,6 +266,14 @@ var validateTests = []struct {
 		errs:  []string{"expected string to match pattern ^[a-z]+$"},
 	},
 	{
+		name: "pattern custom message fail",
+		typ: reflect.TypeOf(struct {
+			Value string `json:"value" pattern:"^[a-z]+$" patternDescription:"alphabetical"`
+		}{}),
+		input: map[string]any{"value": "b@2"},
+		errs:  []string{"expected string to be alphabetical"},
+	},
+	{
 		name: "pattern invalid",
 		typ: reflect.TypeOf(struct {
 			Value string `json:"value" pattern:"^[a-"`


### PR DESCRIPTION
Adds a new `patternDescription` struct tag to allow for human-readable error messages when using the pattern tag. 

Error messages are formatted like `expected string to be {description}` - this allows the user to use their own articles while still being consistent with the other validators

