### PR TITLE
fix: update docs page copyright to 2024

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Huma
 site_url: https://huma.rocks
-copyright: Copyright &copy; 2020-2023 Daniel G. Taylor. Logo &amp; branding designed by Kari Taylor.
+copyright: Copyright &copy; 2020-2024 Daniel G. Taylor. Logo &amp; branding designed by Kari Taylor.
 repo_name: danielgtaylor/huma
 repo_url: https://github.com/danielgtaylor/huma
 edit_uri: edit/main/docs/docs/


### PR DESCRIPTION
Page footer displays a copyright message, this updates it to 2024. I'm a few months late 😊 