### PR TITLE
fix: unmarshaling of request body when using struct embedding

### DIFF
--- a/huma_test.go
+++ b/huma_test.go
@@ -60,6 +60,13 @@ func (UUID) Schema(r huma.Registry) *huma.Schema {
 	return &huma.Schema{Type: huma.TypeString, Format: "uuid"}
 }
 
+// BodyContainer is an embed request body struct to test request body unmarshalling
+type BodyContainer struct {
+	Body struct {
+		Name string `json:"name"`
+	}
+}
+
 func TestFeatures(t *testing.T) {
 	for _, feature := range []struct {
 		Name         string
@@ -621,6 +628,23 @@ func TestFeatures(t *testing.T) {
 				assert.Equal(t, "#/components/schemas/ANameHint", api.OpenAPI().Paths["/body"].Put.RequestBody.Content["application/json"].Schema.Ref)
 			},
 			Method: http.MethodPut,
+			URL:    "/body",
+			Body:   `{"name": "Name"}`,
+		},
+		{
+			Name: "request-body-embed-struct",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPost,
+					Path:   "/body",
+				}, func(ctx context.Context, input *struct {
+					BodyContainer
+				}) (*struct{}, error) {
+					assert.Equal(t, "Name", input.Body.Name)
+					return nil, nil
+				})
+			},
+			Method: http.MethodPost,
 			URL:    "/body",
 			Body:   `{"name": "Name"}`,
 		},


### PR DESCRIPTION
Stumbled on this bug while trying to refactor some handler inputs. When the request `Body` is defined within an embedded struct, unmarshaling of the request body does not work as expected, because the field is retrieved by index which points to the embedded struct, not its `Body` content. 

Small example to illustrate the issue : 
```go
type BodyContainer struct {
  Body struct {
    Name string `json:"name"`
 }
}

type HandlerInput struct {
  BodyContainer
}

func Handler(ctx context.Context, input HandlerInput) (*struct{}, error) {
  fmt.Printf("%+v", input.Body) // Name is empty string even when it is not in the JSON payload
  return nil, nil
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of input body validation and conversion.

- **Tests**
  - Enhanced test cases for request body unmarshalling with a new `BodyContainer` struct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->