### PR TITLE
fix(schema): proper minimum, maximum in generated schemas.

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -550,9 +550,15 @@ func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Sch
 		}
 	}
 
-	fs.Minimum = floatTag(f, "minimum")
+	if _, ok := f.Tag.Lookup("minimum"); ok {
+		fs.Minimum = floatTag(f, "minimum")
+	}
+
 	fs.ExclusiveMinimum = floatTag(f, "exclusiveMinimum")
-	fs.Maximum = floatTag(f, "maximum")
+
+	if _, ok := f.Tag.Lookup("maximum"); ok {
+		fs.Maximum = floatTag(f, "maximum")
+	}
 	fs.ExclusiveMaximum = floatTag(f, "exclusiveMaximum")
 	fs.MultipleOf = floatTag(f, "multipleOf")
 	fs.MinLength = intTag(f, "minLength")

--- a/schema_test.go
+++ b/schema_test.go
@@ -73,6 +73,14 @@ func (t *TypedArrayWithCustomDesc) TransformSchema(r huma.Registry, s *huma.Sche
 	return s
 }
 
+type TypedIntegerWithCustomLimits int
+
+func (c *TypedIntegerWithCustomLimits) TransformSchema(r huma.Registry, s *huma.Schema) *huma.Schema {
+	s.Minimum = Ptr(float64(1))
+	s.Maximum = Ptr(float64(10))
+	return s
+}
+
 func TestSchema(t *testing.T) {
 	bitSize := strconv.Itoa(bits.UintSize)
 
@@ -845,6 +853,60 @@ func TestSchema(t *testing.T) {
 				} `json:"value" nullable:"true"`
 			}{},
 			panics: `nullable is not supported for field 'Value' which is type '#/components/schemas/ValueStruct'`,
+		},
+		{
+			name: "field-custom-limits-int",
+			input: struct {
+				Value TypedIntegerWithCustomLimits `json:"value"`
+			}{},
+			expected: ` {
+					"additionalProperties":false,
+					"properties":{
+						"value":{
+							"type":"integer",
+							"format":"int64",
+							"minimum":1,
+							"maximum":10
+						}
+					},
+					"required":["value"],
+					"type":"object"
+				}`,
+		},
+		{
+			name: "field-custom-limits-int-with-tag",
+			input: struct {
+				Value TypedIntegerWithCustomLimits `json:"value" minimum:"2"`
+			}{},
+			expected: ` {
+					"additionalProperties":false,
+					"properties":{
+						"value":{
+							"type":"integer",
+							"format":"int64",
+							"minimum":2,
+							"maximum":10
+						}
+					},
+					"required":["value"],
+					"type":"object"
+				}`,
+		},
+		{
+			name: "field-ptr-to-custom-limits-int",
+			input: struct {
+				Value *TypedIntegerWithCustomLimits `json:"value"`
+			}{},
+			expected: ` {
+				"additionalProperties":false,
+				"properties":{
+					"value":{
+						"type": ["integer", "null"]
+					}
+				},
+				"required":["value"],
+				"type":"object"
+			}`,
 		},
 		{
 			name: "field-custom-array",

--- a/schema_test.go
+++ b/schema_test.go
@@ -901,6 +901,7 @@ func TestSchema(t *testing.T) {
 				"additionalProperties":false,
 				"properties":{
 					"value":{
+						"format":"int64",
 						"type": ["integer", "null"]
 					}
 				},


### PR DESCRIPTION
It's similar to #512, but about `minimum` and `maximum`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced validation for minimum and maximum fields in schema generation, ensuring accurate representation of constraints.
	- Introduced a new type, `TypedIntegerWithCustomLimits`, allowing for specific integer limits in schemas.

- **Bug Fixes**
	- Improved robustness of schema generation by preventing errors when required tags are absent.

- **Tests**
	- Expanded test coverage for schema transformations, validating various scenarios for the new integer limit type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->