### PR TITLE
fix: recompute property names after schema transform

### DIFF
--- a/huma_test.go
+++ b/huma_test.go
@@ -1951,13 +1951,13 @@ func TestExhaustiveErrors(t *testing.T) {
 				"location": "path.id",
 				"value": 15
 			}, {
-				"message": "expected length <= 10",
-				"location": "body.name",
-				"value": "12345678901"
-			}, {
 				"message": "expected number >= 1",
 				"location": "body.count",
 				"value": -6
+			}, {
+				"message": "expected length <= 10",
+				"location": "body.name",
+				"value": "12345678901"
 			}, {
 				"message": "input resolver error",
 				"location": "path.id",

--- a/schema.go
+++ b/schema.go
@@ -290,18 +290,15 @@ func (s *Schema) PrecomputeMessages() {
 		}
 	}
 
-	if s.propertyNames == nil {
-		s.propertyNames = make([]string, 0, len(s.Properties))
-		for name := range s.Properties {
-			s.propertyNames = append(s.propertyNames, name)
-		}
+	s.propertyNames = make([]string, 0, len(s.Properties))
+	for name := range s.Properties {
+		s.propertyNames = append(s.propertyNames, name)
 	}
+	sort.Strings(s.propertyNames)
 
-	if s.requiredMap == nil {
-		s.requiredMap = map[string]bool{}
-		for _, name := range s.Required {
-			s.requiredMap[name] = true
-		}
+	s.requiredMap = map[string]bool{}
+	for _, name := range s.Required {
+		s.requiredMap[name] = true
 	}
 
 	if s.Items != nil {
@@ -672,7 +669,10 @@ func SchemaFromType(r Registry, t reflect.Type) *Schema {
 	// Transform generated schema if type implements SchemaTransformer
 	v := reflect.New(t).Interface()
 	if st, ok := v.(SchemaTransformer); ok {
-		return st.TransformSchema(r, s)
+		s = st.TransformSchema(r, s)
+
+		// The schema may have been modified, so recompute the error messages.
+		s.PrecomputeMessages()
 	}
 	return s
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -1448,7 +1448,7 @@ func TestValidateSchemaTransformerDeleteField(t *testing.T) {
 
 	huma.Validate(registry, s, pb, huma.ModeReadFromServer, map[string]any{"field1": "value1"}, res)
 	// We should have no errors and no panics.
-	assert.Len(t, res.Errors, 0)
+	assert.Empty(t, res.Errors)
 }
 
 func ExampleModelValidator() {

--- a/validate_test.go
+++ b/validate_test.go
@@ -1449,6 +1449,7 @@ func TestValidateSchemaTransformerDeleteField(t *testing.T) {
 	huma.Validate(registry, s, pb, huma.ModeReadFromServer, map[string]any{"field1": "value1"}, res)
 	// We should have no errors and no panics.
 	assert.Empty(t, res.Errors)
+	assert.NotContains(t, s.Properties, "field2")
 }
 
 func ExampleModelValidator() {

--- a/validate_test.go
+++ b/validate_test.go
@@ -1428,6 +1428,29 @@ func TestValidateCustomFormatter(t *testing.T) {
 	assert.Equal(t, "custom: [mail: missing '@' or angle-addr] (value: alice)", res.Errors[0].Error())
 }
 
+type TransformDeleteField struct {
+	Field1 string `json:"field1"`
+	Field2 string `json:"field2"`
+}
+
+var _ huma.SchemaTransformer = (*TransformDeleteField)(nil)
+
+func (t *TransformDeleteField) TransformSchema(r huma.Registry, s *huma.Schema) *huma.Schema {
+	delete(s.Properties, "field2")
+	return s
+}
+
+func TestValidateSchemaTransformerDeleteField(t *testing.T) {
+	registry := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
+	s := registry.Schema(reflect.TypeOf(&TransformDeleteField{}), true, "TestInput")
+	pb := huma.NewPathBuffer([]byte(""), 0)
+	res := &huma.ValidateResult{}
+
+	huma.Validate(registry, s, pb, huma.ModeReadFromServer, map[string]any{"field1": "value1"}, res)
+	// We should have no errors and no panics.
+	assert.Len(t, res.Errors, 0)
+}
+
 func ExampleModelValidator() {
 	// Define a type you want to validate.
 	type Model struct {
@@ -1452,7 +1475,7 @@ func ExampleModelValidator() {
 	errs = validator.Validate(typ, val)
 	fmt.Println(errs)
 
-	// Output: [expected length <= 5 (name: abcdefg) expected number >= 25 (age: 1)]
+	// Output: [expected number >= 25 (age: 1) expected length <= 5 (name: abcdefg)]
 	// []
 }
 


### PR DESCRIPTION
This PR makes a few small but important changes:

1. Call `schema.PrecomputeMessages()` after a call to a `huma.SchemaTransformer` as it may have modified the schema.
2. Make `PrecomputeMessages()` recreate the property names, rather than only setting them if they don't already exist.
3. Sort the property names so the order is deterministic. This helps with testing.

Fixes #607.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced middleware functionality testing with new test cases for cookie handling, parameter validation, and response handling.
	- Introduced a new struct for schema modifications, allowing properties to be deleted.

- **Bug Fixes**
	- Improved error message clarity in schema transformations.

- **Documentation**
	- Updated test cases for better output and coverage, ensuring comprehensive validation of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->