### PR TITLE
feat: allow scalar pointers with defaults

### DIFF
--- a/docs/docs/features/request-validation.md
+++ b/docs/docs/features/request-validation.md
@@ -142,6 +142,22 @@ Built-in string formats include:
 | `regex`                           | Regular expression              | `[a-z]+`                               |
 | `uuid`                            | UUID                            | `550e8400-e29b-41d4-a716-446655440000` |
 
+### Defaults
+
+The `default` field validation tag listed above is used to both document the existence of a server-side default value as well as to automatically have Huma set that value for you. This is useful for fields that are optional but have a default value if not provided.
+
+Similar to how the standard library JSON unmarshaler works, it is recommended to use pointers for scalar types where the zero value has semantic meaning to your application. For example, if you have a `bool` field that defaults to `true`, you should use a `*bool` field and set the default to `true`. This way, if the field is not provided, the default value will be used.
+
+```go title="code.go"
+type MyInput struct {
+	Body struct {
+		Enabled *bool `json:"enabled" default:"true"`
+	}
+}
+```
+
+If you had used `bool` instead of `*bool` then the zero value of `false` would get overridden by the default value of `true`, even if false is explictly sent by the client.
+
 ### Read and Write Only
 
 Note that the `readOnly` and `writeOnly` validations are not enforced by Huma and the values in those fields are not modified by Huma. They are purely for documentation purposes and allow you to re-use structs for both inputs and outputs.

--- a/huma_test.go
+++ b/huma_test.go
@@ -665,7 +665,7 @@ func TestFeatures(t *testing.T) {
 					}
 				}) (*struct{}, error) {
 					assert.EqualValues(t, "Huma", *input.Body.Name)
-					assert.EqualValues(t, true, *input.Body.Enabled)
+					assert.True(t, *input.Body.Enabled)
 					assert.EqualValues(t, []*string{Ptr("foo"), Ptr("bar")}, input.Body.Tags)
 					assert.EqualValues(t, []*int{Ptr(1), Ptr(2), Ptr(3)}, input.Body.Numbers)
 					assert.Equal(t, 1, input.Body.Items[0].ID)
@@ -697,7 +697,7 @@ func TestFeatures(t *testing.T) {
 				}) (*struct{}, error) {
 					// Ensure we can send the zero value and it doesn't get overridden.
 					assert.EqualValues(t, "", *input.Body.Name)
-					assert.EqualValues(t, false, *input.Body.Enabled)
+					assert.False(t, *input.Body.Enabled)
 					assert.Equal(t, 1, input.Body.Items[0].ID)
 					assert.False(t, *input.Body.Items[0].Verified)
 					return nil, nil

--- a/huma_test.go
+++ b/huma_test.go
@@ -670,12 +670,14 @@ func TestFeatures(t *testing.T) {
 					assert.EqualValues(t, []*int{Ptr(1), Ptr(2), Ptr(3)}, input.Body.Numbers)
 					assert.Equal(t, 1, input.Body.Items[0].ID)
 					assert.True(t, *input.Body.Items[0].Verified)
+					assert.Equal(t, 2, input.Body.Items[1].ID)
+					assert.False(t, *input.Body.Items[1].Verified)
 					return nil, nil
 				})
 			},
 			Method: http.MethodPut,
 			URL:    "/body",
-			Body:   `{"items": [{"id": 1}]}`,
+			Body:   `{"items": [{"id": 1}, {"id": 2, "verified": false}]}`,
 		},
 		{
 			Name: "request-body-pointer-defaults-set",
@@ -688,24 +690,17 @@ func TestFeatures(t *testing.T) {
 						// Test defaults for primitive types.
 						Name    *string `json:"name,omitempty" default:"Huma"`
 						Enabled *bool   `json:"enabled,omitempty" default:"true"`
-						// Test defaults for fields within slices of structs.
-						Items []struct {
-							ID       int   `json:"id"`
-							Verified *bool `json:"verified,omitempty" default:"true"`
-						} `json:"items,omitempty"`
 					}
 				}) (*struct{}, error) {
 					// Ensure we can send the zero value and it doesn't get overridden.
 					assert.EqualValues(t, "", *input.Body.Name)
 					assert.False(t, *input.Body.Enabled)
-					assert.Equal(t, 1, input.Body.Items[0].ID)
-					assert.False(t, *input.Body.Items[0].Verified)
 					return nil, nil
 				})
 			},
 			Method: http.MethodPut,
 			URL:    "/body",
-			Body:   `{"name": "", "enabled": false, "items": [{"id": 1, "verified": false}]}`,
+			Body:   `{"name": "", "enabled": false}`,
 		},
 		{
 			Name: "request-body-required",


### PR DESCRIPTION
This PR is an attempt to fix a long-standing issue where defaults would override explicitly sent zero values from a client if the zero value has semantic meaning for an operation handler.

It implements a new feature that allows the use of scalar pointers with defaults to match the existing behavior of the standard library JSON and other marshaling packages like https://github.com/fxamacker/cbor, which is to use a scalar pointer to determine whether a value has been set by a client or not. You can now do something like this:

```go
type MyInput struct {
	Body struct {
		Enabled *bool `json:"enabled,omitempty" default:"true"`
	}
}
```

The behavior is:

| Client sends | Handler sees |
| -------------|-------------- |
| `true` | `true` |
| `false` | `false` |
| `null` / `undefined` | `true` |

This implementation does not require any additional marshal/unmarshal steps or impact the performance of the running service. It does require some additional reflection & conversions on service startup, but that's a one-time cost and the additional code complexity is not too bad.

Just to note, you still cannot provide defaults for pointers to structs. It would be possible to support this but requires different unmarshaling code in `jsonTagValue` so I'm not going to implement it unless there is a good reason to do so.

FYI @Grumpfy, @robsonpeixoto, @barata0 - what do you think?

Fixes #597, #627, #628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Expanded and clarified request validation documentation, including details on struct tags, optional/required fields, nullable fields, and validation tags.
	- Added sections on defaults, read/write-only fields, strict vs. loose validation, and advanced validation rules.

- **Bug Fixes**
	- Improved error handling and parameter processing in the API framework, enhancing clarity and robustness.

- **Tests**
	- Enhanced middleware and request handling tests, including scenarios for cookie handling and request bodies with pointers.
	- Added tests for various error conditions and improved OpenAPI documentation generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->