### PR TITLE
fix: support fields with ,omitempty but no name

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -681,7 +681,9 @@ func SchemaFromType(r Registry, t reflect.Type) *Schema {
 			name := f.Name
 			omit := false
 			if j := f.Tag.Get("json"); j != "" {
-				name = strings.Split(j, ",")[0]
+				if n := strings.Split(j, ",")[0]; n != "" {
+					name = n
+				}
 				if strings.Contains(j, "omitempty") {
 					omit = true
 				}

--- a/schema_test.go
+++ b/schema_test.go
@@ -427,6 +427,21 @@ func TestSchema(t *testing.T) {
 			}`,
 		},
 		{
+			name: "field-optional-without-name",
+			input: struct {
+				Value string `json:",omitempty"`
+			}{},
+			expected: `{
+				"type": "object",
+				"properties": {
+					"Value": {
+						"type": "string"
+					}
+				},
+				"additionalProperties": false
+			}`,
+		},
+		{
 			name: "field-example-custom",
 			input: struct {
 				Value CustomSchema `json:"value" example:"foo"`


### PR DESCRIPTION
Based on a [comment](https://github.com/danielgtaylor/huma/issues/238#issuecomment-2016448086) by @lazharichir this was an annoying bug where `json:",omitempty"` resulted in blank names in Huma-generated schemas. This is actually allowed by the standard library and means to just re-used the field name, so Huma now follows that same logic.