### PR TITLE
fix: race by deferring the return of buf to sync.Pool when using RawBody

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -1292,8 +1292,8 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 						}
 					}
 
-					buf.Reset()
-					bufPool.Put(buf)
+					defer bufPool.Put(buf)
+					defer buf.Reset()
 				}
 			}
 		}


### PR DESCRIPTION
You are still using the result of buf.Bytes() in body, later in this function. This defers until completion. Alternatively we can make body a copy of the bytes from the buffer.

https://www.captaincodeman.com/golang-buffer-pool-gotcha#the-gotcha---were-still-using-it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved resource management in the registration process by optimizing buffer handling.
	- Enhanced control flow and error handling through the use of deferred execution for cleanup.

- **Tests**
	- Added a new test function to evaluate race conditions for concurrent API requests, improving the reliability of the API under high load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->