### PR TITLE
fix: make nullable arrays configurable

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -22,6 +22,12 @@ import (
 // ErrSchemaInvalid is sent when there is a problem building the schema.
 var ErrSchemaInvalid = errors.New("schema is invalid")
 
+// DefaultArrayNullable controls whether arrays are nullable by default. Set
+// this to `false` to make arrays non-nullable by default, but be aware that
+// any `nil` slice will still encode as `null` in JSON. See also:
+// https://pkg.go.dev/encoding/json#Marshal.
+var DefaultArrayNullable = true
+
 // JSON Schema type constants
 const (
 	TypeBoolean = "boolean"
@@ -763,7 +769,7 @@ func schemaFromType(r Registry, t reflect.Type) *Schema {
 			s.ContentEncoding = "base64"
 		} else {
 			s.Type = TypeArray
-			s.Nullable = true
+			s.Nullable = DefaultArrayNullable
 			s.Items = r.Schema(t.Elem(), true, t.Name()+"Item")
 
 			if t.Kind() == reflect.Array {

--- a/schema_test.go
+++ b/schema_test.go
@@ -1319,6 +1319,22 @@ func TestMarshalDiscriminator(t *testing.T) {
 	}`, string(b))
 }
 
+func TestSchemaArrayNotNullable(t *testing.T) {
+	huma.DefaultArrayNullable = false
+	defer func() {
+		huma.DefaultArrayNullable = true
+	}()
+
+	type Value struct {
+		Field []string `json:"field"`
+	}
+
+	r := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
+	s := r.Schema(reflect.TypeOf(Value{}), false, "")
+
+	assert.Equal(t, "array", s.Properties["field"].Type)
+}
+
 type BenchSub struct {
 	Visible bool      `json:"visible" default:"true"`
 	Metrics []float64 `json:"metrics" maxItems:"31"`

--- a/schema_test.go
+++ b/schema_test.go
@@ -723,6 +723,46 @@ func TestSchema(t *testing.T) {
 			}`,
 		},
 		{
+			name: "field-nullable-array",
+			input: struct {
+				Int []int64 `json:"int" nullable:"true"`
+			}{},
+			expected: `{
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"int": {
+						"type": ["array", "null"],
+						"items": {
+							"type": "integer",
+							"format": "int64"
+						}
+					}
+				},
+				"required": ["int"]
+			}`,
+		},
+		{
+			name: "field-non-nullable-array",
+			input: struct {
+				Int []int64 `json:"int" nullable:"false"`
+			}{},
+			expected: `{
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"int": {
+						"type": "array",
+						"items": {
+							"type": "integer",
+							"format": "int64"
+						}
+					}
+				},
+				"required": ["int"]
+			}`,
+		},
+		{
 			name: "field-nullable-struct",
 			input: struct {
 				Field struct {


### PR DESCRIPTION
This is an alternative approach to #594. @lsdch would love to know what you think.

1. There is precedent in Huma to use global variables to control behavior. This adds another such value to set the default array nullability called `huma.DefaultArrayNullable`.
2. The default stays `true`, as this is more correct based on how Go marshals JSON. A `nil` slice will encode as `null` so we ask the user to opt-in to alternative behavior.
3. Updates docs to reflect this and adds a note about `nil` slices encoding as `null`.
4. Adds a few tests.

IMO this prevents another break, moving back to less correct/accurate behavior, and makes everything explicit. I'm not the biggest fan of global variables but it seems reasonable here instead of trying to plumb everything through the various types and interfaces. Thoughts?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated request validation documentation to clarify nullable fields and rules for optional and required fields.
	- Enhanced examples for making fields nullable in Go structs.

- **New Features**
	- Introduced a global variable to control the default nullability of arrays, simplifying configuration.

- **Tests**
	- Added new test cases for nullable and non-nullable arrays, improving schema validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->