### PR TITLE
fix: catch reflect.StructOf panics in schema transformer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,4 +18,6 @@ jobs:
         with:
           version: v1.57.2
       - run: go test -coverprofile=coverage.txt -covermode=atomic ./...
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/huma_test.go
+++ b/huma_test.go
@@ -1465,6 +1465,23 @@ func TestConvenienceMethods(t *testing.T) {
 	assert.Equal(t, "delete-things-by-thing-id", api.OpenAPI().Paths[path].Delete.OperationID)
 }
 
+type EmbeddedWithMethod struct{}
+
+func (e EmbeddedWithMethod) Method() {}
+
+func TestUnsupportedEmbeddedTypeWithMethods(t *testing.T) {
+	_, api := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+
+	// Should not panic!
+	huma.Post(api, "/things", func(ctx context.Context, input *struct{}) (*struct {
+		Body struct {
+			EmbeddedWithMethod
+		}
+	}, error) {
+		return nil, nil
+	})
+}
+
 // func BenchmarkSecondDecode(b *testing.B) {
 // 	//nolint: musttag
 // 	type MediumSized struct {


### PR DESCRIPTION
This catches a panic related to an unsupported feature of Go that you might run into with types from third-party libraries. The schema transformer prints a warning, skips the type for inserting links, and moves on. We cannot support this until the underlying language is updated, but at least it won't stop your service from running.

Fixes #371 