### PR TITLE
fix: type schema description not work

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -488,7 +488,9 @@ func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Sch
 	if fs == nil {
 		return fs
 	}
-	fs.Description = f.Tag.Get("doc")
+	if doc := f.Tag.Get("doc"); doc != "" {
+		fs.Description = doc
+	}
 	if fs.Format == "date-time" && f.Tag.Get("header") != "" {
 		// Special case: this is a header and uses a different date/time format.
 		// Note that it can still be overridden by the `format` or `timeFormat`


### PR DESCRIPTION
```go
type LockType uint

func (*LockType) Schema(r huma.Registry) *huma.Schema {
	schema := huma.SchemaFromType(r, reflect.TypeOf(0))
	schema.Enum = []any{NFC, Bluetooth}
	schema.Description = "description"
	return schema
}

```