### PR TITLE
Feature: handling files from `multipart/form-data` request

### DIFF
--- a/formdata.go
+++ b/formdata.go
@@ -132,7 +132,7 @@ func (m *MultipartFormFiles[T]) Decode(opMediaType *MediaType) []error {
 	)
 	for i := 0; i < dataType.NumField(); i++ {
 		field := value.Elem().Field(i)
-		key := dataType.Field(i).Tag.Get("form-data")
+		key := dataType.Field(i).Tag.Get("form")
 		if key == "" {
 			continue
 		}
@@ -162,7 +162,7 @@ func (m *MultipartFormFiles[T]) Decode(opMediaType *MediaType) []error {
 
 func formDataFieldName(f reflect.StructField) string {
 	name := f.Name
-	if formDataKey := f.Tag.Get("form-data"); formDataKey != "" {
+	if formDataKey := f.Tag.Get("form"); formDataKey != "" {
 		name = formDataKey
 	}
 	return name
@@ -218,7 +218,7 @@ func multiPartContentEncoding(t reflect.Type) map[string]*Encoding {
 		f := t.Field(i)
 		name := formDataFieldName(f)
 		encoding[name] = &Encoding{
-			ContentType: f.Tag.Get("content-type"),
+			ContentType: f.Tag.Get("contentType"),
 		}
 	}
 	return encoding

--- a/formdata.go
+++ b/formdata.go
@@ -193,7 +193,7 @@ func multiPartFormFileSchema(t reflect.Type) *Schema {
 		}
 
 		if _, ok := f.Tag.Lookup("required"); ok && boolTag(f, "required") {
-			requiredFields = append(requiredFields, name)
+			requiredFields[i] = name
 			schema.requiredMap[name] = true
 		}
 	}

--- a/formdata.go
+++ b/formdata.go
@@ -1,0 +1,164 @@
+package huma
+
+import (
+	"fmt"
+	"mime/multipart"
+	"reflect"
+	"slices"
+)
+
+type MultipartFormFiles[T any] struct {
+	Form *multipart.Form
+	data *T
+}
+
+func (m *MultipartFormFiles[T]) readFile(fh *multipart.FileHeader, location string) (multipart.File, *ErrorDetail) {
+	f, err := fh.Open()
+	if err != nil {
+		return nil, &ErrorDetail{Message: "Failed to open file", Location: location}
+	}
+	return f, nil
+}
+
+func (m *MultipartFormFiles[T]) readSingleFile(key string, schemaForT *Schema) (multipart.File, *ErrorDetail) {
+	fileHeaders := m.Form.File[key]
+	if len(fileHeaders) == 0 {
+		if schemaForT.requiredMap[key] {
+			return nil, &ErrorDetail{Message: "File required", Location: key}
+		} else {
+			return nil, nil
+		}
+	} else if len(fileHeaders) == 1 {
+		return m.readFile(fileHeaders[0], key)
+	}
+	return nil, &ErrorDetail{
+		Message:  "Multiple files received but only one was expected",
+		Location: key,
+	}
+}
+
+func (m *MultipartFormFiles[T]) readMultipleFiles(key string, schemaForT *Schema) ([]multipart.File, []error) {
+	fileHeaders := m.Form.File[key]
+	var (
+		files  = make([]multipart.File, len(fileHeaders))
+		errors []error
+	)
+	if schemaForT.requiredMap[key] && len(fileHeaders) == 0 {
+		return nil, []error{&ErrorDetail{Message: "At least one file is required", Location: key}}
+	}
+	for i, fh := range fileHeaders {
+		file, err := m.readFile(fh, fmt.Sprintf("%s[%d]", key, i))
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+		files = append(files, file)
+	}
+	return files, errors
+}
+
+func (m *MultipartFormFiles[T]) Data() *T {
+	return m.data
+}
+
+// Decodes multipart.Form data into *T, returning []*ErrorDetail if any
+// Schema is used to check for validation constraints
+func (m *MultipartFormFiles[T]) Decode(schemaForT *Schema) []error {
+	var (
+		dataType = reflect.TypeOf(m.data).Elem()
+		value    = reflect.New(dataType)
+		errors   []error
+	)
+	for i := 0; i < dataType.NumField(); i++ {
+		field := value.Elem().Field(i)
+		key := dataType.Field(i).Tag.Get("form-data")
+		if key == "" {
+			continue
+		}
+		switch {
+		case field.Type().String() == "multipart.File":
+			file, err := m.readSingleFile(key, schemaForT)
+			if err != nil {
+				errors = append(errors, err)
+				continue
+			}
+			field.Set(reflect.ValueOf(file))
+		case field.Type().String() == "[]multipart.File":
+			files, errs := m.readMultipleFiles(key, schemaForT)
+			if errs != nil {
+				errors = slices.Concat(errors, errs)
+				continue
+			}
+			field.Set(reflect.ValueOf(files))
+
+		default:
+			continue
+		}
+	}
+	m.data = value.Interface().(*T)
+	return errors
+}
+
+func formDataFieldName(f reflect.StructField) string {
+	name := f.Name
+	if formDataKey := f.Tag.Get("form-data"); formDataKey != "" {
+		name = formDataKey
+	}
+	return name
+}
+
+func multiPartFormFileSchema(t reflect.Type) *Schema {
+	nFields := t.NumField()
+	schema := &Schema{
+		Type:        "object",
+		Properties:  make(map[string]*Schema, nFields),
+		requiredMap: make(map[string]bool, nFields),
+	}
+	requiredFields := make([]string, nFields)
+	for i := 0; i < nFields; i++ {
+		f := t.Field(i)
+		name := formDataFieldName(f)
+
+		switch {
+		case f.Type.String() == "multipart.File":
+			schema.Properties[name] = multiPartFileSchema(f)
+		case f.Type.String() == "[]multipart.File":
+			schema.Properties[name] = &Schema{
+				Type:  "array",
+				Items: multiPartFileSchema(f),
+			}
+		default:
+			// Should we panic if [T] struct defines fields with unsupported types ?
+			continue
+		}
+
+		if _, ok := f.Tag.Lookup("required"); ok && boolTag(f, "required") {
+			requiredFields = append(requiredFields, name)
+			schema.requiredMap[name] = true
+		}
+	}
+	schema.Required = requiredFields
+	return schema
+}
+
+func multiPartFileSchema(f reflect.StructField) *Schema {
+	return &Schema{
+		Type:            "string",
+		Format:          "binary",
+		Description:     f.Tag.Get("doc"),
+		ContentEncoding: "binary",
+	}
+}
+
+func multiPartContentEncoding(t reflect.Type) map[string]*Encoding {
+	nFields := t.NumField()
+	encoding := make(map[string]*Encoding, nFields)
+	for i := 0; i < nFields; i++ {
+		f := t.Field(i)
+		name := formDataFieldName(f)
+		encoding[name] = &Encoding{
+			ContentType: f.Tag.Get("content-type"),
+		}
+	}
+	return encoding
+}

--- a/formdata.go
+++ b/formdata.go
@@ -135,7 +135,7 @@ func (m *MultipartFormFiles[T]) readMultipleFiles(key string, opMediaType *Media
 			errors = append(errors, err)
 			continue
 		}
-		files = append(files, file)
+		files[i] = file
 	}
 	return files, errors
 }

--- a/formdata.go
+++ b/formdata.go
@@ -6,7 +6,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"reflect"
-	"regexp"
 	"slices"
 	"strings"
 )
@@ -20,10 +19,12 @@ type MimeTypeValidator struct {
 	accept []string
 }
 
-var contentTypeSplitRe = regexp.MustCompile(`,\s*`)
-
 func NewMimeTypeValidator(encoding *Encoding) MimeTypeValidator {
-	return MimeTypeValidator{accept: contentTypeSplitRe.Split(encoding.ContentType, -1)}
+	var mimeTypes = strings.Split(encoding.ContentType, ",")
+	for i := range mimeTypes {
+		mimeTypes[i] = strings.Trim(mimeTypes[i], " ")
+	}
+	return MimeTypeValidator{accept: mimeTypes}
 }
 
 func (v MimeTypeValidator) Validate(file multipart.File, location string) *ErrorDetail {

--- a/formdata.go
+++ b/formdata.go
@@ -43,15 +43,15 @@ func (v MimeTypeValidator) Validate(fh *multipart.FileHeader, location string) (
 	if err != nil {
 		return "", &ErrorDetail{Message: "Failed to open file", Location: location}
 	}
-	var buffer = make([]byte, 1000)
-	if _, err := file.Read(buffer); err != nil {
-		return "", &ErrorDetail{Message: "Failed to infer file media type", Location: location}
-	}
-	file.Seek(int64(0), io.SeekStart)
 
 	mimeType := fh.Header.Get("Content-Type")
 	if mimeType == "" {
-		http.DetectContentType(buffer)
+		var buffer = make([]byte, 1000)
+		if _, err := file.Read(buffer); err != nil {
+			return "", &ErrorDetail{Message: "Failed to infer file media type", Location: location}
+		}
+		file.Seek(int64(0), io.SeekStart)
+		mimeType = http.DetectContentType(buffer)
 	}
 	accept := slices.ContainsFunc(v.accept, func(m string) bool {
 		if m == "text/plain" || m == "application/octet-stream" {

--- a/formdata.go
+++ b/formdata.go
@@ -154,9 +154,10 @@ func (m *MultipartFormFiles[T]) Decode(opMediaType *MediaType) []error {
 	)
 	for i := 0; i < dataType.NumField(); i++ {
 		field := value.Elem().Field(i)
-		key := dataType.Field(i).Tag.Get("form")
+		structField := dataType.Field(i)
+		key := structField.Tag.Get("form")
 		if key == "" {
-			continue
+			key = structField.Name
 		}
 		switch {
 		case field.Type() == reflect.TypeOf(FormFile{}):

--- a/huma.go
+++ b/huma.go
@@ -1169,7 +1169,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 						r := f.Addr().
 							MethodByName("Decode").
 							Call([]reflect.Value{
-								reflect.ValueOf(op.RequestBody.Content["multipart/form-data"].Schema),
+								reflect.ValueOf(op.RequestBody.Content["multipart/form-data"]),
 							})
 						errs := r[0].Interface().([]error)
 						if errs != nil {

--- a/huma.go
+++ b/huma.go
@@ -610,6 +610,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 	}
 	rawBodyIndex := -1
 	rawBodyMultipart := false
+	rawBodyDecodedMultipart := false
 	if f, ok := inputType.FieldByName("RawBody"); ok {
 		rawBodyIndex = f.Index[0]
 		if op.RequestBody == nil {
@@ -625,6 +626,10 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 			contentType = "multipart/form-data"
 			rawBodyMultipart = true
 		}
+		if strings.HasPrefix(f.Type.Name(), "MultipartFormFiles") {
+			contentType = "multipart/form-data"
+			rawBodyDecodedMultipart = true
+		}
 
 		if c := f.Tag.Get("contentType"); c != "" {
 			contentType = c
@@ -635,21 +640,34 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 			if op.RequestBody.Content["multipart/form-data"] != nil {
 				break
 			}
-			op.RequestBody.Content["multipart/form-data"] = &MediaType{
-				Schema: &Schema{
-					Type: "object",
-					Properties: map[string]*Schema{
-						"name": {
-							Type:        "string",
-							Description: "general purpose name for multipart form value",
-						},
-						"filename": {
-							Type:        "string",
-							Format:      "binary",
-							Description: "filename of the file being uploaded",
+			if rawBodyMultipart {
+				op.RequestBody.Content["multipart/form-data"] = &MediaType{
+					Schema: &Schema{
+						Type: "object",
+						Properties: map[string]*Schema{
+							"name": {
+								Type:        "string",
+								Description: "general purpose name for multipart form value",
+							},
+							"filename": {
+								Type:        "string",
+								Format:      "binary",
+								Description: "filename of the file being uploaded",
+							},
 						},
 					},
-				},
+				}
+			}
+			if rawBodyDecodedMultipart {
+				dataField, ok := f.Type.FieldByName("data")
+				if !ok {
+					panic("Expected type MultipartFormFiles[T] to have a 'data *T' generic pointer field")
+				}
+				op.RequestBody.Content["multipart/form-data"] = &MediaType{
+					Schema:   multiPartFormFileSchema(dataField.Type.Elem()),
+					Encoding: multiPartContentEncoding(dataField.Type.Elem()),
+				}
+				op.RequestBody.Required = false
 			}
 		default:
 			op.RequestBody.Content[contentType] = &MediaType{
@@ -1135,7 +1153,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 				ctx.SetReadDeadline(time.Time{})
 			}
 
-			if rawBodyMultipart {
+			if rawBodyMultipart || rawBodyDecodedMultipart {
 				form, err := ctx.GetMultipartForm()
 				if err != nil || form == nil {
 					res.Errors = append(res.Errors, &ErrorDetail{
@@ -1144,7 +1162,21 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 					})
 				} else {
 					f := v.Field(rawBodyIndex)
-					f.Set(reflect.ValueOf(*form))
+					if rawBodyMultipart {
+						f.Set(reflect.ValueOf(*form))
+					} else {
+						f.FieldByName("Form").Set(reflect.ValueOf(form))
+						r := f.Addr().
+							MethodByName("Decode").
+							Call([]reflect.Value{
+								reflect.ValueOf(op.RequestBody.Content["multipart/form-data"].Schema),
+							})
+						errs := r[0].Interface().([]error)
+						if errs != nil {
+							WriteErr(api, ctx, http.StatusUnprocessableEntity, "validation failed", errs...)
+							return
+						}
+					}
 				}
 			} else {
 				buf := bufPool.Get().(*bytes.Buffer)

--- a/huma.go
+++ b/huma.go
@@ -632,6 +632,9 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 
 		switch contentType {
 		case "multipart/form-data":
+			if op.RequestBody.Content["multipart/form-data"] != nil {
+				break
+			}
 			op.RequestBody.Content["multipart/form-data"] = &MediaType{
 				Schema: &Schema{
 					Type: "object",

--- a/huma_test.go
+++ b/huma_test.go
@@ -742,17 +742,24 @@ func TestFeatures(t *testing.T) {
 					Path:   "/upload",
 				}, func(ctx context.Context, input *struct {
 					RawBody huma.MultipartFormFiles[struct {
-						HelloWorld multipart.File   `form:"file" contentType:"text/plain"`
-						Greetings  []multipart.File `form:"greetings" contentType:"text/plain"`
+						HelloWorld huma.FormFile   `form:"file" contentType:"text/plain"`
+						Greetings  []huma.FormFile `form:"greetings" contentType:"text/plain"`
 					}]
 				}) (*struct{}, error) {
 					fileData := input.RawBody.Data()
+
+					assert.Equal(t, "text/plain", fileData.HelloWorld.ContentType)
+					assert.True(t, fileData.HelloWorld.IsSet)
+
 					b, err := io.ReadAll(fileData.HelloWorld)
 					require.NoError(t, err)
 					assert.Equal(t, "Hello, World!", string(b))
 
 					expected := []string{"Hello", "World"}
 					for i, f := range fileData.Greetings {
+						assert.Equal(t, "text/plain", f.ContentType)
+						assert.True(t, f.IsSet)
+
 						b, err := io.ReadAll(f)
 						require.NoError(t, err)
 						assert.Equal(t, expected[i], string(b))
@@ -798,8 +805,8 @@ World
 					Path:   "/upload",
 				}, func(ctx context.Context, input *struct {
 					RawBody huma.MultipartFormFiles[struct {
-						HelloWorld multipart.File   `form:"file" contentType:"text/plain" required:"true"`
-						Sentences  []multipart.File `form:"greetings" contentType:"text/plain" required:"true"`
+						HelloWorld huma.FormFile   `form:"file" contentType:"text/plain" required:"true"`
+						Sentences  []huma.FormFile `form:"greetings" contentType:"text/plain" required:"true"`
 					}]
 				}) (*struct{}, error) {
 					return nil, nil

--- a/huma_test.go
+++ b/huma_test.go
@@ -841,11 +841,15 @@ Content-Type: text/plain
 Hello, World!
 --SimpleBoundary--`,
 			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
-				var errors huma.ErrorModel
-				err := json.Unmarshal(resp.Body.Bytes(), &errors)
-				require.NoError(t, err)
-				assert.Equal(t, "file", errors.Errors[0].Location)
-				assert.Equal(t, "greetings", errors.Errors[1].Location)
+				if ok := assert.Equal(t, http.StatusUnprocessableEntity, resp.Code); ok {
+					var errors huma.ErrorModel
+					err := json.Unmarshal(resp.Body.Bytes(), &errors)
+					require.NoError(t, err)
+					assert.Equal(t, "file", errors.Errors[0].Location)
+					assert.Equal(t, "greetings", errors.Errors[1].Location)
+				}
+			},
+		},
 				assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 			},
 		},


### PR DESCRIPTION
This PR aims to improve the handling of `multipart/form-data` requests by: 

- 3570bf1 allowing users to document the request body at the level of operations, which is currently not possible since it is overwritten by huma when `RawBody` is `multipart.FormData`. The [generated schema](https://github.com/danielgtaylor/huma/blob/ed2c3cd81698cb5728a49c7cfa267f23c392f644/huma.go#L633) is more of an example and does not reflect the actual form data structure, which should be specified by the user.
- d6eb219 implementing `MultipartFormFiles`, which can be used to type `RawBody` in request inputs and provides logic for decoding and validating files from a `multipart/form-data` request as `multipart.File` values, as well as generating the associated schema in the spec. Although this could be extended to support data types other than files, it would require significant refactoring to reuse some of the logic from body/query/path/header parameters decoding, and I was not confident enough to engage into it.
- 01ca953 implementing mimetype validation for submitted files

There is currently no automated tests for this PR, I would like to first get some feedback before spending more time on this (and still have to get familiar with `humatest`).

Example usage: 
```go
type FileData struct {
        // This is an example, any number of `multipart.File` fields can be defined.
        // Nested structs are not supported.
	SomeFile multipart.File   `form-data:"some_file" content-type:"image/png" required:"true"`
	SeveralFiles []multipart.File `form-data:"several_files" content-type:"image/png,image/jpeg" required:"true"`
}

type FileHandlerInput struct {
	RawBody huma.MultipartFormFiles[FileData]
}

func FileHandler(ctx context.Context, input *FileHandlerInput) (*struct{}, error) {
  fileData := input.RawBody.Data()
  DoSomeThingWith(fileData.SomeFile)
  OrSomethingElseWith(fileData.SeveralFiles)
}

huma.Register(api,
  huma.Operation{
	  Path:             "/handle-files",
	  Method:        http.MethodPost,
	  OperationID:     "Handle files",
  }, FileHandler)
```

When using `MultipartFormFiles[T]`, only the fields in `T` that implement `multipart.File` or `[]multipart.File` are considered when generating the spec or resolving a request. The raw form data can be accessed at `MultipartFormFiles.Form` which is a `multipart.Form`.

`form-data` tag specifies the lookup key to retrieve the encoded file in the `multipart.Form`. In its absence, the name of the field is used instead. 
`content-type` specifies the acceptable mime types for a file. It is used to document the endpoint in the spec, and validate file format using [`http.DetectContentType`](https://pkg.go.dev/net/http#DetectContentType) 
`required` makes the field required. In the case of `[]multipart.File`, validation checks that at least one file was submitted.

Generated operation spec : 
```json
{
  "/handle-files": {
    "post": {
      "operationId": "HandleFiles",
      "requestBody": {
        "content": {
          "multipart/form-data": {
            "encoding": {
              "some_file": {
                "contentType": "image/png"
              },
              "several_files": {
                "contentType": "image/png,image/jpeg"
              }
            },
            "schema": {
              "properties": {
                "some_file": {
                  "format": "binary",
                  "type": "string"
                },
                "several_files": {
                  "items": {
                    "format": "binary",
                    "type": "string"
                  },
                  "type": "array"
                }
              },
              "required": [
                "some_file",
                "several_files"
              ],
              "type": "object"
            }
          }
        }
      }
    }
  }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality for handling multipart form data in HTTP requests.
  - Added support for validating MIME types in uploaded files.
  - Enhanced the ability to read and decode form data, including single and multiple file uploads.

- **Tests**
  - Added multiple test cases to ensure robust handling of multipart form data, including validation, error handling, and content type detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->