### PR TITLE
fix: reset recovery middleware buffer

### DIFF
--- a/middleware/recovery.go
+++ b/middleware/recovery.go
@@ -107,6 +107,7 @@ func Recovery(onPanic PanicFunc) func(http.Handler) http.Handler {
 			if r.Body != nil {
 				// Get a buffer that the body will be read into.
 				buf = bufPool.Get().(*bytes.Buffer)
+				buf.Reset()
 				defer bufPool.Put(buf)
 
 				r.Body = newBufferedReadCloser(r.Body, buf, MaxLogBodyBytes)


### PR DESCRIPTION
This small bug fix adds a buffer reset that was missing and would sometimes result in multiple request bodies being dumped into the same buffer when under heavy load.

Unfortunately this is difficult to unit test.