### PR TITLE
Add contentMediaType field to generated schema when format is binary

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -154,12 +154,17 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 	if s.Nullable {
 		typ = []string{s.Type, "null"}
 	}
+	var contentMediaType string
+	if s.Format == "binary" {
+		contentMediaType = "application/octet-stream"
+	}
 	return marshalJSON([]jsonFieldInfo{
 		{"type", typ, omitEmpty},
 		{"title", s.Title, omitEmpty},
 		{"description", s.Description, omitEmpty},
 		{"$ref", s.Ref, omitEmpty},
 		{"format", s.Format, omitEmpty},
+		{"contentMediaType", contentMediaType, omitEmpty},
 		{"contentEncoding", s.ContentEncoding, omitEmpty},
 		{"default", s.Default, omitNil},
 		{"examples", s.Examples, omitEmpty},


### PR DESCRIPTION
This PR adds the `contentMediaType` property to the generated schema spec for binary field. This is mainly for the purpose of compatibility with API documentation tools such as Stoplight Elements (see #397).

Note that #415 sets `contentType` property in the schema, but that is not sufficient for Stoplight to show the file upload UI component, event though the [OpenAPI spec](https://spec.openapis.org/oas/v3.1.0#considerations-for-file-uploads) says `contentMediaType` is not required when `contentType` is defined. 
Although that may rather be an issue in Stoplight, in my understanding it does not hurt to add this redundancy to Huma.

Thus, this PR can be considered independently from #415. I hope I'm not mistaken about what the OpenAPI specs say, let me know if you think this rather belongs to Stoplight issues.

Example schema: 

```json
{
  "requestBody": {
	"content": {
		"multipart/form-data": {
			"schema": {
				"properties": {
					"filename": {
						"contentMediaType": "application/octet-stream",
						"description": "filename of the file being uploaded",
						"format": "binary",
						"type": "string"
					},
					"name": {
						"description": "general purpose name for multipart form value",
						"type": "string"
					}
				},
				"type": "object"
			}
		}
	},
	"required": true
}
```

Sample UI screenshot: 
![image](https://github.com/danielgtaylor/huma/assets/17616580/6f765eeb-29ba-4817-9fa1-54c1972710e9)

