### PR TITLE
fix: marshal empty security object

### DIFF
--- a/huma_test.go
+++ b/huma_test.go
@@ -1792,6 +1792,24 @@ Content of example2.txt.
 			URL:    "/one-of",
 			Body:   `[{"foo": "first"}, {"foo": "second"}]`,
 		},
+		{
+			Name: "security-override-public",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method:   http.MethodGet,
+					Path:     "/public",
+					Security: []map[string][]string{}, // No security for this call!
+				}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+					return nil, nil
+				})
+				// Note: the empty security object should be serialized as an empty
+				// array in the OpenAPI document.
+				b, _ := api.OpenAPI().Paths["/public"].Get.MarshalJSON()
+				assert.Contains(t, string(b), `"security":[]`)
+			},
+			Method: http.MethodGet,
+			URL:    "/public",
+		},
 	} {
 		t.Run(feature.Name, func(t *testing.T) {
 			r := chi.NewRouter()


### PR DESCRIPTION
This implements the suggestion from #593 to enable better `nil` checks using reflection and to make sure the security object is marshaled anytime it is not nil, since an empty array `[]` has valid semantic meaning in OpenAPI to e.g. remove a top-level security requirement to make a single route public.

Adds a test to ensure the empty security object is marshaled. Fixes #593.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a public API operation that requires no security, enhancing accessibility.
	- Improved JSON marshaling logic for better handling of nil values and field omission.

- **Bug Fixes**
	- Enhanced API testing capabilities to ensure accurate representation in OpenAPI documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->