### PR TITLE
fix: check actual type in schema ref when enforcing non-nullable object schemas

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -561,7 +561,7 @@ func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Sch
 	}
 
 	fs.Nullable = boolTag(f, "nullable", fs.Nullable)
-	if fs.Nullable && fs.Ref != "" {
+	if fs.Nullable && fs.Ref != "" && registry.SchemaFromRef(fs.Ref).Type == "object" {
 		// Nullability is only supported for scalar types for now. Objects are
 		// much more complicated because the `null` type lives within the object
 		// definition (requiring multiple copies of the object) or needs to use


### PR DESCRIPTION
ca4b5f6 intends to prevent non-scalar types to be nullable in their schema definition. It does so by checking that the provided schema is not a ref.

However it is possible to end up having a ref schema for a scalar type, which should be nullable. This PR fixes this by actually checking that the schema type of the ref is `object`.


Example scalar type that is purposely registered as a ref : 

```go
type InstitutionKind string

const (
	Lab                InstitutionKind = "Lab"
	FoundingAgency     InstitutionKind = "FundingAgency"
	SequencingPlatform InstitutionKind = "SequencingPlatform"
	Other              InstitutionKind = "Other"
)

var InstitutionKindValues = []InstitutionKind{
	Lab,
	FoundingAgency,
	SequencingPlatform,
	Other,
}

// Register enum in OpenAPI specification
func (u InstitutionKind) Schema(r huma.Registry) *huma.Schema {
  if r.Map()["InstitutionKind"] == nil {
    schemaRef := r.Schema(reflect.TypeOf(""), false, "InstitutionKind")
    schemaRef.Title = "InstitutionKind"
    for _, v := range InstitutionKindValues {
      schemaRef.Enum = append(schemaRef.Enum, string(v))
    }
    r.Map()["InstitutionKind"] = schemaRef
  }

	return &huma.Schema{Ref: "#/components/schemas/InstitutionKind"}
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated schema handling to prevent nullability for object types, ensuring correct representation of null values.
	- Introduced error handling for cases where object types are incorrectly marked as nullable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->