### PR TITLE
Update build-sdk.sh

### DIFF
--- a/docs/terminal/build-sdk.sh
+++ b/docs/terminal/build-sdk.sh
@@ -3,7 +3,7 @@
 go run . openapi >openapi.yaml
 
 # Install the SDK generator
-go install github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@latest
+go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
 
 # Generate the SDK
 mkdir -p sdk


### PR DESCRIPTION
The install instruction does not work anymore, updated it with the new install instruction from https://github.com/oapi-codegen/oapi-codegen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the installation command for the OpenAPI code generator in the build script, ensuring continued functionality and access to the latest SDK generation tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->