### PR TITLE
feat!: drop chi v4 adapter

### DIFF
--- a/adapters/adapters_test.go
+++ b/adapters/adapters_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/danielgtaylor/huma/v2/adapters/humamux"
 	"github.com/danielgtaylor/huma/v2/humatest"
 	"github.com/gin-gonic/gin"
-	chi4 "github.com/go-chi/chi"
 	"github.com/go-chi/chi/v5"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gorilla/mux"
@@ -96,7 +95,6 @@ func TestAdapters(t *testing.T) {
 		new  func() huma.API
 	}{
 		{"chi", func() huma.API { return humachi.New(chi.NewMux(), config()) }},
-		{"chi4", func() huma.API { return humachi.NewV4(chi4.NewMux(), config()) }},
 		{"echo", func() huma.API { return humaecho.New(echo.New(), config()) }},
 		{"fiber", func() huma.API { return humafiber.New(fiber.New(), config()) }},
 		{"gin", func() huma.API { return humagin.New(gin.New(), config()) }},

--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/queryparam"
-	chiV4 "github.com/go-chi/chi"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -22,7 +21,6 @@ type chiContext struct {
 	op     *huma.Operation
 	r      *http.Request
 	w      http.ResponseWriter
-	v4     bool
 	status int
 }
 
@@ -50,11 +48,8 @@ func (c *chiContext) URL() url.URL {
 }
 
 func (c *chiContext) Param(name string) string {
-	if !c.v4 {
-		return chi.URLParam(c.r, name)
-	}
-
-	return chiV4.URLParam(c.r, name)
+	// TODO: switch to c.r.PathValue when go.mod requires go >= 1.22
+	return chi.URLParam(c.r, name)
 }
 
 func (c *chiContext) Query(name string) string {
@@ -134,23 +129,4 @@ func NewAdapter(r chi.Router) huma.Adapter {
 // New creates a new Huma API using the latest v5.x.x version of Chi.
 func New(r chi.Router, config huma.Config) huma.API {
 	return huma.NewAPI(config, &chiAdapter{router: r})
-}
-
-type chiAdapterV4 struct {
-	router chiV4.Router
-}
-
-func (a *chiAdapterV4) Handle(op *huma.Operation, handler func(huma.Context)) {
-	a.router.MethodFunc(op.Method, op.Path, func(w http.ResponseWriter, r *http.Request) {
-		handler(&chiContext{op: op, r: r, w: w, v4: true})
-	})
-}
-
-func (a *chiAdapterV4) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	a.router.ServeHTTP(w, r)
-}
-
-// NewV4 creates a new Huma API using the older v4.x.x version of Chi.
-func NewV4(r chiV4.Router, config huma.Config) huma.API {
-	return huma.NewAPI(config, &chiAdapterV4{router: r})
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.0
 	github.com/fxamacker/cbor/v2 v2.6.0
 	github.com/gin-gonic/gin v1.9.1
-	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/gofiber/fiber/v2 v2.52.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.9.1 h1:4idEAncQnU5cB7BeOkPtxjfCSye0AAm1R0RVIqJ+Jmg=
 github.com/gin-gonic/gin v1.9.1/go.mod h1:hPrL7YrpYKXt5YId3A/Tnip5kqbEAP+KLuI3SUcPTeU=
-github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
-github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
 github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=


### PR DESCRIPTION
V4 has been deprecated for 7 months since [da7ce946](https://github.com/go-chi/chi/commit/da7ce9468546b9c352b0c7eac3580961543d0d96)

We could also split it into a different package, but IMHO the maintenance overhead doesn't seem worth it for a deprecated version. People can still maintain separate adapter, since there are no huma-internal dependencies. 

Fixes #423