### PR TITLE
docs: add sponsors; add dark mode images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-![Huma Rest API Framework](https://user-images.githubusercontent.com/106826/78105564-51102780-73a6-11ea-99ff-84d6c1b3e8df.png)
+<a href="#">
+	<picture>
+		<source media="(prefers-color-scheme: dark)" srcset="https://huma.rocks/huma-dark.png" />
+		<source media="(prefers-color-scheme: light)" srcset="https://huma.rocks/huma.png" />
+		<img alt="Huma Logo" src="https://huma.rocks/huma.png" />
+	</picture>
+</a>
 
 [![HUMA Powered](https://img.shields.io/badge/Powered%20By-HUMA-f40273)](https://huma.rocks/) [![CI](https://github.com/danielgtaylor/huma/workflows/CI/badge.svg?branch=main)](https://github.com/danielgtaylor/huma/actions?query=workflow%3ACI+branch%3Amain++) [![codecov](https://codecov.io/gh/danielgtaylor/huma/branch/main/graph/badge.svg)](https://codecov.io/gh/danielgtaylor/huma) [![Docs](https://godoc.org/github.com/danielgtaylor/huma/v2?status.svg)](https://pkg.go.dev/github.com/danielgtaylor/huma/v2?tab=doc) [![Go Report Card](https://goreportcard.com/badge/github.com/danielgtaylor/huma/v2)](https://goreportcard.com/report/github.com/danielgtaylor/huma/v2)
 
@@ -52,6 +58,15 @@ Features include:
 - Generates JSON Schema for each resource using optional `describedby` link relation headers as well as optional `$schema` properties in returned objects that integrate into editors for validation & completion.
 
 This project was inspired by [FastAPI](https://fastapi.tiangolo.com/). Logo & branding designed by Kari Taylor.
+
+## Sponsors
+
+A big thank you to our sponsors:
+
+- [@bclements](https://github.com/bclements)
+- [@bekabaz](https://github.com/bekabaz)
+
+## Testimonials
 
 > This is by far my favorite web framework for Go. It is inspired by FastAPI, which is also amazing, and conforms to many RFCs for common web things ... I really like the feature set, the fact that it [can use] Chi, and the fact that it is still somehow relatively simple to use. I've tried other frameworks and they do not spark joy for me. - [Jeb_Jenky](https://www.reddit.com/r/golang/comments/zhitcg/comment/izmg6vk/?utm_source=reddit&utm_medium=web2x&context=3)
 
@@ -166,4 +181,10 @@ Official Go package documentation can always be found at https://pkg.go.dev/gith
 
 Be sure to star the project if you find it useful!
 
-[![Star History Chart](https://api.star-history.com/svg?repos=danielgtaylor/huma&type=Date)](https://star-history.com/#danielgtaylor/huma&Date)
+<a href="https://star-history.com/#danielgtaylor/huma&Date">
+	<picture>
+		<source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=danielgtaylor/huma&type=Date&theme=dark" />
+		<source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=danielgtaylor/huma&type=Date" />
+		<img alt="Star History Chart" src="https://api.star-history.com/svg?repos=danielgtaylor/huma&type=Date" />
+	</picture>
+</a>


### PR DESCRIPTION
This adds our new sponsors into the README and updates the image links to support dark mode better.