### PR TITLE
Add api version and tls to adapter

### DIFF
--- a/adapters/adapters_test.go
+++ b/adapters/adapters_test.go
@@ -95,11 +95,11 @@ func TestAdapters(t *testing.T) {
 			assert.Nil(t, ctx.TLS())
 			v := ctx.Version()
 			if !isFiber {
-				assert.Equal(t, v.Proto, "HTTP/1.1")
-				assert.Equal(t, v.ProtoMajor, 1)
-				assert.Equal(t, v.ProtoMinor, 1)
+				assert.Equal(t, "HTTP/1.1", v.Proto)
+				assert.Equal(t, 1, v.ProtoMajor)
+				assert.Equal(t, 1, v.ProtoMinor)
 			} else {
-				assert.Equal(t, v.Proto, "http")
+				assert.Equal(t, "http", v.Proto)
 			}
 			next(ctx)
 		})

--- a/adapters/adapters_test.go
+++ b/adapters/adapters_test.go
@@ -90,18 +90,34 @@ func TestAdapters(t *testing.T) {
 		return huma.DefaultConfig("Test", "1.0.0")
 	}
 
+	wrap := func(h huma.API, isFiber bool) huma.API {
+		h.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
+			assert.Nil(t, ctx.TLS())
+			v := ctx.Version()
+			if !isFiber {
+				assert.Equal(t, v.Proto, "HTTP/1.1")
+				assert.Equal(t, v.ProtoMajor, 1)
+				assert.Equal(t, v.ProtoMinor, 1)
+			} else {
+				assert.Equal(t, v.Proto, "http")
+			}
+			next(ctx)
+		})
+		return h
+	}
+
 	for _, adapter := range []struct {
 		name string
 		new  func() huma.API
 	}{
-		{"chi", func() huma.API { return humachi.New(chi.NewMux(), config()) }},
-		{"echo", func() huma.API { return humaecho.New(echo.New(), config()) }},
-		{"fiber", func() huma.API { return humafiber.New(fiber.New(), config()) }},
-		{"gin", func() huma.API { return humagin.New(gin.New(), config()) }},
-		{"httprouter", func() huma.API { return humahttprouter.New(httprouter.New(), config()) }},
-		{"mux", func() huma.API { return humamux.New(mux.NewRouter(), config()) }},
-		{"bunrouter", func() huma.API { return humabunrouter.New(bunrouter.New(), config()) }},
-		{"bunroutercompat", func() huma.API { return humabunrouter.NewCompat(bunrouter.New().Compat(), config()) }},
+		{"chi", func() huma.API { return wrap(humachi.New(chi.NewMux(), config()), false) }},
+		{"echo", func() huma.API { return wrap(humaecho.New(echo.New(), config()), false) }},
+		{"fiber", func() huma.API { return wrap(humafiber.New(fiber.New(), config()), true) }},
+		{"gin", func() huma.API { return wrap(humagin.New(gin.New(), config()), false) }},
+		{"httprouter", func() huma.API { return wrap(humahttprouter.New(httprouter.New(), config()), false) }},
+		{"mux", func() huma.API { return wrap(humamux.New(mux.NewRouter(), config()), false) }},
+		{"bunrouter", func() huma.API { return wrap(humabunrouter.New(bunrouter.New(), config()), false) }},
+		{"bunroutercompat", func() huma.API { return wrap(humabunrouter.NewCompat(bunrouter.New().Compat(), config()), false) }},
 	} {
 		t.Run(adapter.name, func(t *testing.T) {
 			testAdapter(t, adapter.new())

--- a/adapters/humabunrouter/humabunrouter.go
+++ b/adapters/humabunrouter/humabunrouter.go
@@ -112,6 +112,14 @@ func (c *bunContext) TLS() *tls.ConnectionState {
 	return c.r.TLS
 }
 
+func (c *bunContext) Version() huma.ProtoVersion {
+	return huma.ProtoVersion{
+		Proto:      c.r.Proto,
+		ProtoMajor: c.r.ProtoMajor,
+		ProtoMinor: c.r.ProtoMinor,
+	}
+}
+
 // NewContext creates a new Huma context from an HTTP request and response.
 func NewContext(op *huma.Operation, r bunrouter.Request, w http.ResponseWriter) huma.Context {
 	return &bunContext{op: op, r: r, w: w}
@@ -205,6 +213,14 @@ func (c *bunCompatContext) BodyWriter() io.Writer {
 
 func (c *bunCompatContext) TLS() *tls.ConnectionState {
 	return c.r.TLS
+}
+
+func (c *bunCompatContext) Version() huma.ProtoVersion {
+	return huma.ProtoVersion{
+		Proto:      c.r.Proto,
+		ProtoMajor: c.r.ProtoMajor,
+		ProtoMinor: c.r.ProtoMinor,
+	}
 }
 
 // NewCompatContext creates a new Huma context from an HTTP request and response.

--- a/adapters/humabunrouter/humabunrouter.go
+++ b/adapters/humabunrouter/humabunrouter.go
@@ -2,6 +2,7 @@ package humabunrouter
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -107,6 +108,10 @@ func (c *bunContext) BodyWriter() io.Writer {
 	return c.w
 }
 
+func (c *bunContext) TLS() *tls.ConnectionState {
+	return c.r.TLS
+}
+
 // NewContext creates a new Huma context from an HTTP request and response.
 func NewContext(op *huma.Operation, r bunrouter.Request, w http.ResponseWriter) huma.Context {
 	return &bunContext{op: op, r: r, w: w}
@@ -196,6 +201,10 @@ func (c *bunCompatContext) SetHeader(name string, value string) {
 
 func (c *bunCompatContext) BodyWriter() io.Writer {
 	return c.w
+}
+
+func (c *bunCompatContext) TLS() *tls.ConnectionState {
+	return c.r.TLS
 }
 
 // NewCompatContext creates a new Huma context from an HTTP request and response.

--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -2,6 +2,7 @@ package humachi
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -104,6 +105,10 @@ func (c *chiContext) SetHeader(name string, value string) {
 
 func (c *chiContext) BodyWriter() io.Writer {
 	return c.w
+}
+
+func (c *chiContext) TLS() *tls.ConnectionState {
+	return c.r.TLS
 }
 
 // NewContext creates a new Huma context from an HTTP request and response.

--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -111,6 +111,14 @@ func (c *chiContext) TLS() *tls.ConnectionState {
 	return c.r.TLS
 }
 
+func (c *chiContext) Version() huma.ProtoVersion {
+	return huma.ProtoVersion{
+		Proto:      c.r.Proto,
+		ProtoMajor: c.r.ProtoMajor,
+		ProtoMinor: c.r.ProtoMinor,
+	}
+}
+
 // NewContext creates a new Huma context from an HTTP request and response.
 func NewContext(op *huma.Operation, r *http.Request, w http.ResponseWriter) huma.Context {
 	return &chiContext{op: op, r: r, w: w}

--- a/adapters/humaecho/humaecho.go
+++ b/adapters/humaecho/humaecho.go
@@ -2,6 +2,7 @@ package humaecho
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -102,6 +103,10 @@ func (c *echoCtx) SetHeader(name, value string) {
 
 func (c *echoCtx) BodyWriter() io.Writer {
 	return c.orig.Response()
+}
+
+func (c *echoCtx) TLS() *tls.ConnectionState {
+	return c.orig.Request().TLS
 }
 
 type router interface {

--- a/adapters/humaecho/humaecho.go
+++ b/adapters/humaecho/humaecho.go
@@ -109,6 +109,15 @@ func (c *echoCtx) TLS() *tls.ConnectionState {
 	return c.orig.Request().TLS
 }
 
+func (c *echoCtx) Version() huma.ProtoVersion {
+	r := c.orig.Request()
+	return huma.ProtoVersion{
+		Proto:      r.Proto,
+		ProtoMajor: r.ProtoMajor,
+		ProtoMinor: r.ProtoMinor,
+	}
+}
+
 type router interface {
 	Add(method, path string, handler echo.HandlerFunc, middlewares ...echo.MiddlewareFunc) *echo.Route
 }

--- a/adapters/humafiber/humafiber.go
+++ b/adapters/humafiber/humafiber.go
@@ -3,6 +3,7 @@ package humafiber
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -109,6 +110,10 @@ func (c *fiberCtx) SetHeader(name string, value string) {
 
 func (c *fiberCtx) BodyWriter() io.Writer {
 	return c.orig
+}
+
+func (c *fiberCtx) TLS() *tls.ConnectionState {
+	return c.orig.Context().TLSConnectionState()
 }
 
 type router interface {

--- a/adapters/humafiber/humafiber.go
+++ b/adapters/humafiber/humafiber.go
@@ -116,6 +116,12 @@ func (c *fiberCtx) TLS() *tls.ConnectionState {
 	return c.orig.Context().TLSConnectionState()
 }
 
+func (c *fiberCtx) Version() huma.ProtoVersion {
+	return huma.ProtoVersion{
+		Proto: c.orig.Protocol(),
+	}
+}
+
 type router interface {
 	Add(method, path string, handlers ...fiber.Handler) fiber.Router
 }

--- a/adapters/humaflow/humaflow.go
+++ b/adapters/humaflow/humaflow.go
@@ -2,6 +2,7 @@ package humaflow
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -101,6 +102,10 @@ func (c *goContext) SetHeader(name string, value string) {
 
 func (c *goContext) BodyWriter() io.Writer {
 	return c.w
+}
+
+func (c *goContext) TLS() *tls.ConnectionState {
+	return c.r.TLS
 }
 
 // NewContext creates a new Huma context from an HTTP request and response.

--- a/adapters/humaflow/humaflow.go
+++ b/adapters/humaflow/humaflow.go
@@ -108,6 +108,14 @@ func (c *goContext) TLS() *tls.ConnectionState {
 	return c.r.TLS
 }
 
+func (c *goContext) Version() huma.ProtoVersion {
+	return huma.ProtoVersion{
+		Proto:      c.r.Proto,
+		ProtoMajor: c.r.ProtoMajor,
+		ProtoMinor: c.r.ProtoMinor,
+	}
+}
+
 // NewContext creates a new Huma context from an HTTP request and response.
 func NewContext(op *huma.Operation, r *http.Request, w http.ResponseWriter) huma.Context {
 	return &goContext{op: op, r: r, w: w}

--- a/adapters/humagin/humagin.go
+++ b/adapters/humagin/humagin.go
@@ -2,6 +2,7 @@ package humagin
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -102,6 +103,10 @@ func (c *ginCtx) SetHeader(name string, value string) {
 
 func (c *ginCtx) BodyWriter() io.Writer {
 	return c.orig.Writer
+}
+
+func (c *ginCtx) TLS() *tls.ConnectionState {
+	return c.orig.Request.TLS
 }
 
 // Router is an interface that wraps the Gin router's Handle method.

--- a/adapters/humagin/humagin.go
+++ b/adapters/humagin/humagin.go
@@ -109,6 +109,14 @@ func (c *ginCtx) TLS() *tls.ConnectionState {
 	return c.orig.Request.TLS
 }
 
+func (c *ginCtx) Version() huma.ProtoVersion {
+	return huma.ProtoVersion{
+		Proto:      c.orig.Request.Proto,
+		ProtoMajor: c.orig.Request.ProtoMajor,
+		ProtoMinor: c.orig.Request.ProtoMinor,
+	}
+}
+
 // Router is an interface that wraps the Gin router's Handle method.
 type Router interface {
 	Handle(string, string, ...gin.HandlerFunc) gin.IRoutes

--- a/adapters/humago/humago.go
+++ b/adapters/humago/humago.go
@@ -2,6 +2,7 @@ package humago
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -110,6 +111,10 @@ func (c *goContext) SetHeader(name string, value string) {
 
 func (c *goContext) BodyWriter() io.Writer {
 	return c.w
+}
+
+func (c *goContext) TLS() *tls.ConnectionState {
+	return c.r.TLS
 }
 
 // NewContext creates a new Huma context from an HTTP request and response.

--- a/adapters/humago/humago.go
+++ b/adapters/humago/humago.go
@@ -117,6 +117,14 @@ func (c *goContext) TLS() *tls.ConnectionState {
 	return c.r.TLS
 }
 
+func (c *goContext) Version() huma.ProtoVersion {
+	return huma.ProtoVersion{
+		Proto:      c.r.Proto,
+		ProtoMajor: c.r.ProtoMajor,
+		ProtoMinor: c.r.ProtoMinor,
+	}
+}
+
 // NewContext creates a new Huma context from an HTTP request and response.
 func NewContext(op *huma.Operation, r *http.Request, w http.ResponseWriter) huma.Context {
 	return &goContext{op: op, r: r, w: w}

--- a/adapters/humahttprouter/humahttprouter.go
+++ b/adapters/humahttprouter/humahttprouter.go
@@ -2,6 +2,7 @@ package humahttprouter
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -105,6 +106,10 @@ func (c *httprouterContext) SetHeader(name string, value string) {
 
 func (c *httprouterContext) BodyWriter() io.Writer {
 	return c.w
+}
+
+func (c *httprouterContext) TLS() *tls.ConnectionState {
+	return c.r.TLS
 }
 
 type httprouterAdapter struct {

--- a/adapters/humahttprouter/humahttprouter.go
+++ b/adapters/humahttprouter/humahttprouter.go
@@ -112,6 +112,14 @@ func (c *httprouterContext) TLS() *tls.ConnectionState {
 	return c.r.TLS
 }
 
+func (c *httprouterContext) Version() huma.ProtoVersion {
+	return huma.ProtoVersion{
+		Proto:      c.r.Proto,
+		ProtoMajor: c.r.ProtoMajor,
+		ProtoMinor: c.r.ProtoMinor,
+	}
+}
+
 type httprouterAdapter struct {
 	router *httprouter.Router
 }

--- a/adapters/humamux/humamux.go
+++ b/adapters/humamux/humamux.go
@@ -2,6 +2,7 @@ package humamux
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -61,6 +62,10 @@ func (c *gmuxContext) Query(name string) string {
 
 func (c *gmuxContext) Header(name string) string {
 	return c.r.Header.Get(name)
+}
+
+func (c *gmuxContext) TLS() *tls.ConnectionState {
+	return c.r.TLS
 }
 
 func (c *gmuxContext) EachHeader(cb func(name, value string)) {

--- a/adapters/humamux/humamux.go
+++ b/adapters/humamux/humamux.go
@@ -68,6 +68,14 @@ func (c *gmuxContext) TLS() *tls.ConnectionState {
 	return c.r.TLS
 }
 
+func (c *gmuxContext) Version() huma.ProtoVersion {
+	return huma.ProtoVersion{
+		Proto:      c.r.Proto,
+		ProtoMajor: c.r.ProtoMajor,
+		ProtoMinor: c.r.ProtoMinor,
+	}
+}
+
 func (c *gmuxContext) EachHeader(cb func(name, value string)) {
 	for name, values := range c.r.Header {
 		for _, value := range values {

--- a/api.go
+++ b/api.go
@@ -69,7 +69,7 @@ type Context interface {
 
 	TLS() *tls.ConnectionState
 
-	//ApiVersion() string
+	Version() ProtoVersion
 
 	// Method returns the HTTP method for the request.
 	Method() string
@@ -120,6 +120,13 @@ type Context interface {
 
 	// BodyWriter returns the response body writer.
 	BodyWriter() io.Writer
+}
+
+// Represent http protocol version
+type ProtoVersion struct {
+	Proto      string
+	ProtoMajor int
+	ProtoMinor int
 }
 
 type (

--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package huma
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -65,6 +66,10 @@ type Context interface {
 
 	// Context returns the underlying request context.
 	Context() context.Context
+
+	TLS() *tls.ConnectionState
+
+	//ApiVersion() string
 
 	// Method returns the HTTP method for the request.
 	Method() string

--- a/api.go
+++ b/api.go
@@ -67,8 +67,10 @@ type Context interface {
 	// Context returns the underlying request context.
 	Context() context.Context
 
+	// TLS / SSL connection information.
 	TLS() *tls.ConnectionState
 
+	// Version of the HTTP protocol as text and integers.
 	Version() ProtoVersion
 
 	// Method returns the HTTP method for the request.


### PR DESCRIPTION
Hi, 
I added new methods: Version/TLS to adapter (issue: https://github.com/danielgtaylor/huma/issues/590) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced context interfaces across multiple adapters to include methods for retrieving TLS connection states and HTTP protocol versions.
	- Introduced a new `ProtoVersion` type for encapsulating HTTP protocol details.

- **Bug Fixes**
	- Improved middleware application for API instances to ensure consistent handling of HTTP context and version across adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->