### PR TITLE
docs: fix YAML command example

### DIFF
--- a/docs/docs/features/cli.md
+++ b/docs/docs/features/cli.md
@@ -135,11 +135,18 @@ cli.Root().AddCommand(&cobra.Command{
 	Use:   "openapi",
 	Short: "Print the OpenAPI spec",
 	Run: func(cmd *cobra.Command, args []string) {
-		b, _ := yaml.Marshal(api.OpenAPI())
+		b, err := api.OpenAPI().YAML()
+		if err != nil {
+			panic(err)
+		}
 		fmt.Println(string(b))
 	},
 })
 ```
+
+!!! info "Note"
+
+    You can use `api.OpenAPI().DowngradeYAML()` to output OpenAPI 3.0 instead of 3.1 for tools that don't support 3.1 yet.
 
 Now you can run your service and use the new command: `go run . openapi`. Notice that it never starts the server; it just runs your command handler code. Some ideas for custom commands:
 


### PR DESCRIPTION
This PR updates the example command to use the `OpenAPI().YAML()` method which handles serialization to YAML for you without the need of a third-party library and taking into account custom serialization logic.

Fixes #618.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded documentation for the Service CLI, including detailed guidance on input options, command usage, and custom commands.
	- Added instructions for setting application name and version in help output.
	- Included a note on downgrading OpenAPI output to version 3.0 for compatibility.

- **Bug Fixes**
	- Improved error handling for the OpenAPI command.

- **Documentation**
	- Enhanced structure and clarity of the CLI documentation for better navigation and understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->