### PR TITLE
Update cli-client.md

### DIFF
--- a/docs/docs/tutorial/cli-client.md
+++ b/docs/docs/tutorial/cli-client.md
@@ -61,7 +61,7 @@ Once configured, you can call the API operations using high-level commands gener
 
 {{ asciinema("../../terminal/restish-call.cast", rows="20") }}
 
-See the help commands like `restish tutorial --help` or `restish tutorial get-greeting --help` for more details. If you set up command-line completion, you can also use tab to see all available commands.
+See the help commands like `restish tutorial --help` or `restish tutorial get-greeting-by-name --help` for more details. If you set up command-line completion, you can also use tab to see all available commands.
 
 ## Review
 


### PR DESCRIPTION
Typo in `.cast` also should be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the CLI Client documentation to reflect the new command for retrieving a greeting: changed from `restish tutorial get-greeting --help` to `restish tutorial get-greeting-by-name --help`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->