### PR TITLE
feat: unwrap resp for better deadline/flush SSE support

### DIFF
--- a/sse/sse.go
+++ b/sse/sse.go
@@ -160,7 +160,7 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 				send := func(msg Message) error {
 					if deadliner != nil {
 						if err := deadliner.SetWriteDeadline(time.Now().Add(WriteTimeout)); err != nil {
-							fmt.Println("warning: unable to set write deadline: %w", err)
+							fmt.Println("warning: unable to set write deadline: " + err.Error())
 						}
 					} else {
 						fmt.Println("warning: unable to set write deadline")

--- a/sse/sse.go
+++ b/sse/sse.go
@@ -24,6 +24,14 @@ func deref(t reflect.Type) reflect.Type {
 	return t
 }
 
+type unwrapper interface {
+	Unwrap() http.ResponseWriter
+}
+
+type writeDeadliner interface {
+	SetWriteDeadline(time.Time) error
+}
+
 // Message is a single SSE message. There is no `event` field as this is
 // handled by the `eventTypeMap` when registering the operation.
 type Message struct {
@@ -119,9 +127,41 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 				ctx.SetHeader("Content-Type", "text/event-stream")
 				bw := ctx.BodyWriter()
 				encoder := json.NewEncoder(bw)
+
+				// Get the flusher/deadliner from the response writer if possible.
+				var flusher http.Flusher
+				flushCheck := bw
+				for {
+					if f, ok := flushCheck.(http.Flusher); ok {
+						flusher = f
+						break
+					}
+					if u, ok := flushCheck.(unwrapper); ok {
+						flushCheck = u.Unwrap()
+					} else {
+						break
+					}
+				}
+
+				var deadliner writeDeadliner
+				deadlineCheck := bw
+				for {
+					if d, ok := deadlineCheck.(writeDeadliner); ok {
+						deadliner = d
+						break
+					}
+					if u, ok := deadlineCheck.(unwrapper); ok {
+						deadlineCheck = u.Unwrap()
+					} else {
+						break
+					}
+				}
+
 				send := func(msg Message) error {
-					if d, ok := bw.(interface{ SetWriteDeadline(time.Time) error }); ok {
-						d.SetWriteDeadline(time.Now().Add(WriteTimeout))
+					if deadliner != nil {
+						if err := deadliner.SetWriteDeadline(time.Now().Add(WriteTimeout)); err != nil {
+							fmt.Println("warning: unable to set write deadline: %w", err)
+						}
 					} else {
 						fmt.Println("warning: unable to set write deadline")
 					}
@@ -155,8 +195,8 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 						return err
 					}
 					bw.Write([]byte("\n"))
-					if f, ok := bw.(http.Flusher); ok {
-						f.Flush()
+					if flusher != nil {
+						flusher.Flush()
 					} else {
 						fmt.Println("error: unable to flush")
 						return fmt.Errorf("unable to flush: %w", http.ErrNotSupported)


### PR DESCRIPTION
This PR adds support for unwrapping HTTP response writers similar to how Go's built-in `http.ResponseController` handles it to enable better support for setting write deadlines and flushing during Server Sent Events handling in various routers. This fixes some issues with Chi and Gin, and updates the SSE example to be able to run with either router to show that it works.

Fixes #491. Related to https://github.com/go-chi/chi/issues/947.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced server functionality to support multiple router options for Server-Sent Events (SSE).
	- Introduced new interfaces for improved handling of HTTP response writers.

- **Bug Fixes**
	- Improved error handling for write deadlines in SSE requests.

- **Tests**
	- Expanded test cases for the `DummyWriter` to cover new error scenarios related to write deadlines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->