### PR TITLE
fix: use status code returned from NewError when writing errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -252,7 +252,11 @@ var NewError = func(status int, msg string, errs ...error) StatusError {
 // configured error type and with the given status code and message. It is
 // marshaled using the API's content negotiation methods.
 func WriteErr(api API, ctx Context, status int, msg string, errs ...error) error {
-	var err any = NewError(status, msg, errs...)
+	var err = NewError(status, msg, errs...)
+
+	// NewError may have modified the status code, so update it here if needed.
+	// If it was not modified then this is a no-op.
+	status = err.GetStatus()
 
 	ct, negotiateErr := api.Negotiate(ctx.Header("Accept"))
 	if negotiateErr != nil {


### PR DESCRIPTION
This PR fixes a bug where `huma.NewError` might be used to modify an outgoing status code (e.g. turning a 422 into a 400 to match a legacy API contract or match company standards). Previously the updated status code was incorrectly ignored, making it impossible to update the response status code without a hacky solution like a middleware.

Fixes #561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in the API to return a 400 status code for validation errors instead of 422, improving clarity for users.
  
- **Tests**
	- Introduced a new test to validate the updated error handling behavior for custom validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->