### PR TITLE
fix: support non-addressable resolver values

### DIFF
--- a/huma_test.go
+++ b/huma_test.go
@@ -2277,6 +2277,27 @@ func TestBodyRace(t *testing.T) {
 	}
 }
 
+type CustomMapValue string
+
+func (v *CustomMapValue) Resolve(ctx huma.Context) []error {
+	return nil
+}
+
+func TestResolverCustomTypePrimitive(t *testing.T) {
+	_, api := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+	huma.Post(api, "/test", func(ctx context.Context, input *struct {
+		Body struct {
+			Tags map[string]CustomMapValue `json:"tags"`
+		}
+	}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	assert.NotPanics(t, func() {
+		api.Post("/test", map[string]any{"tags": map[string]string{"foo": "bar"}})
+	})
+}
+
 // func BenchmarkSecondDecode(b *testing.B) {
 // 	//nolint: musttag
 // 	type MediumSized struct {


### PR DESCRIPTION
This fixes a bug where non-addressable values which implement resolver types could not be used.

Fixes #558 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of resolvers in the registration process for better robustness.
	- Introduced a new custom type, `CustomMapValue`, enhancing API capabilities to handle specific data types.
  
- **Tests**
	- Added tests to validate the behavior of the new custom type and ensure type safety in API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->