### PR TITLE
must specify openapi config

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -77,12 +77,11 @@ func TestErrorResponses(t *testing.T) {
 }
 
 func TestNegotiateError(t *testing.T) {
-	_, api := humatest.New(t, huma.Config{})
+	_, api := humatest.New(t, huma.Config{OpenAPI: &huma.OpenAPI{Info: &huma.Info{Title: "Test API", Version: "1.0.0"}}})
 
 	req, _ := http.NewRequest("GET", "/", nil)
 	resp := httptest.NewRecorder()
 	ctx := humatest.NewContext(nil, req, resp)
-
 	require.Error(t, huma.WriteErr(api, ctx, 400, "bad request"))
 }
 

--- a/huma_test.go
+++ b/huma_test.go
@@ -1404,23 +1404,6 @@ func TestParamPointerPanics(t *testing.T) {
 	})
 }
 
-func TestEmptyConfigPanicsWithClearMessage(t *testing.T) {
-	_, app := humatest.New(t, huma.Config{})
-
-	assert.PanicsWithError(t, "specify a value for OpenAPI", func() {
-		huma.Register(app, huma.Operation{
-			Method: http.MethodGet,
-			Path:   "/",
-		}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
-			return nil, nil
-		})
-
-		app.Get("/", func(ctx context.Context, input *struct{}) (*struct{}, error) {
-			return nil, nil
-		})
-	})
-}
-
 func TestPointerDefaultPanics(t *testing.T) {
 	// For now, we don't support these, so we panic rather than have subtle
 	// bugs that are hard to track down.

--- a/huma_test.go
+++ b/huma_test.go
@@ -1404,6 +1404,23 @@ func TestParamPointerPanics(t *testing.T) {
 	})
 }
 
+func TestEmptyConfigPanicsWithClearMessage(t *testing.T) {
+	_, app := humatest.New(t, huma.Config{})
+
+	assert.PanicsWithError(t, "specify a value for OpenAPI", func() {
+		huma.Register(app, huma.Operation{
+			Method: http.MethodGet,
+			Path:   "/",
+		}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+			return nil, nil
+		})
+
+		app.Get("/", func(ctx context.Context, input *struct{}) (*struct{}, error) {
+			return nil, nil
+		})
+	})
+}
+
 func TestPointerDefaultPanics(t *testing.T) {
 	// For now, we don't support these, so we panic rather than have subtle
 	// bugs that are hard to track down.

--- a/humatest/humatest.go
+++ b/humatest/humatest.go
@@ -200,6 +200,11 @@ func Wrap(tb TB, api huma.API) TestAPI {
 // to customize how the API is created. If no configuration is provided then
 // a simple default configuration supporting `application/json` is used.
 func New(tb TB, configs ...huma.Config) (http.Handler, TestAPI) {
+	for _, config := range configs {
+		if config.OpenAPI == nil {
+			panic("custom huma.Config structs must specify a value for OpenAPI")
+		}
+	}
 	if len(configs) == 0 {
 		configs = append(configs, huma.Config{
 			OpenAPI: &huma.OpenAPI{

--- a/humatest/humatest_test.go
+++ b/humatest/humatest_test.go
@@ -164,3 +164,9 @@ func TestDumpBodyError(t *testing.T) {
 	_, err = io.ReadAll(req.Body)
 	require.Error(t, err)
 }
+
+func TestOpenAPIRequired(t *testing.T) {
+	assert.PanicsWithValue(t, "custom huma.Config structs must specify a value for OpenAPI", func() {
+		New(t, huma.Config{})
+	})
+}


### PR DESCRIPTION
I noticed if you supply an empty config struct you get an unhelpful panic with `invalid memory address or nil pointer dereference`. This PR changes the panic to supply a helpful message describing the problem. 

An alternative solution would be to make it so that an empty huma.Config{} doesn't panic at all.