### PR TITLE
Update min Go version for tutorial

### DIFF
--- a/docs/docs/tutorial/installation.md
+++ b/docs/docs/tutorial/installation.md
@@ -6,7 +6,7 @@ description: Learn how to install Huma and create your first API.
 
 ## Prerequisites
 
-Huma requires [Go 1.20 or newer](https://go.dev/dl/), so install that first. You'll also want some kind of [text editor or IDE](https://code.visualstudio.com/) to write code and a terminal to run commands.
+Huma requires [Go 1.22 or newer](https://go.dev/dl/), so install that first. You'll also want some kind of [text editor or IDE](https://code.visualstudio.com/) to write code and a terminal to run commands.
 
 ## Project Setup
 


### PR DESCRIPTION
With Go < 1.22 I get this error when running the tutorial:

```
../../go/pkg/mod/github.com/danielgtaylor/huma/v2@v2.18.0/formdata.go:173:21:

undefined: slices.Concat
```
I think slices.Concat is new in 1.22. With 1.22.4 the tutorial works fine.

I am a tech writer by day, using Go at night to write tests of the docs that I write. I could be completely wrong about the need for 1.22, but here is my reference: https://blog.carlana.net/post/2024/golang-slices-concat/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the required version of Go for Huma from 1.20 to 1.22 in the installation tutorial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->