### PR TITLE
Revert nullable schema generation for array slices

### DIFF
--- a/api.go
+++ b/api.go
@@ -191,6 +191,10 @@ type Config struct {
 	CreateHooks []func(Config) Config
 }
 
+func (c *Config) RegistryConfig() *RegistryConfig {
+	return c.Components.Schemas.Config()
+}
+
 // API represents a Huma API wrapping a specific router.
 type API interface {
 	// Adapter returns the router adapter for this API, providing a generic

--- a/api_test.go
+++ b/api_test.go
@@ -126,3 +126,13 @@ func TestChiRouterPrefix(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.Code)
 	assert.Contains(t, resp.Body.String(), "/api/openapi.yaml")
 }
+
+func TestRegistryConfig(t *testing.T) {
+	cfg := huma.DefaultConfig("Test", "3.1")
+
+	// Test default value
+	assert.False(t, cfg.Components.Schemas.Config().NullSlices)
+
+	cfg.RegistryConfig().NullSlices = true
+	assert.True(t, cfg.Components.Schemas.Config().NullSlices)
+}

--- a/registry.go
+++ b/registry.go
@@ -9,6 +9,15 @@ import (
 	"unicode/utf8"
 )
 
+// RegistryConfig contains configuration options to control how OpenAPI schemas
+// are generated
+type RegistryConfig struct {
+	// NullSlices specifies whether slices in request and response body should be
+	// marked as nullable in the generated OpenAPI spec to reflect the behavior
+	// of [encoding/json] package.
+	NullSlices bool
+}
+
 // Registry creates and stores schemas and their references, and supports
 // marshalling to JSON/YAML for use as an OpenAPI #/components/schemas object.
 // Behavior is implementation-dependent, but the design allows for recursive
@@ -20,6 +29,7 @@ type Registry interface {
 	TypeFromRef(ref string) reflect.Type
 	Map() map[string]*Schema
 	RegisterTypeAlias(t reflect.Type, alias reflect.Type)
+	Config() *RegistryConfig
 }
 
 // DefaultSchemaNamer provides schema names for types. It uses the type name
@@ -66,6 +76,11 @@ type mapRegistry struct {
 	seen    map[reflect.Type]bool
 	namer   func(reflect.Type, string) string
 	aliases map[reflect.Type]reflect.Type
+	config  RegistryConfig
+}
+
+func (r *mapRegistry) Config() *RegistryConfig {
+	return &r.config
 }
 
 func (r *mapRegistry) Schema(t reflect.Type, allowRef bool, hint string) *Schema {
@@ -170,5 +185,8 @@ func NewMapRegistry(prefix string, namer func(t reflect.Type, hint string) strin
 		seen:    map[reflect.Type]bool{},
 		aliases: map[reflect.Type]reflect.Type{},
 		namer:   namer,
+		config: RegistryConfig{
+			NullSlices: false,
+		},
 	}
 }

--- a/schema.go
+++ b/schema.go
@@ -762,7 +762,6 @@ func schemaFromType(r Registry, t reflect.Type) *Schema {
 			s.ContentEncoding = "base64"
 		} else {
 			s.Type = TypeArray
-			s.Nullable = true
 			s.Items = r.Schema(t.Elem(), true, t.Name()+"Item")
 
 			if t.Kind() == reflect.Array {

--- a/schema.go
+++ b/schema.go
@@ -762,6 +762,7 @@ func schemaFromType(r Registry, t reflect.Type) *Schema {
 			s.ContentEncoding = "base64"
 		} else {
 			s.Type = TypeArray
+			s.Nullable = r.Config().NullSlices
 			s.Items = r.Schema(t.Elem(), true, t.Name()+"Item")
 
 			if t.Kind() == reflect.Array {

--- a/schema_test.go
+++ b/schema_test.go
@@ -205,12 +205,12 @@ func TestSchema(t *testing.T) {
 		{
 			name:     "array",
 			input:    [2]int{1, 2},
-			expected: `{"type": ["array", "null"], "items": {"type": "integer", "format": "int64"}, "minItems": 2, "maxItems": 2}`,
+			expected: `{"type": "array", "items": {"type": "integer", "format": "int64"}, "minItems": 2, "maxItems": 2}`,
 		},
 		{
 			name:     "slice",
 			input:    []int{1, 2, 3},
-			expected: `{"type": ["array", "null"], "items": {"type": "integer", "format": "int64"}}`,
+			expected: `{"type": "array", "items": {"type": "integer", "format": "int64"}}`,
 		},
 		{
 			name:     "map",
@@ -286,7 +286,7 @@ func TestSchema(t *testing.T) {
 				"type": "object",
 				"properties": {
 					"value": {
-						"type": ["array", "null"],
+						"type": "array",
 						"minItems": 1,
 						"maxItems": 10,
 						"uniqueItems": true,
@@ -344,7 +344,7 @@ func TestSchema(t *testing.T) {
 				"type": "object",
 				"properties": {
 					"value": {
-						"type": ["array", "null"],
+						"type": "array",
 						"items": {
 							"type": "integer",
 							"format": "int64",
@@ -434,7 +434,7 @@ func TestSchema(t *testing.T) {
 				"type": "object",
 				"properties": {
 					"value": {
-						"type": ["array", "null"],
+						"type": "array",
 						"items": {
 							"type": "string"
 						},
@@ -454,7 +454,7 @@ func TestSchema(t *testing.T) {
 				"type": "object",
 				"properties": {
 					"value": {
-						"type": ["array", "null"],
+						"type": "array",
 						"items": {
 							"type": "integer",
 							"format": "int64"
@@ -753,7 +753,7 @@ func TestSchema(t *testing.T) {
 						},
 						"maxItems":1,
 						"minItems":1,
-						"type":["array", "null"]
+						"type":"array"
 					},
 					"byRef":{
 						"$ref":"#/components/schemas/RecursiveChildKey"
@@ -771,7 +771,7 @@ func TestSchema(t *testing.T) {
 						"items":{
 							"$ref":"#/components/schemas/RecursiveChildLoop"
 						},
-						"type":["array", "null"]}
+						"type":"array"}
 					},
 					"required":["slice","array","map","byValue", "byRef"],
 					"type":"object"
@@ -893,7 +893,7 @@ func TestSchema(t *testing.T) {
 				"additionalProperties":false,
 				"properties":{
 					"values":{
-						"type":["array", "null"],
+						"type":"array",
 						"items":{
 							"type":"string",
 							"minLength":1,
@@ -1050,7 +1050,7 @@ func TestSchema(t *testing.T) {
 						},
 						"maxItems":4,
 						"minItems":4,
-						"type":["array", "null"]
+						"type":"array"
 					}
 				},
 				"required":["value"],
@@ -1073,7 +1073,7 @@ func TestSchema(t *testing.T) {
 						},
 						"maxItems":4,
 						"minItems":4,
-						"type":["array", "null"]
+						"type":"array"
 					}
 				},
 				"required":["value"],


### PR DESCRIPTION
1961ef9 reverts #527 which seems to be causing more trouble than good (see #571 and comments on #527).

110fcaa introduces a configuration field in the schema registry, which allows specifying whether schemas for arrays/slices should be nullable by default. This is not ideal since it would rather belong in the [huma.Config](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Config), but then it would not be accessible at the time of schema generation without major changes in the API. Let me know if you got ideas on how to improve this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `RegistryConfig` struct to manage nullability of slices in OpenAPI schema generation.
  - Enhanced `Config` methods to provide direct access to registry configurations.

- **Bug Fixes**
  - Improved handling of the `Nullable` property for array types, allowing dynamic control based on configuration settings.

- **Tests**
  - Updated test cases to reflect the new `NullSlices` configuration, ensuring accurate schema generation for nullable arrays and slices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->