### PR TITLE
fix: more robust nil check for link transformer

### DIFF
--- a/huma_test.go
+++ b/huma_test.go
@@ -1115,6 +1115,30 @@ Content of example2.txt.
 			},
 		},
 		{
+			Name: "response-transform-nil-body",
+			Transformers: []huma.Transformer{
+				huma.NewSchemaLinkTransformer("/", "/").Transform,
+			},
+			Register: func(t *testing.T, api huma.API) {
+				huma.Get(api, "/transform", func(ctx context.Context, i *struct{}) (*struct {
+					Body *struct {
+						Field string `json:"field"`
+					}
+				}, error) {
+					return &struct {
+						Body *struct {
+							Field string `json:"field"`
+						}
+					}{}, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/transform",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code)
+			},
+		},
+		{
 			Name: "response-transform-error",
 			Transformers: []huma.Transformer{
 				func(ctx huma.Context, status string, v any) (any, error) {

--- a/transforms.go
+++ b/transforms.go
@@ -150,7 +150,8 @@ func (t *SchemaLinkTransformer) OnAddOperation(oapi *OpenAPI, op *Operation) {
 // Transform is called for every response to add the `$schema` field and/or
 // the Link header pointing to the JSON Schema.
 func (t *SchemaLinkTransformer) Transform(ctx Context, status string, v any) (any, error) {
-	if v == nil {
+	vv := reflect.ValueOf(v)
+	if vv.Kind() == reflect.Pointer && vv.IsNil() {
 		return v, nil
 	}
 
@@ -184,7 +185,7 @@ func (t *SchemaLinkTransformer) Transform(ctx Context, status string, v any) (an
 	bufPool.Put(buf)
 
 	// Copy over all the exported fields.
-	vv := reflect.Indirect(reflect.ValueOf(v))
+	vv = reflect.Indirect(vv)
 	for i, j := range info.fields {
 		// Field 0 is the $schema field, so we need to offset the index by one.
 		// There might have been unexported fields in the struct declared in the schema,


### PR DESCRIPTION
This uses reflection to check for nil which is more robust and can prevent a panic/500 error from happening if the operation returns successful with a nil body.