### PR TITLE
Make huma play well with custom error types returned from handlers

### DIFF
--- a/error.go
+++ b/error.go
@@ -248,6 +248,43 @@ var NewError = func(status int, msg string, errs ...error) StatusError {
 	}
 }
 
+// HandleTypedError dynamically creates an HTTP error response based on the type of the provided error.
+// This allows API implementers to customize the HTTP error response according to different error types
+// handled by the application.
+//
+// Usage example:
+//
+//	type NotFoundError struct {
+//		Resource string
+//	}
+//
+//	func (e *NotFoundError) Error() string {
+//		return fmt.Sprintf("Resource '%s' not found", e.Resource)
+//	}
+//
+//	type ValidationError struct {
+//		Field   string
+//		Message string
+//	}
+//
+//	func (e *ValidationError) Error() string {
+//		return fmt.Sprintf("Validation failed on '%s': %s", e.Field, e.Message)
+//	}
+//
+//	NewTypedError = func(err error) StatusError {
+//		switch e := err.(type) {
+//		case *NotFoundError:
+//			return NewError(http.StatusNotFound, e.Error())
+//		case *ValidationError:
+//			return NewError(http.StatusBadRequest, e.Error())
+//		default:
+//			return NewError(http.StatusInternalServerError, "An unexpected error has occurred")
+//		}
+//	}
+var HandleTypedError = func(err error) StatusError {
+	return NewError(http.StatusInternalServerError, err.Error())
+}
+
 // WriteErr writes an error response with the given context, using the
 // configured error type and with the given status code and message. It is
 // marshaled using the API's content negotiation methods.

--- a/huma.go
+++ b/huma.go
@@ -1341,7 +1341,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 				status = se.GetStatus()
 				err = se
 			} else {
-				err = NewError(http.StatusInternalServerError, err.Error())
+				err = HandleTypedError(err)
 			}
 
 			ct, _ := api.Negotiate(ctx.Header("Accept"))


### PR DESCRIPTION
Allow use of custom handling when custom errors are returned from handlers.

Closes: https://github.com/danielgtaylor/huma/issues/482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved error handling with the new `HandleTypedError` function for dynamic HTTP error responses.
  - Introduced a `NotFoundError` type for custom error messages in resource not found scenarios.

- **Bug Fixes**
  - Updated `Register` function to delegate error handling to the `HandleTypedError` function, ensuring consistent and descriptive error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->