### PR TITLE
fix: schema enum validation

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -487,8 +487,9 @@ func Validate(r Registry, s *Schema, path *PathBuffer, mode ValidateMode, v any,
 
 	if len(s.Enum) > 0 {
 		found := false
+		vs := fmt.Sprint(v)
 		for _, e := range s.Enum {
-			if e == v {
+			if fmt.Sprint(e) == vs {
 				found = true
 				break
 			}


### PR DESCRIPTION
```go
type LockType uint

const (
	NFC LockType = iota + 1
	Bluetooth
)

func (*LockType) Schema(r huma.Registry) *huma.Schema {
	schema := huma.SchemaFromType(r, reflect.TypeOf(0))
	schema.Enum = []any{NFC, Bluetooth}
	return schema
}
```

```json
{
  "title": "Unprocessable Entity",
  "status": 422,
  "detail": "validation failed",
  "errors": [
    {
      "message": "expected value to be one of \"1, 2\"",
      "location": "body.type",
      "value": 1
    }
  ]
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation logic to ensure correct comparison of enum values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->