### PR TITLE
fix: Add support for Percent-Encoding RFC 3986

### DIFF
--- a/adapters/humaflow/flow/flow.go
+++ b/adapters/humaflow/flow/flow.go
@@ -165,7 +165,7 @@ func (m *Mux) Group(fn func(*Mux)) {
 
 // ServeHTTP makes the router implement the http.Handler interface.
 func (m *Mux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	urlSegments := strings.Split(r.URL.Path, "/")
+	urlSegments := strings.Split(r.URL.EscapedPath(), "/")
 	allowedMethods := []string{}
 
 	for _, route := range *m.routes {

--- a/adapters/humaflow/flow/flow.go
+++ b/adapters/humaflow/flow/flow.go
@@ -62,6 +62,7 @@ package flow
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"regexp"
 	"slices"
 	"strings"
@@ -227,15 +228,20 @@ func (r *route) match(ctx context.Context, urlSegments []string) (context.Contex
 		if strings.HasPrefix(routeSegment, ":") {
 			key, rxPattern, containsRx := strings.Cut(strings.TrimPrefix(routeSegment, ":"), "|")
 
+			value, err := url.QueryUnescape(urlSegments[i])
+			if err != nil {
+				return ctx, false
+			}
+
 			if containsRx {
-				if compiledRXPatterns[rxPattern].MatchString(urlSegments[i]) {
-					ctx = context.WithValue(ctx, contextKey(key), urlSegments[i])
+				if compiledRXPatterns[rxPattern].MatchString(value) {
+					ctx = context.WithValue(ctx, contextKey(key), value)
 					continue
 				}
 			}
 
-			if !containsRx && urlSegments[i] != "" {
-				ctx = context.WithValue(ctx, contextKey(key), urlSegments[i])
+			if !containsRx && value != "" {
+				ctx = context.WithValue(ctx, contextKey(key), value)
 				continue
 			}
 

--- a/adapters/humaflow/flow/flow_test.go
+++ b/adapters/humaflow/flow/flow_test.go
@@ -98,7 +98,7 @@ func TestMatching(t *testing.T) {
 		{
 			[]string{"GET"}, "/path-params/:era",
 			"GET", "/path-params/a%3A%2F%2Fb%2Fc",
-			http.StatusOK, map[string]string{"era": "a%3A%2F%2Fb%2Fc"}, "",
+			http.StatusOK, map[string]string{"era": "a://b/c"}, "",
 		},
 		// regexp
 		{

--- a/adapters/humaflow/flow/flow_test.go
+++ b/adapters/humaflow/flow/flow_test.go
@@ -95,6 +95,11 @@ func TestMatching(t *testing.T) {
 			"GET", "/path-params/60/beatles/lennon/bar",
 			http.StatusNotFound, map[string]string{"era": "60", "group": "beatles", "member": "lennon"}, "",
 		},
+		{
+			[]string{"GET"}, "/path-params/:era",
+			"GET", "/path-params/a%3A%2F%2Fb%2Fc",
+			http.StatusOK, map[string]string{"era": "a%3A%2F%2Fb%2Fc"}, "",
+		},
 		// regexp
 		{
 			[]string{"GET"}, "/path-params/:era|^[0-9]{2}$/:group|^[a-z].+$",


### PR DESCRIPTION
**Problem**:
The current implementation does not allow to use of encoded named parameters like:
`/path/:param` - `/path-params/a%3A%2F%2Fb%2Fc`

Which is fully legal by [RFC 3986](http://www.ietf.org/rfc/rfc3986.txt)

Solution:
Use [EscapedPath()](https://pkg.go.dev/net/url#URL.EscapedPath) instead of direct access to a `u.Path`

> Note that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/. A consequence is that it is impossible to tell which slashes in the Path were slashes in the raw URL and which were %2f. This distinction is rarely important, but when it is, the code should use the [URL.EscapedPath](https://pkg.go.dev/net/url#URL.EscapedPath) method, which preserves the original encoding of Path.

Details:
https://pkg.go.dev/net/url#URL

PR into the original package:
https://github.com/alexedwards/flow/pull/11