### PR TITLE
fix: check if struct implements interface SchemaProvider after deref

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -601,16 +601,16 @@ type SchemaProvider interface {
 //	registry := huma.NewMapRegistry("#/prefix", huma.DefaultSchemaNamer)
 //	schema := huma.SchemaFromType(registry, reflect.TypeOf(MyType{}))
 func SchemaFromType(r Registry, t reflect.Type) *Schema {
+	isPointer := t.Kind() == reflect.Pointer
+
+	s := Schema{}
+	t = deref(t)
+
 	v := reflect.New(t).Interface()
 	if sp, ok := v.(SchemaProvider); ok {
 		// Special case: type provides its own schema. Do not try to generate.
 		return sp.Schema(r)
 	}
-
-	isPointer := t.Kind() == reflect.Pointer
-
-	s := Schema{}
-	t = deref(t)
 
 	// Handle special cases.
 	switch t {

--- a/schema_test.go
+++ b/schema_test.go
@@ -480,6 +480,23 @@ func TestSchema(t *testing.T) {
 			}`,
 		},
 		{
+			name: "field-example-custom-pointer",
+			input: struct {
+				Value *CustomSchema `json:"value" example:"foo"`
+			}{},
+			expected: `{
+				"type": "object",
+				"properties": {
+					"value": {
+						"type": "string",
+						"examples": ["foo"]
+					}
+				},
+				"additionalProperties": false,
+				"required": ["value"]
+			}`,
+		},
+		{
 			name: "field-enum-custom",
 			input: struct {
 				Value OmittableNullable[string] `json:"value,omitempty" enum:"foo,bar"`


### PR DESCRIPTION
Problem:
Currently the Schema(r Registry) *Schema on types that implement a custom schema will only be called if the field is not a pointer. 

Solution:
In the function SchemaFromType we first deref the type so that we always compare a non pointer type against the interface. 

fixes: #412 