### PR TITLE
feat: add param descriptions from schemas

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -183,14 +183,22 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 		}
 
 		if !boolTag(f, "hidden") {
+			desc := ""
+			if pfi.Schema != nil {
+				// If the schema has a description, use it. Some tools will not show
+				// the description if it is only on the schema.
+				desc = pfi.Schema.Description
+			}
+
 			// Document the parameter if not hidden.
 			op.Parameters = append(op.Parameters, &Param{
-				Name:     name,
-				In:       pfi.Loc,
-				Explode:  explode,
-				Required: pfi.Required,
-				Schema:   pfi.Schema,
-				Example:  example,
+				Name:        name,
+				Description: desc,
+				In:          pfi.Loc,
+				Explode:     explode,
+				Required:    pfi.Required,
+				Schema:      pfi.Schema,
+				Example:     example,
 			})
 		}
 

--- a/huma_test.go
+++ b/huma_test.go
@@ -127,7 +127,7 @@ func TestFeatures(t *testing.T) {
 					Method: http.MethodGet,
 					Path:   "/test-params/{string}/{int}/{uuid}",
 				}, func(ctx context.Context, input *struct {
-					PathString   string    `path:"string"`
+					PathString   string    `path:"string" doc:"Some docs"`
 					PathInt      int       `path:"int"`
 					PathUUID     UUID      `path:"uuid"`
 					QueryString  string    `query:"string"`
@@ -186,6 +186,9 @@ func TestFeatures(t *testing.T) {
 					assert.Equal(t, "bar", input.CookieFull.Value)
 					return nil, nil
 				})
+
+				// Docs should be available on the param object, not just the schema.
+				assert.Equal(t, "Some docs", api.OpenAPI().Paths["/test-params/{string}/{int}/{uuid}"].Get.Parameters[0].Description)
 
 				// `http.Cookie` should be treated as a string.
 				assert.Equal(t, "string", api.OpenAPI().Paths["/test-params/{string}/{int}/{uuid}"].Get.Parameters[27].Schema.Type)


### PR DESCRIPTION
This sets the parameter description from the schema description if one is available, enabling descriptions for a wider range of tools, including SwaggerUI.

Fixes #365