### PR TITLE
fix: validate hidden fields

### DIFF
--- a/schema_test.go
+++ b/schema_test.go
@@ -619,18 +619,26 @@ func TestSchema(t *testing.T) {
 		{
 			name: "field-skip",
 			input: struct {
+				// Not filtered out (just a normal field)
+				Value1 string `json:"value1"`
 				// Filtered out from JSON tag
-				Value1 string `json:"-"`
+				Value2 string `json:"-"`
 				// Filtered because it's private
-				value2 string
+				value3 string
 				// Filtered due to being an unsupported type
-				Value3 func()
+				Value4 func()
 				// Filtered due to being hidden
-				Value4 string `json:"value4,omitempty" hidden:"true"`
+				Value5 string `json:"value4,omitempty" hidden:"true"`
 			}{},
 			expected: `{
 				"type": "object",
-				"additionalProperties": false
+				"additionalProperties": false,
+				"required": ["value1"],
+				"properties": {
+					"value1": {
+						"type": "string"
+					}
+				}
 			}`,
 		},
 		{

--- a/validate_test.go
+++ b/validate_test.go
@@ -1050,6 +1050,28 @@ var validateTests = []struct {
 		errs:  []string{"expected length >= 1"},
 	},
 	{
+		name: "hidden is optional",
+		typ: reflect.TypeOf(struct {
+			Value string `json:"value" minLength:"5" hidden:"true"`
+		}{}),
+		input: map[any]any{},
+	},
+	{
+		name: "hidden success",
+		typ: reflect.TypeOf(struct {
+			Value string `json:"value" minLength:"5" hidden:"true"`
+		}{}),
+		input: map[any]any{"value": "abcde"},
+	},
+	{
+		name: "hidden fail",
+		typ: reflect.TypeOf(struct {
+			Value string `json:"value" minLength:"5" hidden:"true"`
+		}{}),
+		input: map[any]any{"value": "abc"},
+		errs:  []string{"expected length >= 5"},
+	},
+	{
 		name: "dependentRequired empty success",
 		typ: reflect.TypeOf(struct {
 			Value     string `json:"value,omitempty" dependentRequired:"dependent"`


### PR DESCRIPTION
This PR fixes the validation of hidden fields so that:

1. Hidden fields are allowed in the input and treated as optional fields
2. HIdden fields, if present, are validated by whatever rules are set (e.g. min/max/len/pattern)

Fixes #516 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `hidden` field to manage property visibility in JSON schema output.
	- Enhanced control over required fields by ignoring hidden properties.

- **Bug Fixes**
	- Updated test cases to ensure correct handling of hidden fields and their validation.

- **Tests**
	- Added new test cases for validating hidden fields, including scenarios for optional fields and length constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->