### PR TITLE
fix: apply schema name text transforms to type hints

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -31,6 +31,10 @@ type Registry interface {
 func DefaultSchemaNamer(t reflect.Type, hint string) string {
 	name := deref(t).Name()
 
+	if name == "" {
+		name = hint
+	}
+
 	// Better support for lists, so e.g. `[]int` becomes `ListInt`.
 	name = strings.ReplaceAll(name, "[]", "List[")
 
@@ -51,9 +55,6 @@ func DefaultSchemaNamer(t reflect.Type, hint string) string {
 	}
 	name = result
 
-	if name == "" {
-		name = hint
-	}
 	return name
 }
 

--- a/registry_test.go
+++ b/registry_test.go
@@ -27,28 +27,30 @@ func TestDefaultSchemaNamer(t *testing.T) {
 	for _, example := range []struct {
 		typ  any
 		name string
+		hint string
 	}{
-		{int(0), "Int"},
-		{int64(0), "Int64"},
-		{S{}, "S"},
-		{time.Time{}, "Time"},
-		{Output[int]{}, "OutputInt"},
-		{Output[*int]{}, "OutputInt"},
-		{Output[[]int]{}, "OutputListInt"},
-		{Output[[]*int]{}, "OutputListInt"},
-		{Output[[][]int]{}, "OutputListListInt"},
-		{Output[map[string]int]{}, "OutputMapStringInt"},
-		{Output[map[string][]*int]{}, "OutputMapStringListInt"},
-		{Output[S]{}, "OutputS"},
-		{Output[ü]{}, "OutputÜ"},
-		{Output[MP4]{}, "OutputMP4"},
-		{Output[Embedded[*time.Time]]{}, "OutputEmbeddedTime"},
-		{Output[*[]Embedded[time.Time]]{}, "OutputListEmbeddedTime"},
-		{Output[EmbeddedTwo[[]time.Time, **url.URL]]{}, "OutputEmbeddedTwoListTimeURL"},
-		{Renamed{}, "Renamed"},
+		{int(0), "Int", ""},
+		{int64(0), "Int64", ""},
+		{S{}, "S", ""},
+		{time.Time{}, "Time", ""},
+		{Output[int]{}, "OutputInt", ""},
+		{Output[*int]{}, "OutputInt", ""},
+		{Output[[]int]{}, "OutputListInt", ""},
+		{Output[[]*int]{}, "OutputListInt", ""},
+		{Output[[][]int]{}, "OutputListListInt", ""},
+		{Output[map[string]int]{}, "OutputMapStringInt", ""},
+		{Output[map[string][]*int]{}, "OutputMapStringListInt", ""},
+		{Output[S]{}, "OutputS", ""},
+		{Output[ü]{}, "OutputÜ", ""},
+		{Output[MP4]{}, "OutputMP4", ""},
+		{Output[Embedded[*time.Time]]{}, "OutputEmbeddedTime", ""},
+		{Output[*[]Embedded[time.Time]]{}, "OutputListEmbeddedTime", ""},
+		{Output[EmbeddedTwo[[]time.Time, **url.URL]]{}, "OutputEmbeddedTwoListTimeURL", ""},
+		{Renamed{}, "Renamed", ""},
+		{struct{}{}, "SomeGenericThing", "Some[pkg.Generic]Thing"},
 	} {
 		t.Run(example.name, func(t *testing.T) {
-			name := DefaultSchemaNamer(reflect.TypeOf(example.typ), "hint")
+			name := DefaultSchemaNamer(reflect.TypeOf(example.typ), example.hint)
 			assert.Equal(t, example.name, name)
 		})
 	}

--- a/registry_test.go
+++ b/registry_test.go
@@ -48,6 +48,7 @@ func TestDefaultSchemaNamer(t *testing.T) {
 		{Output[EmbeddedTwo[[]time.Time, **url.URL]]{}, "OutputEmbeddedTwoListTimeURL", ""},
 		{Renamed{}, "Renamed", ""},
 		{struct{}{}, "SomeGenericThing", "Some[pkg.Generic]Thing"},
+		{struct{}{}, "Type1Type2Type3", "pkg1.Type1[path/to/pkg2.Type2]pkg3.Type3"},
 	} {
 		t.Run(example.name, func(t *testing.T) {
 			name := DefaultSchemaNamer(reflect.TypeOf(example.typ), example.hint)


### PR DESCRIPTION
This makes sure that text transforms to remove `[`, `]`, and other special characters get applied to type hints, which can be generated from the parent type. For example, `pkg1.Type1[path/to/pkg2.Type2]pkg3.Type3` would become `Type1Type2Type3`.

Fixes #364.