### PR TITLE
fix: unsupported param type url.URL

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"reflect"
 	"regexp"
 	"slices"
@@ -1125,6 +1126,16 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 							return
 						}
 						f.Set(reflect.ValueOf(t))
+						pv = value
+						break
+						// Special case: url.URL
+					} else if f.Type() == urlType {
+						u, err := url.Parse(value)
+						if err != nil {
+							res.Add(pb, value, "invalid url.URL value")
+							return
+						}
+						f.Set(reflect.ValueOf(*u))
 						pv = value
 						break
 					}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the `Register` function to support and validate `url.URL` types, ensuring proper handling of URL inputs.
	- Added functionality to the test suite to handle URL parameters, improving robustness in testing URL validation.

- **Bug Fixes**
	- Improved error handling for invalid URL values, providing clearer feedback to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->