### PR TITLE
feat: allow toggling additional properties from request body struct tag

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -587,6 +587,12 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 				hint = nameHint
 			}
 			s := SchemaFromField(registry, f, hint)
+			if _, ok = f.Tag.Lookup("additionalProperties"); ok {
+				if s.Ref != "" {
+					s = registry.SchemaFromRef(s.Ref)
+				}
+				s.AdditionalProperties = boolTag(f, "additionalProperties")
+			}
 
 			op.RequestBody = &RequestBody{
 				Required: required,

--- a/huma_test.go
+++ b/huma_test.go
@@ -625,6 +625,27 @@ func TestFeatures(t *testing.T) {
 			Body:   `{"name": "Name"}`,
 		},
 		{
+			Name: "request-body-additionalProperties",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPost,
+					Path:   "/body",
+				}, func(ctx context.Context, input *struct {
+					Body struct {
+						Name string `json:"name"`
+					} `additionalProperties:"true"`
+				}) (*struct{}, error) {
+					return nil, nil
+				})
+			},
+			Method: http.MethodPost,
+			URL:    "/body",
+			Body:   `{"name": "Name", "someAdditionalProp": 3.1415}`,
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusNoContent, resp.Code)
+			},
+		},
+		{
 			Name: "request-ptr-body-required",
 			Register: func(t *testing.T, api huma.API) {
 				huma.Register(api, huma.Operation{


### PR DESCRIPTION
This is a small QoL improvement that allows toggling the `additionalProperties` attribute on a request body, without having to modify the body struct type. 

Usage : 
```go
type HandlerInput struct {
  Body SomeInputType `additionalProperties:"true"`
}
```