### PR TITLE
fix(schema): schema example not work in Parameter

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -167,6 +167,9 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 		if e := f.Tag.Get("example"); e != "" {
 			example = jsonTagValue(registry, f.Type.Name(), pfi.Schema, f.Tag.Get("example"))
 		}
+		if example == nil && len(pfi.Schema.Examples) > 0 {
+			example = pfi.Schema.Examples[0]
+		}
 
 		// While discouraged, make it possible to make query/header params required.
 		if r := f.Tag.Get("required"); r == "true" {

--- a/huma_test.go
+++ b/huma_test.go
@@ -2134,6 +2134,32 @@ func TestUnsupportedEmbeddedTypeWithMethods(t *testing.T) {
 	})
 }
 
+type SchemaWithExample int
+
+func (*SchemaWithExample) Schema(r huma.Registry) *huma.Schema {
+	schema := &huma.Schema{
+		Type:     huma.TypeInteger,
+		Examples: []any{1},
+	}
+	return schema
+}
+
+func TestSchemaWithExample(t *testing.T) {
+	_, app := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+	huma.Register(app, huma.Operation{
+		OperationID: "test",
+		Method:      http.MethodGet,
+		Path:        "/test",
+	}, func(ctx context.Context, input *struct {
+		Test SchemaWithExample `query:"test"`
+	}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	example := app.OpenAPI().Paths["/test"].Get.Parameters[0].Example
+	assert.Equal(t, 1, example)
+}
+
 // func BenchmarkSecondDecode(b *testing.B) {
 // 	//nolint: musttag
 // 	type MediumSized struct {


### PR DESCRIPTION
```go
type GreetingType int

func (*GreetingType) Schema(r huma.Registry) *huma.Schema {
	schema := &huma.Schema{
		Type:     huma.TypeInteger,
		Examples: []any{1},
	}
	return schema
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced example generation logic for improved flexibility and usability in the application.
	- Default examples are now utilized when no explicit examples are defined, enriching the user experience.
	- Introduced a new integer type with an example value, improving API documentation clarity.
- **Tests**
	- Added a test to validate the new integer type's behavior within the API context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->