### PR TITLE
fix: automatically precompute schema validation messages

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -681,7 +681,9 @@ func schemaFromType(r Registry, t reflect.Type) *Schema {
 	v := reflect.New(t).Interface()
 	if sp, ok := v.(SchemaProvider); ok {
 		// Special case: type provides its own schema. Do not try to generate.
-		return sp.Schema(r)
+		custom := sp.Schema(r)
+		custom.PrecomputeMessages()
+		return custom
 	}
 
 	// Handle special cases.


### PR DESCRIPTION
This fix makes it easier to use custom schemas by removing the need to manually call `schema.PrecomputeMessages()` before the server starts up.

Fixes #454.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced request body handling and schema validation for improved reliability.
  - Introduced a new test function to validate error reporting for custom schemas.

- **Bug Fixes**
  - Strengthened checks on input bodies to ensure proper validation before processing.

- **Tests**
  - Added a specific test scenario for validating API behavior with invalid input for custom schemas.

- **Documentation**
  - Improved clarity on how message precomputation is handled within schema validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->