### PR TITLE
feat: add request remote address to context

### DIFF
--- a/adapters/humabunrouter/humabunrouter.go
+++ b/adapters/humabunrouter/humabunrouter.go
@@ -45,6 +45,10 @@ func (c *bunContext) Host() string {
 	return c.r.Host
 }
 
+func (c *bunContext) RemoteAddr() string {
+	return c.r.RemoteAddr
+}
+
 func (c *bunContext) URL() url.URL {
 	return *c.r.URL
 }
@@ -129,6 +133,10 @@ func (c *bunCompatContext) Method() string {
 
 func (c *bunCompatContext) Host() string {
 	return c.r.Host
+}
+
+func (c *bunCompatContext) RemoteAddr() string {
+	return c.r.RemoteAddr
 }
 
 func (c *bunCompatContext) URL() url.URL {

--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -43,6 +43,10 @@ func (c *chiContext) Host() string {
 	return c.r.Host
 }
 
+func (c *chiContext) RemoteAddr() string {
+	return c.r.RemoteAddr
+}
+
 func (c *chiContext) URL() url.URL {
 	return *c.r.URL
 }

--- a/adapters/humaecho/humaecho.go
+++ b/adapters/humaecho/humaecho.go
@@ -42,6 +42,10 @@ func (c *echoCtx) Host() string {
 	return c.orig.Request().Host
 }
 
+func (c *echoCtx) RemoteAddr() string {
+	return c.orig.Request().RemoteAddr
+}
+
 func (c *echoCtx) URL() url.URL {
 	return *c.orig.Request().URL
 }

--- a/adapters/humafiber/humafiber.go
+++ b/adapters/humafiber/humafiber.go
@@ -43,6 +43,10 @@ func (c *fiberCtx) Host() string {
 	return c.orig.Hostname()
 }
 
+func (c *fiberCtx) RemoteAddr() string {
+	return c.orig.Context().RemoteAddr().String()
+}
+
 func (c *fiberCtx) URL() url.URL {
 	u, _ := url.Parse(string(c.orig.Request().RequestURI()))
 	return *u

--- a/adapters/humaflow/humaflow.go
+++ b/adapters/humaflow/humaflow.go
@@ -41,6 +41,10 @@ func (c *goContext) Host() string {
 	return c.r.Host
 }
 
+func (c *goContext) RemoteAddr() string {
+	return c.r.RemoteAddr
+}
+
 func (c *goContext) URL() url.URL {
 	return *c.r.URL
 }

--- a/adapters/humagin/humagin.go
+++ b/adapters/humagin/humagin.go
@@ -42,6 +42,10 @@ func (c *ginCtx) Host() string {
 	return c.orig.Request.Host
 }
 
+func (c *ginCtx) RemoteAddr() string {
+	return c.orig.Request.RemoteAddr
+}
+
 func (c *ginCtx) URL() url.URL {
 	return *c.orig.Request.URL
 }

--- a/adapters/humago/humago.go
+++ b/adapters/humago/humago.go
@@ -43,6 +43,10 @@ func (c *goContext) Host() string {
 	return c.r.Host
 }
 
+func (c *goContext) RemoteAddr() string {
+	return c.r.RemoteAddr
+}
+
 func (c *goContext) URL() url.URL {
 	return *c.r.URL
 }

--- a/adapters/humahttprouter/humahttprouter.go
+++ b/adapters/humahttprouter/humahttprouter.go
@@ -45,6 +45,10 @@ func (c *httprouterContext) Host() string {
 	return c.r.Host
 }
 
+func (c *httprouterContext) RemoteAddr() string {
+	return c.r.RemoteAddr
+}
+
 func (c *httprouterContext) URL() url.URL {
 	return *c.r.URL
 }

--- a/adapters/humamux/humamux.go
+++ b/adapters/humamux/humamux.go
@@ -43,6 +43,10 @@ func (c *gmuxContext) Host() string {
 	return c.r.Host
 }
 
+func (c *gmuxContext) RemoteAddr() string {
+	return c.r.RemoteAddr
+}
+
 func (c *gmuxContext) URL() url.URL {
 	return *c.r.URL
 }

--- a/api.go
+++ b/api.go
@@ -72,6 +72,9 @@ type Context interface {
 	// Host returns the HTTP host for the request.
 	Host() string
 
+	// RemoteAddr returns the remote address of the client.
+	RemoteAddr() string
+
 	// URL returns the full URL for the request.
 	URL() url.URL
 


### PR DESCRIPTION
Based on several user requests, this adds access to the remote address from the client request to the Huma context so you can use it in middleware and resolvers.

Fixes #445.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve the remote address of the client in various context structs across multiple adapters.
  - Introduced a new `RemoteAddr()` method to the `Context` interface, enhancing the ability to access the client's remote address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->