### PR TITLE
fix(schema): proper minLength, maxLength in generated schemas.

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -555,8 +555,13 @@ func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Sch
 	fs.Maximum = floatTag(f, "maximum")
 	fs.ExclusiveMaximum = floatTag(f, "exclusiveMaximum")
 	fs.MultipleOf = floatTag(f, "multipleOf")
-	fs.MinLength = intTag(f, "minLength")
-	fs.MaxLength = intTag(f, "maxLength")
+	if _, ok := f.Tag.Lookup("minLength"); ok {
+		fs.MinLength = intTag(f, "minLength")
+	}
+
+	if _, ok := f.Tag.Lookup("maxLength"); ok {
+		fs.MaxLength = intTag(f, "maxLength")
+	}
 	fs.Pattern = f.Tag.Get("pattern")
 	fs.PatternDescription = f.Tag.Get("patternDescription")
 	if _, ok := f.Tag.Lookup("minItems"); ok {

--- a/schema_test.go
+++ b/schema_test.go
@@ -73,6 +73,17 @@ func (t *TypedArrayWithCustomDesc) TransformSchema(r huma.Registry, s *huma.Sche
 	return s
 }
 
+type TypedStringWithCustomLength struct{}
+
+func (c TypedStringWithCustomLength) Schema(r huma.Registry) *huma.Schema {
+	min, max := 1, 10
+	return &huma.Schema{
+		Type:      "string",
+		MinLength: &min,
+		MaxLength: &max,
+	}
+}
+
 func TestSchema(t *testing.T) {
 	bitSize := strconv.Itoa(bits.UintSize)
 
@@ -845,6 +856,63 @@ func TestSchema(t *testing.T) {
 				} `json:"value" nullable:"true"`
 			}{},
 			panics: `nullable is not supported for field 'Value' which is type '#/components/schemas/ValueStruct'`,
+		},
+		{
+			name: "field-custom-length-string-in-slice",
+			input: struct {
+				Values []TypedStringWithCustomLength `json:"values"`
+			}{},
+			expected: ` {
+				"additionalProperties":false,
+				"properties":{
+					"values":{
+						"type":"array",
+						"items":{
+							"type":"string",
+							"minLength":1,
+							"maxLength":10
+						}
+					}
+				},
+				"required":["values"],
+				"type":"object"
+			}`,
+		},
+		{
+			name: "field-custom-length-string",
+			input: struct {
+				Value TypedStringWithCustomLength `json:"value"`
+			}{},
+			expected: ` {
+				"additionalProperties":false,
+				"properties":{
+					"value":{
+						"type":"string",
+						"minLength":1,
+						"maxLength":10
+					}
+				},
+				"required":["value"],
+				"type":"object"
+			}`,
+		},
+		{
+			name: "field-ptr-to-custom-length-string",
+			input: struct {
+				Value *TypedStringWithCustomLength `json:"value"`
+			}{},
+			expected: ` {
+				"additionalProperties":false,
+				"properties":{
+					"value":{
+						"type":"string",
+						"minLength":1,
+						"maxLength":10
+					}
+				},
+				"required":["value"],
+				"type":"object"
+			}`,
 		},
 		{
 			name: "field-custom-array",

--- a/schema_test.go
+++ b/schema_test.go
@@ -73,14 +73,13 @@ func (t *TypedArrayWithCustomDesc) TransformSchema(r huma.Registry, s *huma.Sche
 	return s
 }
 
-type TypedStringWithCustomLength struct{}
+type TypedStringWithCustomLength string
 
 func (c TypedStringWithCustomLength) Schema(r huma.Registry) *huma.Schema {
-	min, max := 1, 10
 	return &huma.Schema{
 		Type:      "string",
-		MinLength: &min,
-		MaxLength: &max,
+		MinLength: Ptr(1),
+		MaxLength: Ptr(10),
 	}
 }
 
@@ -897,6 +896,24 @@ func TestSchema(t *testing.T) {
 			}`,
 		},
 		{
+			name: "field-custom-length-string-with-tag",
+			input: struct {
+				Value TypedStringWithCustomLength `json:"value" maxLength:"20"`
+			}{},
+			expected: ` {
+				"additionalProperties":false,
+				"properties":{
+					"value":{
+						"type":"string",
+						"minLength":1,
+						"maxLength":20
+					}
+				},
+				"required":["value"],
+				"type":"object"
+			}`,
+		},
+		{
 			name: "field-ptr-to-custom-length-string",
 			input: struct {
 				Value *TypedStringWithCustomLength `json:"value"`
@@ -907,6 +924,24 @@ func TestSchema(t *testing.T) {
 					"value":{
 						"type":"string",
 						"minLength":1,
+						"maxLength":10
+					}
+				},
+				"required":["value"],
+				"type":"object"
+			}`,
+		},
+		{
+			name: "field-ptr-to-custom-length-string-with-tag",
+			input: struct {
+				Value *TypedStringWithCustomLength `json:"value" minLength:"0"`
+			}{},
+			expected: ` {
+				"additionalProperties":false,
+				"properties":{
+					"value":{
+						"type":"string",
+						"minLength":0,
 						"maxLength":10
 					}
 				},


### PR DESCRIPTION
It fixes #512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced schema handling to conditionally assign minimum and maximum length constraints based on tag presence, providing more flexible schema definitions.

- **Tests**
  - Introduced new test cases for custom length constraints on strings, validating functionality across various scenarios, including slices and pointer fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->