### PR TITLE
feat: support OpenAPI servers base path & router groups

### DIFF
--- a/adapters/adapters_test.go
+++ b/adapters/adapters_test.go
@@ -87,21 +87,23 @@ func testAdapter(t *testing.T, api huma.API) {
 }
 
 func TestAdapters(t *testing.T) {
-	config := huma.DefaultConfig("Test", "1.0.0")
+	config := func() huma.Config {
+		return huma.DefaultConfig("Test", "1.0.0")
+	}
 
 	for _, adapter := range []struct {
 		name string
 		new  func() huma.API
 	}{
-		{"chi", func() huma.API { return humachi.New(chi.NewMux(), config) }},
-		{"chi4", func() huma.API { return humachi.NewV4(chi4.NewMux(), config) }},
-		{"echo", func() huma.API { return humaecho.New(echo.New(), config) }},
-		{"fiber", func() huma.API { return humafiber.New(fiber.New(), config) }},
-		{"gin", func() huma.API { return humagin.New(gin.New(), config) }},
-		{"httprouter", func() huma.API { return humahttprouter.New(httprouter.New(), config) }},
-		{"mux", func() huma.API { return humamux.New(mux.NewRouter(), config) }},
-		{"bunrouter", func() huma.API { return humabunrouter.New(bunrouter.New(), config) }},
-		{"bunroutercompat", func() huma.API { return humabunrouter.NewCompat(bunrouter.New().Compat(), config) }},
+		{"chi", func() huma.API { return humachi.New(chi.NewMux(), config()) }},
+		{"chi4", func() huma.API { return humachi.NewV4(chi4.NewMux(), config()) }},
+		{"echo", func() huma.API { return humaecho.New(echo.New(), config()) }},
+		{"fiber", func() huma.API { return humafiber.New(fiber.New(), config()) }},
+		{"gin", func() huma.API { return humagin.New(gin.New(), config()) }},
+		{"httprouter", func() huma.API { return humahttprouter.New(httprouter.New(), config()) }},
+		{"mux", func() huma.API { return humamux.New(mux.NewRouter(), config()) }},
+		{"bunrouter", func() huma.API { return humabunrouter.New(bunrouter.New(), config()) }},
+		{"bunroutercompat", func() huma.API { return humabunrouter.NewCompat(bunrouter.New().Compat(), config()) }},
 	} {
 		t.Run(adapter.name, func(t *testing.T) {
 			testAdapter(t, adapter.new())

--- a/api_test.go
+++ b/api_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/danielgtaylor/huma/v2/humatest"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
@@ -86,4 +87,41 @@ func TestContextValue(t *testing.T) {
 
 	resp := api.Get("/test")
 	assert.Equal(t, http.StatusNoContent, resp.Code)
+}
+
+func TestRouterPrefix(t *testing.T) {
+	mux := chi.NewMux()
+	var api huma.API
+	mux.Route("/api", func(r chi.Router) {
+		config := huma.DefaultConfig("My API", "1.0.0")
+		config.Servers = []*huma.Server{{URL: "http://localhost:8888/api"}}
+		api = humachi.New(r, config)
+	})
+
+	type TestOutput struct {
+		Body struct {
+			Field string `json:"field"`
+		}
+	}
+
+	// Register a simple hello world operation in the API.
+	huma.Get(api, "/test", func(ctx context.Context, input *struct{}) (*TestOutput, error) {
+		return &TestOutput{}, nil
+	})
+
+	// Create a test API around the underlying router to make easier requests.
+	tapi := humatest.NewTestAPI(t, mux, huma.Config{})
+
+	// The top-level router should respond to the full path even though the
+	// operation was registered with just `/test`.
+	resp := tapi.Get("/api/test")
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	// The transformer should generate links with the full URL path.
+	assert.Contains(t, resp.Header().Get("Link"), "/api/schemas/TestOutputBody.json")
+
+	// The docs HTML should point to the full URL including base path.
+	resp = tapi.Get("/api/docs")
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Contains(t, resp.Body.String(), "/api/openapi.yaml")
 }

--- a/humatest/humatest.go
+++ b/humatest/humatest.go
@@ -136,6 +136,8 @@ func (a *testAPI) Do(method, path string, args ...any) *httptest.ResponseRecorde
 	}
 
 	req, _ := http.NewRequest(method, path, b)
+	req.RequestURI = path
+	req.RemoteAddr = "127.0.0.1:12345"
 	if isJSON {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/transforms.go
+++ b/transforms.go
@@ -77,6 +77,13 @@ func (t *SchemaLinkTransformer) OnAddOperation(oapi *OpenAPI, op *Operation) {
 		}
 	}
 
+	// Figure out if there should be a base path prefix. This might be set when
+	// using a sub-router / group or if the gateway consumes a part of the path.
+	schemasPath := t.schemasPath
+	if prefix := getAPIPrefix(oapi); prefix != "" {
+		schemasPath = path.Join(prefix, schemasPath)
+	}
+
 	registry := oapi.Components.Schemas
 	for _, resp := range op.Responses {
 		for _, content := range resp.Content {
@@ -88,7 +95,7 @@ func (t *SchemaLinkTransformer) OnAddOperation(oapi *OpenAPI, op *Operation) {
 			typ := deref(registry.TypeFromRef(content.Schema.Ref))
 
 			extra := schemaField{
-				Schema: t.schemasPath + "/" + path.Base(content.Schema.Ref) + ".json",
+				Schema: schemasPath + "/" + path.Base(content.Schema.Ref) + ".json",
 			}
 
 			fieldIndexes := []int{}


### PR DESCRIPTION
This PR is an alternative approach to #305 by @burgesQ to enable serving the OpenAPI and schemas at the correct path when given a router group / sub-router at some base path like `/api`. It works like this:

```go
mux := chi.NewMux()
mux.Route("/api", func(r chi.Router) {
	config := huma.DefaultConfig("My API", "1.0.0")
	config.Servers = []*huma.Server{{URL: "https://example.com/api"}}
	api = humachi.New(r, config)

	// TODO: register operations
	huma.Get(api, "/demo", ...)
})
http.ListenAndServe("localhost:8888", mux)
```

This creates a sub-router at `/api` and then sets the `https://example.com/api` server URL including the base path. The sub-router is used to create the Huma instance. The `/demo` route registered via Huma then becomes `/api/huma` when the service is running, and all the docs/openapi/schemas/etc will be linked correctly.

I personally like the idea of using the already existing OpenAPI server base path functionality rather than duplicating it via a prefix/basePath parameter in the config. What do you think?

@spa5k, I believe this should fix #331. Please let me know if this would work for you.

I also did a quick example of how other routers can do this, e.g. for Gin you can use `humagin.NewWithGroup(router, group, config)` (you have to pass both the router and group since `*gin.RouterGroup` has no `ServeHTTP` method).

For the Go 1.22+ `http.ServeMux` via `humago` there is now a prefix you can set which acts similarly to the other router's groups. Use `humago.NewWithPrefix(mux, prefix, config)`.

This should also enable us to support rewriting API gateways, e.g. document the server's URL with base path like `https://example.com/api` but then do *not* use a sub-router as the incoming request to Go will never see the `/api` which was stripped off. Any other cases I'm missing?

Fixes #305, #331.