### PR TITLE
docs: add sponsors to docs homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ This project was inspired by [FastAPI](https://fastapi.tiangolo.com/). Logo & br
 
 ## Sponsors
 
-A big thank you to our sponsors:
+A big thank you to our current & former sponsors:
 
 - [@bclements](https://github.com/bclements)
 - [@bekabaz](https://github.com/bekabaz)
+- [@victoraugustolls](https://github.com/victoraugustolls)
 
 ## Testimonials
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,6 +3,10 @@ title: Huma Introduction
 description: A modern, simple, fast & flexible micro framework for building HTTP APIs in Golang backed by OpenAPI 3 and JSON Schema.
 hide:
     - navigation
+sponsors:
+    - bclements
+    - bekabaz
+    - victoraugustolls
 ---
 
 # Huma {.hidden}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - "Go Reference": "https://pkg.go.dev/github.com/danielgtaylor/huma/v2?tab=doc"
 theme:
   name: material
+  custom_dir: overrides
   logo: logo.png
   favicon: favicon.png
   palette:

--- a/docs/overrides/partials/toc.html
+++ b/docs/overrides/partials/toc.html
@@ -1,0 +1,72 @@
+<!--
+  Copyright (c) 2016-2024 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Determine title -->
+{% set title = lang.t("toc") %}
+{% if config.mdx_configs.toc and config.mdx_configs.toc.title %}
+{% set title = config.mdx_configs.toc.title %}
+{% endif %}
+
+<!-- Table of contents -->
+<nav class="md-nav md-nav--secondary" aria-label="{{ title }}">
+	{% set toc = page.toc %}
+
+	<!--
+    Check whether the content starts with a level 1 headline. If it does, the
+    top-level anchor must be skipped, since it would be redundant to the link
+    to the current page that is located just above the anchor. Therefore we
+    directly continue with the children of the anchor.
+  -->
+	{% set first = toc | first %}
+	{% if first and first.level == 1 %}
+	{% set toc = first.children %}
+	{% endif %}
+
+	<!-- Table of contents title and list -->
+	{% if toc %}
+	<label class="md-nav__title" for="__toc">
+		<span class="md-nav__icon md-icon"></span>
+		{{ title }}
+	</label>
+	<ul class="md-nav__list" data-md-component="toc" data-md-scrollfix>
+		{% for toc_item in toc %}
+		{% include "partials/toc-item.html" %}
+		{% endfor %}
+	</ul>
+	{% endif %}
+
+	{% if page.meta and page.meta.sponsors %}
+	<div style="margin-top: 1em">
+		<label class="md-nav__title">Sponsors</label>
+		<div class="md-nav" style="display: block; padding: 0.8em;">Thank you to our wonderful current & former sponsors!</div>
+		<ul class="md-nav__list">
+			{% for sponsor in page.meta.sponsors %}
+			<li class="md-nav__item">
+				<a class="md-nav__link" href="https://github.com/{{ sponsor }}" target="_blank" rel="noopener">
+					@{{ sponsor}}
+				</a>
+			</li>
+			{% endfor %}
+		</ul>
+	</div>
+	{% endif %}
+</nav>


### PR DESCRIPTION
Updates the list of sponsors, adds the sponsors to the right part of the project homepage under the TOC links.