### PR TITLE
Add default Server object when calling humago.NewWithPrefix

### DIFF
--- a/adapters/humago/humago.go
+++ b/adapters/humago/humago.go
@@ -162,5 +162,10 @@ func New(m Mux, config huma.Config) huma.API {
 //	config.Servers = []*huma.Server{{URL: "http://example.com/api"}}
 //	api := humago.NewWithPrefix(mux, "/api", config)
 func NewWithPrefix(m Mux, prefix string, config huma.Config) huma.API {
+	if len(config.Servers) == 0 {
+		config.Servers = append(config.Servers, &huma.Server{
+			URL: prefix,
+		})
+	}
 	return huma.NewAPI(config, &goAdapter{m, prefix})
 }


### PR DESCRIPTION
Provide a better experience (e.g., no errors when opening `/docs`) when `config.Servers` is unset, and make `humago.NewWithPrefix` more similar to `humago.New`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced server configuration functionality to ensure at least one server URL is always set, improving reliability.

- **Bug Fixes**
	- Prevented potential issues related to empty server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->