### PR TITLE
Allow using pointers for non param fields in input structs

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -97,15 +97,6 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 			return nil
 		}
 
-		if f.Type.Kind() == reflect.Pointer {
-			// TODO: support pointers? The problem is that when we dynamically
-			// create an instance of the input struct the `params.Every(...)`
-			// call cannot set them as the value is `reflect.Invalid` unless
-			// dynamically allocated, but we don't know when to allocate until
-			// after the `Every` callback has run. Doable, but a bigger change.
-			panic("pointers are not supported for path/query/header parameters")
-		}
-
 		pfi := &paramFieldInfo{
 			Type: f.Type,
 		}
@@ -144,6 +135,15 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 			}
 		} else {
 			return nil
+		}
+
+		if f.Type.Kind() == reflect.Pointer {
+			// TODO: support pointers? The problem is that when we dynamically
+			// create an instance of the input struct the `params.Every(...)`
+			// call cannot set them as the value is `reflect.Invalid` unless
+			// dynamically allocated, but we don't know when to allocate until
+			// after the `Every` callback has run. Doable, but a bigger change.
+			panic("pointers are not supported for path/query/header parameters")
 		}
 
 		pfi.Schema = SchemaFromField(registry, f, "")


### PR DESCRIPTION
This PR allows using pointers fields in input structs, if they are not path/query/header/cookie parameters. This gives more flexibility to huma users, e.g. when defining resolvers

```go
type EndpointInput struct {
  Token string `header:"Authorization"`
  User *User
}

func (i *EndpointInput) Resolve(ctx huma.Context) []error {
  user, token_valid := ValidateToken(i.Token) // user is nil if token is missing or invalid
  i.User = user 
  return nil
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for pointer types in input structures, enhancing the resolver mechanism.
	- Added a new test to validate the functionality of pointer handling in HTTP operations.

- **Bug Fixes**
	- Adjusted the control flow for pointer type checks to allow for additional logic before triggering a panic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->