### PR TITLE
fix: order of operations when resetting buffer

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -1299,8 +1299,8 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 						// No raw body, and the body has already been unmarshalled above, so
 						// we can return the buffer to the pool now as we don't need the
 						// bytes any more.
-						bufPool.Put(buf)
 						buf.Reset()
+						bufPool.Put(buf)
 					}
 				}
 			}


### PR DESCRIPTION
This fixes an order-of-operations bug that was due to copy/paste and removal of `defer` statements, however defers execute in reverse order while the copied statements execute in order. This means the buffer could be sent back into the pool before getting reset, causing a potential race on the next read. This was a silly mistake that should have been caught with the race detector during tests but was unfortunately missed. Sorry about that!

Fixes #552 