### PR TITLE
feat: use config.Info.Title as the page title in the API docs

### DIFF
--- a/api.go
+++ b/api.go
@@ -422,7 +422,7 @@ func NewAPI(config Config, a Adapter) API {
     <meta charset="utf-8" />
     <meta name="referrer" content="same-origin" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <title>` + title + ` reference</title>
+    <title>` + title + `</title>
     <!-- Embed elements Elements via Web Component -->
     <link href="https://unpkg.com/@stoplight/elements@8.1.0/styles.min.css" rel="stylesheet" />
     <script src="https://unpkg.com/@stoplight/elements@8.1.0/web-components.min.js"

--- a/api.go
+++ b/api.go
@@ -418,7 +418,7 @@ func NewAPI(config Config, a Adapter) API {
     <meta charset="utf-8" />
     <meta name="referrer" content="same-origin" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <title>Elements in HTML</title>
+    <title>` + config.Info.Title + ` reference</title>
     <!-- Embed elements Elements via Web Component -->
     <link href="https://unpkg.com/@stoplight/elements@8.1.0/styles.min.css" rel="stylesheet" />
     <script src="https://unpkg.com/@stoplight/elements@8.1.0/web-components.min.js"

--- a/api.go
+++ b/api.go
@@ -412,13 +412,17 @@ func NewAPI(config Config, a Adapter) API {
 				openAPIPath = path.Join(prefix, openAPIPath)
 			}
 			ctx.SetHeader("Content-Type", "text/html")
+			title := "Elements in HTML"
+			if config.Info != nil && config.Info.Title != "" {
+				title = config.Info.Title + " Reference"
+			}
 			ctx.BodyWriter().Write([]byte(`<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="referrer" content="same-origin" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <title>` + config.Info.Title + ` reference</title>
+    <title>` + title + ` reference</title>
     <!-- Embed elements Elements via Web Component -->
     <link href="https://unpkg.com/@stoplight/elements@8.1.0/styles.min.css" rel="stylesheet" />
     <script src="https://unpkg.com/@stoplight/elements@8.1.0/web-components.min.js"

--- a/docs/docs/features/api-docs.md
+++ b/docs/docs/features/api-docs.md
@@ -37,7 +37,7 @@ router.Get("/docs", func(w http.ResponseWriter, r *http.Request) {
     <meta charset="utf-8" />
     <meta name="referrer" content="same-origin" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <title>Elements in HTML</title>
+    <title>Docs Example reference</title>
     <!-- Embed elements Elements via Web Component -->
     <link href="https://unpkg.com/@stoplight/elements@8.0.0/styles.min.css" rel="stylesheet" />
     <script src="https://unpkg.com/@stoplight/elements@8.0.0/web-components.min.js"


### PR DESCRIPTION
Hi there, Thanks for Huma. 

It's been a really nice experience so-far. As I'm using the framework to develop a third-party friendly API I saw a small improvement that could help with the experience. Feel free to close or merge ;) 

### What has been done
The automatic API documentation has the default title of "Elements in HTML". This PR changes that page title to something more identifiable. 

### Note
The change assumes that `config.Info` is not `nil`. The GoDoc describes that it is required but I'm too new to the framework to make a educated guess if it's enforced or not. 