### PR TITLE
Fix typo in SSE doc

### DIFF
--- a/docs/docs/features/server-sent-events-sse.md
+++ b/docs/docs/features/server-sent-events-sse.md
@@ -25,7 +25,7 @@ sse.Register(api, huma.Operation{
 	// Mapping of event type name to Go struct for that event.
 	"message":      DefaultMessage{},
 	"userCreate":   UserCreatedEvent{},
-	"mailRecieved": MailReceivedEvent{},
+	"mailReceived": MailReceivedEvent{},
 }, func(ctx context.Context, input *struct{}, send sse.Sender) {
 	// Send an event every second for 10 seconds.
 	for x := 0; x < 10; x++ {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the event type name from "mailRecieved" to "mailReceived" in the Server-Sent Events documentation for improved accuracy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->