### PR TITLE
Allow providing name hints using tags for anonymous body structs

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -582,8 +582,11 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 			if c := f.Tag.Get("contentType"); c != "" {
 				contentType = c
 			}
-
-			s := SchemaFromField(registry, f, getHint(inputType, f.Name, op.OperationID+"Request"))
+			hint := getHint(inputType, f.Name, op.OperationID+"Request")
+			if nameHint := f.Tag.Get("nameHint"); nameHint != "" {
+				hint = nameHint
+			}
+			s := SchemaFromField(registry, f, hint)
 
 			op.RequestBody = &RequestBody{
 				Required: required,
@@ -708,7 +711,11 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 			op.Responses[statusStr].Headers = map[string]*Param{}
 		}
 		if !outBodyFunc {
-			outSchema := SchemaFromField(registry, f, getHint(outputType, f.Name, op.OperationID+"Response"))
+			hint := getHint(outputType, f.Name, op.OperationID+"Response")
+			if nameHint := f.Tag.Get("nameHint"); nameHint != "" {
+				hint = nameHint
+			}
+			outSchema := SchemaFromField(registry, f, hint)
 			if op.Responses[statusStr].Content == nil {
 				op.Responses[statusStr].Content = map[string]*MediaType{}
 			}

--- a/huma_test.go
+++ b/huma_test.go
@@ -618,14 +618,7 @@ func TestFeatures(t *testing.T) {
 				}) (*struct{}, error) {
 					return nil, nil
 				})
-
-				registry := api.OpenAPI().Components.Schemas
-				origType := registry.TypeFromRef(
-					api.OpenAPI().Paths["/body"].Put.RequestBody.Content["application/json"].Schema.Ref,
-				)
-				assert.Equal(t, "ANameHint",
-					huma.DefaultSchemaNamer(origType, "ANameHint"),
-				)
+				assert.Equal(t, "#/components/schemas/ANameHint", api.OpenAPI().Paths["/body"].Put.RequestBody.Content["application/json"].Schema.Ref)
 			},
 			Method: http.MethodPut,
 			URL:    "/body",
@@ -1051,14 +1044,7 @@ Content of example2.txt.
 					resp.Body.Greeting = "Hello, world!"
 					return resp, nil
 				})
-
-				registry := api.OpenAPI().Components.Schemas
-				origType := registry.TypeFromRef(
-					api.OpenAPI().Paths["/response"].Get.Responses["200"].Content["application/json"].Schema.Ref,
-				)
-				assert.Equal(t, "GreetingResp",
-					huma.DefaultSchemaNamer(origType, "GreetingResp"),
-				)
+				assert.Equal(t, "#/components/schemas/GreetingResp", api.OpenAPI().Paths["/response"].Get.Responses["200"].Content["application/json"].Schema.Ref)
 			},
 			Method: http.MethodGet,
 			URL:    "/response",


### PR DESCRIPTION
Small change introducing the possibility to provide name hints for request/response body through struct tags. Previously discussed in #322

Example: 
```go
type EndpointInput struct {
  Body struct {
    SomeData string `json:"some_data"`
  } `name-hint:"SomeName"`
}
```

Because it defines a name hint, it only applies to anonymous types. We could go further and allow overriding the name altogether but that would involve changing the schema namer interface (`func (t reflect.Type, hint string) string`) to include one more parameter, which might break backward compatibility.