### PR TITLE
fix: use errors.As to get StatusError, enabling wrapping

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -2,6 +2,7 @@ package huma_test
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -100,4 +101,12 @@ func TestTransformError(t *testing.T) {
 	ctx := humatest.NewContext(nil, req, resp)
 
 	require.Error(t, huma.WriteErr(api, ctx, 400, "bad request"))
+}
+
+func TestErrorAs(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", huma.Error400BadRequest("test"))
+
+	var e huma.StatusError
+	require.ErrorAs(t, err, &e)
+	assert.Equal(t, 400, e.GetStatus())
 }

--- a/huma.go
+++ b/huma.go
@@ -1274,7 +1274,8 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 		output, err := handler(ctx.Context(), &input)
 		if err != nil {
 			status := http.StatusInternalServerError
-			if se, ok := err.(StatusError); ok {
+			var se StatusError
+			if errors.As(err, &se) {
 				status = se.GetStatus()
 			} else {
 				err = NewError(http.StatusInternalServerError, err.Error())

--- a/huma_test.go
+++ b/huma_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net"
@@ -648,6 +649,22 @@ Content of example2.txt.
 					Path:   "/error",
 				}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
 					return nil, huma.Error403Forbidden("nope")
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/error",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusForbidden, resp.Code)
+			},
+		},
+		{
+			Name: "handler-wrapped-error",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/error",
+				}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+					return nil, fmt.Errorf("wrapped: %w", huma.Error403Forbidden("nope"))
 				})
 			},
 			Method: http.MethodGet,


### PR DESCRIPTION
This updates the code to allow wrapping of the HTTP status errors, which can be useful to provide additional context for logging among other things. Adds a couple of tests to ensure it works as expected.

Fixes #380.