### PR TITLE
fix: if err & response are nil, return default status

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -1379,6 +1379,13 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 			return
 		}
 
+		if output == nil {
+			// Special case: No err or output, so just set the status code and return.
+			// This is a weird case, but it's better than panicking or returning 500.
+			ctx.SetStatus(op.DefaultStatus)
+			return
+		}
+
 		// Serialize output headers
 		ct := ""
 		vo := reflect.ValueOf(output).Elem()

--- a/huma_test.go
+++ b/huma_test.go
@@ -1433,6 +1433,30 @@ Content of example2.txt.
 			},
 		},
 		{
+			Name: "response-nil",
+			Register: func(t *testing.T, api huma.API) {
+				type Resp struct {
+					Body struct {
+						Greeting string `json:"greeting"`
+					}
+				}
+
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/response",
+				}, func(ctx context.Context, input *struct{}) (*Resp, error) {
+					return nil, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/response",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				// This should not panic and should return the default status code,
+				// which for responses which normally have a body is 200.
+				assert.Equal(t, http.StatusOK, resp.Code)
+			},
+		},
+		{
 			Name: "response-raw",
 			Register: func(t *testing.T, api huma.API) {
 				type Resp struct {


### PR DESCRIPTION
Handle a special case where a handler with a response body returns a `nil` error *and* response struct. This just returns the operation's default status code. This should not be a common case, but is friendlier behavior than having the code panic.

Fixes #544 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling in the registration process, ensuring graceful management of cases with no output.

- **Tests**
  - Introduced a new test case to verify the behavior of the system when a nil response is returned, ensuring the application does not panic and defaults to the correct HTTP status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->