### PR TITLE
fix(schema): proper array minItems, maxItems and doc reporting in generated schemas

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -71,6 +71,11 @@ func (r *mapRegistry) Schema(t reflect.Type, allowRef bool, hint string) *Schema
 	origType := t
 	t = deref(t)
 
+	// Pointer to array should decay to array
+	if t.Kind() == reflect.Array || t.Kind() == reflect.Slice {
+		origType = t
+	}
+
 	alias, ok := r.aliases[t]
 	if ok {
 		return r.Schema(alias, allowRef, hint)

--- a/schema.go
+++ b/schema.go
@@ -559,8 +559,12 @@ func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Sch
 	fs.MaxLength = intTag(f, "maxLength")
 	fs.Pattern = f.Tag.Get("pattern")
 	fs.PatternDescription = f.Tag.Get("patternDescription")
-	fs.MinItems = intTag(f, "minItems")
-	fs.MaxItems = intTag(f, "maxItems")
+	if _, ok := f.Tag.Lookup("minItems"); ok {
+		fs.MinItems = intTag(f, "minItems")
+	}
+	if _, ok := f.Tag.Lookup("maxItems"); ok {
+		fs.MaxItems = intTag(f, "maxItems")
+	}
 	fs.UniqueItems = boolTag(f, "uniqueItems")
 	fs.MinProperties = intTag(f, "minProperties")
 	fs.MaxProperties = intTag(f, "maxProperties")


### PR DESCRIPTION
Hi!

We have a use case that can be summarised by:
```golang
// sRGB color space, normalized : R,G,B,A
type Color4f [4]float64

func (c Color4f) TransformSchema(r huma.Registry, s *huma.Schema) *huma.Schema {
	s.Description = "RGBA floating point color such as semi-transparent white is [1.0,1.0,1.0,0.5]"
	return s
}

type RequestParams struct {
	OptionalColor           *Color4f     `json:"optionalColor,omitempty"`
	RequiredColor          Color4f       `json:"requiredColor"`
}

```

Expected schema:
``` json
    "RequestParams": {
        "additionalProperties": false,
        "properties": {
          "optionalColor": {
            "description": "RGBA floating point color such as semi-transparent white is [1.0,1.0,1.0,0.5]",
            "items": {
              "format": "double",
              "type": "number"
            },
            "maxItems": 4,
            "minItems": 4,
            "type": "array"
          },
          "requiredColor": {
            "description": "RGBA floating point color such as semi-transparent white is [1.0,1.0,1.0,0.5]",
            "items": {
              "format": "double",
              "type": "number"
            },
            "maxItems": 4,
            "minItems": 4,
            "type": "array"
          }
        },
        "required": [
          "requiredColor"
        ],
        "type": "object"
      }
```
Actual schema:
```json
     "RequestParams": {
        "additionalProperties": false,
        "properties": {
          "optionalColor": {
            "items": {
              "format": "double",
              "type": "number"
            },
            "type": "array"
          },
          "requiredColor": {
            "description": "RGBA floating point color such as semi-transparent white is [1.0,1.0,1.0,0.5]",
            "items": {
              "format": "double",
              "type": "number"
            },
            "type": "array"
          }
        },
        "required": [
          "requiredColor"
        ],
        "type": "object"
      }
```

We're currently missing the minItems and maxItems for both fields and the custom description is missing if the field is a pointer to the Color4f type.

This PR try to address this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved schema processing to handle pointers to arrays more efficiently.
	- Enhanced schema generation to support `minItems` and `maxItems` tags for better validation.

- **Tests**
	- Added tests for custom arrays and pointer arrays with descriptions to ensure robust schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->