### PR TITLE
docs: fix middleware header example

### DIFF
--- a/docs/docs/features/middleware.md
+++ b/docs/docs/features/middleware.md
@@ -57,13 +57,12 @@ Example:
 
 ```go title="code.go"
 func MyMiddleware(ctx huma.Context, next func(huma.Context)) {
+	// Set a custom header on the response.
+	ctx.SetHeader("My-Custom-Header", "Hello, world!")
+
 	// Call the next middleware in the chain. This eventually calls the
 	// operation handler as well.
 	next(ctx)
-
-	// Set a custom header on the response *after* the operation handler
-	// has finished.
-	ctx.SetHeader("My-Custom-Header", "Hello, world!")
 }
 
 func NewHumaAPI() huma.API {


### PR DESCRIPTION
Small documentation fix - you cannot set headers after the body has already been written. A more advanced middleware could capture the body in memory before setting a header, but that is beyond the scope of this example.

Fixes #355.