### PR TITLE
feat: support json.RawMessage

### DIFF
--- a/docs/docs/features/request-inputs.md
+++ b/docs/docs/features/request-inputs.md
@@ -56,6 +56,19 @@ The special struct field `Body` will be treated as the input request body and ca
 
 `RawBody []byte` can also be used alongside `Body` to provide access to the `[]byte` used to validate & parse `Body`.
 
+### Special Types
+
+The following special types are supported out of the box:
+
+| Type              | Schema                                      | Example                       |
+| ----------------- | ------------------------------------------- | ----------------------------- |
+| `time.Time`       | `{"type": "string", "format": "date-time"}` | `"2020-01-01T12:00:00Z"`      |
+| `url.URL`         | `{"type": "string", "format": "uri"}`       | `"https://example.com"`       |
+| `net.IP`          | `{"type": "string", "format": "ipv4"}`      | `"127.0.0.1"`                 |
+| `json.RawMessage` | `{}`                                        | `["whatever", "you", "want"]` |
+
+You can override this default behavior if needed as described in [Schema Customization](./schema-customization.md) and [Request Validation](./request-validation.md), e.g. setting a custom `format` tag for IPv6.
+
 ### Other Body Types
 
 Sometimes, you want to bypass the normal body parsing and instead read the raw body contents directly. This is useful for unstructured data, file uploads, or other binary data. You can use `RawBody []byte` **without** a `Body` field to access the raw body bytes without any parsing/validation being applied. For example, to accept some `text/plain` input:
@@ -78,9 +91,9 @@ This enables you to also do your own parsing of the input, if needed.
 
 ### Multipart Form Data
 
-Multipart form data is supported by using a `RawBody` with a type of  
+Multipart form data is supported by using a `RawBody` with a type of
 `multipart.Form` type in the input struct. This will parse the request using
-Go standard library multipart processing implementation. 
+Go standard library multipart processing implementation.
 
 For example:
 

--- a/schema.go
+++ b/schema.go
@@ -30,9 +30,10 @@ const (
 
 // Special JSON Schema formats.
 var (
-	timeType = reflect.TypeOf(time.Time{})
-	ipType   = reflect.TypeOf(net.IP{})
-	urlType  = reflect.TypeOf(url.URL{})
+	timeType       = reflect.TypeOf(time.Time{})
+	ipType         = reflect.TypeOf(net.IP{})
+	urlType        = reflect.TypeOf(url.URL{})
+	rawMessageType = reflect.TypeOf(json.RawMessage{})
 )
 
 func deref(t reflect.Type) reflect.Type {
@@ -597,6 +598,8 @@ func SchemaFromType(r Registry, t reflect.Type) *Schema {
 		return &Schema{Type: TypeString, Format: "uri"}
 	case ipType:
 		return &Schema{Type: TypeString, Format: "ipv4"}
+	case rawMessageType:
+		return &Schema{}
 	}
 
 	minZero := 0.0

--- a/schema_test.go
+++ b/schema_test.go
@@ -140,6 +140,11 @@ func TestSchema(t *testing.T) {
 			expected: `{"type": "string", "format": "ipv4"}`,
 		},
 		{
+			name:     "json.RawMessage",
+			input:    &json.RawMessage{},
+			expected: `{}`,
+		},
+		{
 			name:     "bytes",
 			input:    []byte("test"),
 			expected: `{"type": "string", "contentEncoding": "base64"}`,

--- a/validate_test.go
+++ b/validate_test.go
@@ -812,6 +812,13 @@ var validateTests = []struct {
 		errs: []string{"expected object with at most 1 properties"},
 	},
 	{
+		name: "json.RawMessage success",
+		typ: reflect.TypeOf(struct {
+			Value json.RawMessage `json:"value"`
+		}{}),
+		input: map[string]any{"value": map[string]any{"some": []any{"thing"}}},
+	},
+	{
 		name:  "object struct success",
 		typ:   reflect.TypeOf(struct{}{}),
 		input: map[string]any{},


### PR DESCRIPTION
This adds support for `json.RawMessage` which generates an empty schema (no validation). This means any input is valid and it's up to the handler code to determine if there are any errors.

Fixes #348.