### PR TITLE
feat: add per-operation router-agnostic middleware

### DIFF
--- a/api.go
+++ b/api.go
@@ -224,7 +224,10 @@ type API interface {
 	// the next Middleware.
 	UseMiddleware(middlewares ...func(ctx Context, next func(Context)))
 
-	// Middlewares returns a slice of middleware handler functions.
+	// Middlewares returns a slice of middleware handler functions that will be
+	// run for all operations. Middleware are run in the order they are added.
+	// See also `huma.Operation{}.Middlewares` for adding operation-specific
+	// middleware at operation registration time.
 	Middlewares() Middlewares
 }
 

--- a/docs/docs/features/middleware.md
+++ b/docs/docs/features/middleware.md
@@ -151,6 +151,35 @@ func MyMiddleware(ctx huma.Context, next func(ctx huma.Context)) {
 
     The [`huma.ErrorDetail`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#ErrorDetail) struct can be used to provide more information about the error, such as the location of the error and the value which was seen.
 
+### Operations
+
+You can also add router-agnostic middleware to individual operations by setting the [`huma.Operation.Middlewares`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Operation) field. This middleware will run after the router-specific middleware and before the operation handler.
+
+```go title="code.go"
+func MyMiddleware(ctx huma.Context, next func(huma.Context)) {
+	// Call the next middleware in the chain. This eventually calls the
+	// operation handler as well.
+	next(ctx)
+}
+
+func main() {
+	// ...
+	api := humachi.New(router, config)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "demo",
+		Method:      http.MethodGet,
+		Path:        "/demo",
+		Middlewares: huma.Middlewares{MyMiddleware},
+	}, func(ctx context.Context, input *MyInput) (*MyOutput, error) {
+		// TODO: implement handler...
+		return nil, nil
+	})
+}
+```
+
+It's also possible for global middleware to run only for certain paths by checking the request context's URL within the middleware, or by using something like the `huma.Operation.Metadata` to trigger the middleware logic using custom settings. It's up to you to decide how to structure your middleware and operations.
+
 ## Dive Deeper
 
 -   Reference

--- a/huma.go
+++ b/huma.go
@@ -795,7 +795,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 
 	a := api.Adapter()
 
-	a.Handle(&op, api.Middlewares().Handler(func(ctx Context) {
+	a.Handle(&op, api.Middlewares().Handler(op.Middlewares.Handler(func(ctx Context) {
 		var input I
 
 		// Get the validation dependencies from the shared pool.
@@ -1347,7 +1347,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 		} else {
 			ctx.SetStatus(status)
 		}
-	}))
+	})))
 }
 
 // AutoRegister auto-detects operation registration methods and registers them

--- a/openapi.go
+++ b/openapi.go
@@ -867,6 +867,11 @@ type Operation struct {
 	// functions which generate operations.
 	Metadata map[string]any `yaml:"-"`
 
+	// Middlewares is a list of middleware functions to run before the handler.
+	// This is useful for adding custom logic to operations, such as logging,
+	// authentication, or rate limiting.
+	Middlewares Middlewares `yaml:"-"`
+
 	// --- OpenAPI fields ---
 
 	// Tags is a list of tags for API documentation control. Tags can be used for


### PR DESCRIPTION
This PR introduces a small change to add per-operation router-agnostic middleware using the existing `huma.Operation` struct configured at operation registration time. It can be used like this, which also facilitates wrapping/composition utility functions:

```go
huma.Register(api, huma.Operation{
	Method: http.MethodGet,
	Path:   "/demo",
	Middlewares: huma.Middlewares{
		func(ctx huma.Context, next func(huma.Context)) {
			// TODO: implement middleware here...
			next(ctx)
		},
	},
}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
	// TODO: implement handler here...
	return nil, nil
})
```

Let me know what you think. Fixes #378.