### PR TITLE
feat: hidden body field support

### DIFF
--- a/docs/docs/features/request-validation.md
+++ b/docs/docs/features/request-validation.md
@@ -15,38 +15,56 @@ type Person struct {
 }
 ```
 
-The standard `json` tag is supported and can be used to rename a field and mark fields as optional using `omitempty`. The following additional tags are supported on model fields:
+The standard `json` tag is supported and can be used to rename a field and mark fields as optional using `omitempty`. Any field tagged with `json:"-"` will be ignored in the schema.
 
-| Tag                 | Description                               | Example                       |
-|---------------------|-------------------------------------------|-------------------------------|
-| `doc`               | Describe the field                        | `doc:"Who to greet"`          |
-| `format`            | Format hint for the field                 | `format:"date-time"`          |
-| `enum`              | A comma-separated list of possible values | `enum:"one,two,three"`        |
-| `default`           | Default value                             | `default:"123"`               |
-| `minimum`           | Minimum (inclusive)                       | `minimum:"1"`                 |
-| `exclusiveMinimum`  | Minimum (exclusive)                       | `exclusiveMinimum:"0"`        |
-| `maximum`           | Maximum (inclusive)                       | `maximum:"255"`               |
-| `exclusiveMaximum`  | Maximum (exclusive)                       | `exclusiveMaximum:"100"`      |
-| `multipleOf`        | Value must be a multiple of this value    | `multipleOf:"2"`              |
-| `minLength`         | Minimum string length                     | `minLength:"1"`               |
-| `maxLength`         | Maximum string length                     | `maxLength:"80"`              |
-| `pattern`           | Regular expression pattern                | `pattern:"[a-z]+"`            |
-| `minItems`          | Minimum number of array items             | `minItems:"1"`                |
-| `maxItems`          | Maximum number of array items             | `maxItems:"20"`               |
-| `uniqueItems`       | Array items must be unique                | `uniqueItems:"true"`          |
-| `minProperties`     | Minimum number of object properties       | `minProperties:"1"`           |
-| `maxProperties`     | Maximum number of object properties       | `maxProperties:"20"`          |
-| `example`           | Example value                             | `example:"123"`               |
-| `readOnly`          | Sent in the response only                 | `readOnly:"true"`             |
-| `writeOnly`         | Sent in the request only                  | `writeOnly:"true"`            |
-| `deprecated`        | This field is deprecated                  | `deprecated:"true"`           |
-| `dependentRequired` | Required fields when the field is present | `dependentRequired:"one,two"` |
+The following additional tags are supported on model fields:
 
-Parameters have some additional validation tags:
+| Tag                  | Description                                | Example                         |
+| -------------------- | ------------------------------------------ | ------------------------------- |
+| `doc`                | Describe the field                         | `doc:"Who to greet"`            |
+| `format`             | Format hint for the field                  | `format:"date-time"`            |
+| `enum`               | A comma-separated list of possible values  | `enum:"one,two,three"`          |
+| `default`            | Default value                              | `default:"123"`                 |
+| `minimum`            | Minimum (inclusive)                        | `minimum:"1"`                   |
+| `exclusiveMinimum`   | Minimum (exclusive)                        | `exclusiveMinimum:"0"`          |
+| `maximum`            | Maximum (inclusive)                        | `maximum:"255"`                 |
+| `exclusiveMaximum`   | Maximum (exclusive)                        | `exclusiveMaximum:"100"`        |
+| `multipleOf`         | Value must be a multiple of this value     | `multipleOf:"2"`                |
+| `minLength`          | Minimum string length                      | `minLength:"1"`                 |
+| `maxLength`          | Maximum string length                      | `maxLength:"80"`                |
+| `pattern`            | Regular expression pattern                 | `pattern:"[a-z]+"`              |
+| `patternDescription` | Description of the pattern used for errors | `patternDescription:"alphanum"` |
+| `minItems`           | Minimum number of array items              | `minItems:"1"`                  |
+| `maxItems`           | Maximum number of array items              | `maxItems:"20"`                 |
+| `uniqueItems`        | Array items must be unique                 | `uniqueItems:"true"`            |
+| `minProperties`      | Minimum number of object properties        | `minProperties:"1"`             |
+| `maxProperties`      | Maximum number of object properties        | `maxProperties:"20"`            |
+| `example`            | Example value                              | `example:"123"`                 |
+| `readOnly`           | Sent in the response only                  | `readOnly:"true"`               |
+| `writeOnly`          | Sent in the request only                   | `writeOnly:"true"`              |
+| `deprecated`         | This field is deprecated                   | `deprecated:"true"`             |
+| `hidden`             | Hide field/param from documentation        | `hidden:"true"`                 |
+| `dependentRequired`  | Required fields when the field is present  | `dependentRequired:"one,two"`   |
 
-| Tag      | Description                       | Example         |
-| -------- | --------------------------------- | --------------- |
-| `hidden` | Hide parameter from documentation | `hidden:"true"` |
+Built-in string formats include:
+
+| Format                            | Description                     | Example                                |
+| --------------------------------- | ------------------------------- | -------------------------------------- |
+| `date-time`                       | Date and time in RFC3339 format | `2021-12-31T23:59:59Z`                 |
+| `date-time-http`                  | Date and time in HTTP format    | `Fri, 31 Dec 2021 23:59:59 GMT`        |
+| `date`                            | Date in RFC3339 format          | `2021-12-31`                           |
+| `time`                            | Time in RFC3339 format          | `23:59:59`                             |
+| `email` / `idn-email`             | Email address                   | `kari@example.com`                     |
+| `hostname`                        | Hostname                        | `example.com`                          |
+| `ipv4`                            | IPv4 address                    | `127.0.0.1`                            |
+| `ipv6`                            | IPv6 address                    | `::1`                                  |
+| `uri` / `iri`                     | URI                             | `https://example.com`                  |
+| `uri-reference` / `iri-reference` | URI reference                   | `/path/to/resource`                    |
+| `uri-template`                    | URI template                    | `/path/{id}`                           |
+| `json-pointer`                    | JSON Pointer                    | `/path/to/field`                       |
+| `relative-json-pointer`           | Relative JSON Pointer           | `0/1`                                  |
+| `regex`                           | Regular expression              | `[a-z]+`                               |
+| `uuid`                            | UUID                            | `550e8400-e29b-41d4-a716-446655440000` |
 
 ## Strict vs. Loose Field Validation
 

--- a/huma.go
+++ b/huma.go
@@ -182,17 +182,16 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 			pfi.TimeFormat = timeFormat
 		}
 
-		if f.Tag.Get("hidden") == "" {
-			// Document the parameter if not hidden.
-			op.Parameters = append(op.Parameters, &Param{
-				Name:     name,
-				In:       pfi.Loc,
-				Explode:  explode,
-				Required: pfi.Required,
-				Schema:   pfi.Schema,
-				Example:  example,
-			})
-		}
+		// Document the parameter if not hidden.
+		op.Parameters = append(op.Parameters, &Param{
+			Name:     name,
+			In:       pfi.Loc,
+			Explode:  explode,
+			Required: pfi.Required,
+			Schema:   pfi.Schema,
+			Example:  example,
+		})
+
 		return pfi
 	}, false, "Body")
 }

--- a/huma.go
+++ b/huma.go
@@ -182,15 +182,17 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 			pfi.TimeFormat = timeFormat
 		}
 
-		// Document the parameter if not hidden.
-		op.Parameters = append(op.Parameters, &Param{
-			Name:     name,
-			In:       pfi.Loc,
-			Explode:  explode,
-			Required: pfi.Required,
-			Schema:   pfi.Schema,
-			Example:  example,
-		})
+		if !boolTag(f, "hidden") {
+			// Document the parameter if not hidden.
+			op.Parameters = append(op.Parameters, &Param{
+				Name:     name,
+				In:       pfi.Loc,
+				Explode:  explode,
+				Required: pfi.Required,
+				Schema:   pfi.Schema,
+				Example:  example,
+			})
+		}
 
 		return pfi
 	}, false, "Body")

--- a/schema.go
+++ b/schema.go
@@ -445,9 +445,6 @@ func jsonTag(r Registry, f reflect.StructField, s *Schema, name string) any {
 // This is used by `huma.SchemaFromType` when it encounters a struct, and
 // is used to generate schemas for path/query/header parameters.
 func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Schema {
-	if f.Tag.Get("hidden") != "" {
-		return nil
-	}
 	fs := registry.Schema(f.Type, true, hint)
 	if fs == nil {
 		return fs
@@ -691,6 +688,12 @@ func SchemaFromType(r Registry, t reflect.Type) *Schema {
 			}
 			if name == "-" {
 				// This field is deliberately ignored.
+				continue
+			}
+
+			if boolTag(f, "hidden") {
+				// This field is deliberately ignored. It may still exist, but won't
+				// be documented.
 				continue
 			}
 

--- a/schema.go
+++ b/schema.go
@@ -445,6 +445,9 @@ func jsonTag(r Registry, f reflect.StructField, s *Schema, name string) any {
 // This is used by `huma.SchemaFromType` when it encounters a struct, and
 // is used to generate schemas for path/query/header parameters.
 func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Schema {
+	if f.Tag.Get("hidden") != "" {
+		return nil
+	}
 	fs := registry.Schema(f.Type, true, hint)
 	if fs == nil {
 		return fs

--- a/schema_test.go
+++ b/schema_test.go
@@ -535,6 +535,8 @@ func TestSchema(t *testing.T) {
 				value2 string
 				// Filtered due to being an unsupported type
 				Value3 func()
+				// Filtered due to being hidden
+				Value4 string `json:"value4,omitempty" hidden:"true"`
 			}{},
 			expected: `{
 				"type": "object",


### PR DESCRIPTION
Attempting to address https://github.com/danielgtaylor/huma/issues/327 which will allow the use of the `hidden` validation tag on Body fields. To avoid double checking of the hidden tag, I moved the existing check from findParams() to only be in SchemaFromField(). All existing tests are passing, however I am not familiar enough with the entire repository to guarantee correctness. Any feedback is welcome.

Fixes #327.