### PR TITLE
fix(schema):  default value not work

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -515,7 +515,9 @@ func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Sch
 	if enc := f.Tag.Get("encoding"); enc != "" {
 		fs.ContentEncoding = enc
 	}
-	fs.Default = jsonTag(registry, f, fs, "default")
+	if defaultValue := jsonTag(registry, f, fs, "default"); defaultValue != nil {
+		fs.Default = defaultValue
+	}
 
 	if value := f.Tag.Get("example"); value != "" {
 		if e := jsonTagValue(registry, f.Name, fs, value); e != nil {


### PR DESCRIPTION
```go
type GreetingType int

func (*GreetingType) Schema(r huma.Registry) *huma.Schema {
	schema := &huma.Schema{
		Type:    huma.TypeInteger,
		Default: 10,
	}
	return schema
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of default values in schema generation, ensuring that invalid nil values are not assigned.

- **Refactor**
	- Enhanced the control flow for assigning default values to improve robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->