### PR TITLE
feat: support context in errors formatter

### DIFF
--- a/error.go
+++ b/error.go
@@ -365,3 +365,7 @@ func Error504GatewayTimeout(msg string, errs ...error) StatusError {
 
 // ErrorFormatter is a function that formats an error message
 var ErrorFormatter func(format string, a ...any) string = fmt.Sprintf
+
+// ErrorFormatterContext is a function that will be used instead of ErrorFormatter
+// to format an error message when defined
+var ErrorFormatterContext func(ctx Context, format string, a ...any) string = nil

--- a/huma.go
+++ b/huma.go
@@ -1143,7 +1143,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 				}
 
 				if !op.SkipValidateParams {
-					Validate(oapi.Components.Schemas, p.Schema, pb, ModeWriteToServer, pv, res)
+					ValidateContext(ctx, oapi.Components.Schemas, p.Schema, pb, ModeWriteToServer, pv, res)
 				}
 			}
 		})
@@ -1251,7 +1251,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 							pb.Reset()
 							pb.Push("body")
 							count := len(res.Errors)
-							Validate(oapi.Components.Schemas, inSchema, pb, ModeWriteToServer, parsed, res)
+							ValidateContext(ctx, oapi.Components.Schemas, inSchema, pb, ModeWriteToServer, parsed, res)
 							parseErrCount = len(res.Errors) - count
 							if parseErrCount > 0 {
 								errStatus = http.StatusUnprocessableEntity


### PR DESCRIPTION
Hello!

This is a follow up for https://github.com/danielgtaylor/huma/pull/520 to allow localization of the error messages.

My idea is that we can't assume any particular implementation for the localization, instead we can provide an interface that would let developers to take the language from context and apply any transformations to the errors they see fit.

From the API level we expose one more hook:
```
// ErrorFormatterContext is a function that will be used instead of ErrorFormatter
// to format an error message when defined
var ErrorFormatterContext func(ctx Context, format string, a ...any) string = nil
```

To apply the translation a developer might:
1. Add a middleware to read `Accept-Language` header, validate it is a supported language and put the value into Context.
2. Define ErrorFormatterContext, e.g. (simplified)
```go
import (
	"embed"
	"strings"

	"github.com/nicksnyder/go-i18n/v2/i18n"
	"golang.org/x/text/language"
)

var bundle *i18n.Bundle

func init() {
	bundle = i18n.NewBundle(language.English)
	_, _ = bundle.LoadMessageFileFS(localeFS, "i18n/en.json")
	_, _ = bundle.LoadMessageFileFS(localeFS, "i18n/ja.json")
}

huma.ErrorFormatterContext = func(ctx Context, format string, a ...any) string {
	localizer := i18n.NewLocalizer(bundle, middleware.GetLanguage(ctx))
	localizedMessage, _ := localizer.Localize(&i18n.LocalizeConfig{
		MessageID:    format,
		TemplateData: a,
	})
	return localizedMessage
}
```

To keep backward compatibility and to avoid introducing performance regressions the code is a bit boilerplaty. Please let me know what you think about such approach. I didn't fully cover it with tests yet, want to get your feedback first.

Below are the results of the benchmark on my machine (please keep in mind I had to disable few tests because they are failing on main branch):
```
BenchmarkValidate/bool-12      	270200919	         4.446 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int-12       	178897509	         6.574 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int_from_float64-12         	161212857	         6.613 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int_from_int8-12            	184066688	         6.551 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int_from_int16-12           	190347226	         6.290 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int_from_int32-12           	167603607	         6.566 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int_from_int64-12           	183883692	         6.580 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int_from_uint-12            	176594246	         6.555 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int_from_uint8-12           	180268419	         7.428 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int_from_uint16-12          	179324629	         6.532 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int_from_uint32-12          	183534787	         6.515 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int_from_uint64-12          	183638134	         6.513 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/float64_from_int-12         	199660590	         6.010 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/float64_from_float32-12     	191371929	         6.072 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/int64-12                    	184026264	         6.573 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/minimum-12                  	183218635	         6.534 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/exclusive_minimum-12        	184018750	         6.538 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/maximum-12                  	183950544	         6.539 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/exclusive_maximum-12        	181728464	         6.552 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/multiple_of-12              	97737116	        12.23 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/string-12                   	196833898	         6.053 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/min_length-12               	162912882	         7.396 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/max_length-12               	162739723	         7.425 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/non_ascii_max_length-12     	100000000	        11.06 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/pattern-12                  	27916633	        41.54 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/datetime-12                 	27612126	        43.22 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/datetime_string-12          	27862994	        42.90 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/date-time-http-12           	 5110598	       228.4 ns/op	     163 B/op	       4 allocs/op
BenchmarkValidate/date-12                     	20342314	        59.22 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/time-12                     	 5154030	       233.7 ns/op	     144 B/op	       6 allocs/op
BenchmarkValidate/email-12                    	 6468878	       183.7 ns/op	      96 B/op	       5 allocs/op
BenchmarkValidate/hostname-12                 	 4481942	       270.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/idn-hostname-12             	162504363	         7.380 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/ipv4-12                     	45344332	        26.33 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/ipv6-12                     	18462342	        65.40 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/uri-12                      	 9973724	       119.5 ns/op	     144 B/op	       1 allocs/op
BenchmarkValidate/uuid-12                     	57361718	        20.81 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/uuid_success_prefix-12      	45659420	        25.67 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/uuid_success_braces-12      	57278894	        21.17 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/uritemplate-12              	 2202934	       535.3 ns/op	     177 B/op	       2 allocs/op
BenchmarkValidate/jsonpointer-12              	 8444362	       140.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/rel_jsonpointer-12          	22817845	        50.46 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/regex-12                    	 1000000	      1132 ns/op	    2424 B/op	      35 allocs/op
BenchmarkValidate/base64_byte-12              	14051227	        84.51 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/base64_string-12            	14230352	        84.12 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/array-12                    	30504241	        39.35 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/array#01-12                 	23295598	        50.62 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/array#02-12                 	25144251	        48.23 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/array#03-12                 	24682659	        49.23 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/array#04-12                 	24420728	        49.62 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/array#05-12                 	23881963	        50.27 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/array#06-12                 	23479976	        50.17 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/array#07-12                 	23197987	        50.40 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/array#08-12                 	24260210	        49.28 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/array#09-12                 	23804269	        50.23 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/array#10-12                 	16736858	        70.46 ns/op	      12 B/op	       3 allocs/op
BenchmarkValidate/array#11-12                 	16053108	        75.94 ns/op	      24 B/op	       3 allocs/op
BenchmarkValidate/min_items-12                	65701222	        18.00 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/max_items-12                	66922114	        18.08 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/unique-12                   	 7690896	       156.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/map-12                      	18823540	        63.78 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/map_any-12                  	19147344	        62.30 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/map_any_int-12              	10234318	       116.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/map_minProps-12             	25853199	        46.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/map_any_minProps-12         	26218141	        45.28 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/map_maxProps-12             	26026839	        46.12 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/map_any_maxProps-12         	26390905	        45.22 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/json.RawMessage-12          	293788394	         4.080 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/object_struct-12            	122741674	         9.802 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/object_struct_any-12        	100000000	        10.07 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/object_optional-12          	50584797	        23.76 ns/op	      48 B/op	       1 allocs/op
BenchmarkValidate/object_any_optional-12      	50881323	        23.41 ns/op	      48 B/op	       1 allocs/op
BenchmarkValidate/readOnly_set-12             	199912593	         5.980 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/readOnly_any_set-12         	199883401	         5.986 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/readOnly_missing-12         	50041440	        23.79 ns/op	      48 B/op	       1 allocs/op
BenchmarkValidate/readOnly_any_missing-12     	50294958	        23.69 ns/op	      48 B/op	       1 allocs/op
BenchmarkValidate/nested-12                   	 7614474	       155.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/nested_any-12               	 5440443	       221.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/enum_string-12              	122468490	         9.801 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/enum_int-12                 	142374466	         8.447 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/enum_uint16-12              	142445456	         8.475 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/enum_array-12               	50447810	        24.57 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/optional-12                 	48244921	        24.02 ns/op	      48 B/op	       1 allocs/op
BenchmarkValidate/optional_null-12            	47455761	        23.96 ns/op	      48 B/op	       1 allocs/op
BenchmarkValidate/optional_any_null-12        	49453860	        23.64 ns/op	      48 B/op	       1 allocs/op
BenchmarkValidate/dependentRequired_empty-12  	50979675	        25.24 ns/op	      48 B/op	       1 allocs/op
BenchmarkValidate/dependentRequired_filled-12 	199451079	         6.006 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/dependentRequired_ignored-12         	50559667	        23.45 ns/op	      48 B/op	       1 allocs/op
BenchmarkValidate/dependentRequired_empty_success_any-12         	50454794	        23.52 ns/op	      48 B/op	       1 allocs/op
BenchmarkValidate/dependentRequired_filled_success_any-12        	200792670	         6.003 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidate/dependentRequired_ignored_success_any-12       	49787020	        24.23 ns/op	      48 B/op	       1 allocs/op
BenchmarkValidate/pointer_required_field-12                      	17407976	        66.04 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/bool-12                                 	275868912	         4.364 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int-12                                  	183983472	         6.543 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int_from_float64-12                     	184027334	         6.623 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int_from_int8-12                        	182789446	         6.534 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int_from_int16-12                       	192011558	         6.289 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int_from_int32-12                       	183929068	         6.526 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int_from_int64-12                       	183563646	         6.527 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int_from_uint-12                        	183101719	         6.522 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int_from_uint8-12                       	183503845	         6.522 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int_from_uint16-12                      	183333051	         6.527 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int_from_uint32-12                      	183707679	         6.534 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int_from_uint64-12                      	183834288	         6.605 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/float64_from_int-12                     	200769546	         6.002 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/float64_from_float32-12                 	200920788	         5.985 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/int64-12                                	183533512	         6.539 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/minimum-12                              	183799303	         6.527 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/exclusive_minimum-12                    	184067876	         6.514 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/maximum-12                              	183705043	         6.516 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/exclusive_maximum-12                    	182966852	         6.516 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/multiple_of-12                          	98415445	        12.27 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/string-12                               	200753550	         5.982 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/min_length-12                           	162586975	         7.343 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/max_length-12                           	157070572	         7.347 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/non_ascii_max_length-12                 	100000000	        11.00 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/pattern-12                              	28508274	        41.46 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/datetime-12                             	26376886	        42.91 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/datetime_string-12                      	27723122	        43.12 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/date-time-http-12                       	 5288682	       224.7 ns/op	     163 B/op	       4 allocs/op
BenchmarkValidateContext/date-12                                 	20100193	        58.14 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/time-12                                 	 5202078	       233.0 ns/op	     144 B/op	       6 allocs/op
BenchmarkValidateContext/email-12                                	 6594186	       191.2 ns/op	      96 B/op	       5 allocs/op
BenchmarkValidateContext/hostname-12                             	 4522002	       268.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/idn-hostname-12                         	156448912	         7.901 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/ipv4-12                                 	40455290	        27.06 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/ipv6-12                                 	18171286	        64.81 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/uri-12                                  	 9853665	       121.9 ns/op	     144 B/op	       1 allocs/op
BenchmarkValidateContext/uuid-12                                 	56786814	        20.96 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/uuid_success_prefix-12                  	46549666	        25.61 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/uuid_success_braces-12                  	56421468	        21.05 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/uritemplate-12                          	 2197502	       543.0 ns/op	     177 B/op	       2 allocs/op
BenchmarkValidateContext/jsonpointer-12                          	 8543415	       142.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/rel_jsonpointer-12                      	23096521	        50.20 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/regex-12                                	 1000000	      1143 ns/op	    2424 B/op	      35 allocs/op
BenchmarkValidateContext/base64_byte-12                          	13531659	        84.70 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/base64_string-12                        	14082234	        87.99 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/array-12                                	30256105	        40.55 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/array#01-12                             	23956658	        50.46 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/array#02-12                             	24133093	        47.76 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/array#03-12                             	24754857	        48.57 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/array#04-12                             	24331578	        49.79 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/array#05-12                             	23897241	        50.31 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/array#06-12                             	23345091	        50.14 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/array#07-12                             	23053130	        51.32 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/array#08-12                             	24015649	        49.16 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/array#09-12                             	23118732	        50.38 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/array#10-12                             	17091866	        70.83 ns/op	      12 B/op	       3 allocs/op
BenchmarkValidateContext/array#11-12                             	15752286	        73.96 ns/op	      24 B/op	       3 allocs/op
BenchmarkValidateContext/min_items-12                            	63409446	        18.56 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/max_items-12                            	65683393	        18.25 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/unique-12                               	 7648353	       156.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/map-12                                  	18714471	        63.97 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/map_any-12                              	19236163	        62.35 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/map_any_int-12                          	10162009	       118.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/map_minProps-12                         	26044821	        46.40 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/map_any_minProps-12                     	26580452	        45.12 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/map_maxProps-12                         	26371210	        46.49 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/map_any_maxProps-12                     	26802914	        45.25 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/json.RawMessage-12                      	292729602	         4.085 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/object_struct-12                        	121021155	         9.839 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/object_struct_any-12                    	100000000	        10.07 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/object_optional-12                      	21694310	        55.96 ns/op	      64 B/op	       2 allocs/op
BenchmarkValidateContext/object_any_optional-12                  	21439066	        55.58 ns/op	      64 B/op	       2 allocs/op
BenchmarkValidateContext/readOnly_set-12                         	200953846	         6.013 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/readOnly_any_set-12                     	194935348	         6.265 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/readOnly_missing-12                     	20954079	        55.58 ns/op	      64 B/op	       2 allocs/op
BenchmarkValidateContext/readOnly_any_missing-12                 	21316279	        55.19 ns/op	      64 B/op	       2 allocs/op
BenchmarkValidateContext/nested-12                               	 7760514	       157.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/nested_any-12                           	 5414528	       220.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/enum_string-12                          	121845676	         9.969 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/enum_int-12                             	142164162	         8.458 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/enum_uint16-12                          	142403752	         8.559 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/enum_array-12                           	51112314	        23.04 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/optional-12                             	21297049	        56.40 ns/op	      64 B/op	       2 allocs/op
BenchmarkValidateContext/optional_null-12                        	21250863	        55.66 ns/op	      64 B/op	       2 allocs/op
BenchmarkValidateContext/optional_any_null-12                    	21761830	        55.74 ns/op	      64 B/op	       2 allocs/op
BenchmarkValidateContext/dependentRequired_empty-12              	21646290	        55.69 ns/op	      64 B/op	       2 allocs/op
BenchmarkValidateContext/dependentRequired_filled-12             	200456008	         6.035 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/dependentRequired_ignored-12            	21333601	        55.32 ns/op	      64 B/op	       2 allocs/op
BenchmarkValidateContext/dependentRequired_empty_success_any-12  	21720079	        55.79 ns/op	      64 B/op	       2 allocs/op
BenchmarkValidateContext/dependentRequired_filled_success_any-12 	199827259	         6.030 ns/op	       0 B/op	       0 allocs/op
BenchmarkValidateContext/dependentRequired_ignored_success_any-12         	21527205	        55.80 ns/op	      64 B/op	       2 allocs/op
BenchmarkValidateContext/pointer_required_field-12                        	16223322	        67.34 ns/op	       0 B/op	       0 allocs/op
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a context-aware error formatting option to enhance error message customization.
	- Improved validation processes with context utilization for better error handling and request management.

- **Bug Fixes**
	- Ensured backward compatibility while transitioning to context-aware validation methods.

- **Tests**
	- Added new tests to validate context-aware error formatting and benchmark performance within the validation framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->