### PR TITLE
refactor: use WriteErr function for handling error returned by handler

### DIFF
--- a/error.go
+++ b/error.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 )
 
 // ErrorDetailer returns error details for responses & debugging. This enables
@@ -262,47 +261,12 @@ func WriteErr(api API, ctx Context, status int, msg string, errs ...error) error
 	// If it was not modified then this is a no-op.
 	status = err.GetStatus()
 
-	ct, negotiateErr := api.Negotiate(ctx.Header("Accept"))
-	if negotiateErr != nil {
-		return negotiateErr
+	writeErr := writeResponse(api, ctx, status, "", err)
+	if writeErr != nil {
+		// If we can't write the error, log it so we know what happened.
+		fmt.Printf("could not write error: %s\n", writeErr)
 	}
-
-	if ctf, ok := err.(ContentTypeFilter); ok {
-		ct = ctf.ContentType(ct)
-	}
-
-	ctx.SetHeader("Content-Type", ct)
-	ctx.SetStatus(status)
-	tval, terr := api.Transform(ctx, strconv.Itoa(status), err)
-	if terr != nil {
-		return terr
-	}
-	return api.Marshal(ctx.BodyWriter(), ct, tval)
-}
-
-func writeStatusError(api API, ctx Context, err StatusError) error {
-	ct, negotiateErr := api.Negotiate(ctx.Header("Accept"))
-	if negotiateErr != nil {
-		return fmt.Errorf("failed to write status error: %w", negotiateErr)
-	}
-	if ctf, ok := err.(ContentTypeFilter); ok {
-		ct = ctf.ContentType(ct)
-	}
-	ctx.SetHeader("Content-Type", ct)
-
-	status := err.GetStatus()
-	ctx.SetStatus(status)
-
-	// If request accept no output, just set the status code and return.
-	if status == http.StatusNoContent || status == http.StatusNotModified {
-		return nil
-	}
-
-	tval, terr := api.Transform(ctx, strconv.Itoa(status), err)
-	if terr != nil {
-		return terr
-	}
-	return api.Marshal(ctx.BodyWriter(), ct, tval)
+	return writeErr
 }
 
 // Status304NotModified returns a 304. This is not really an error, but

--- a/error_test.go
+++ b/error_test.go
@@ -83,7 +83,7 @@ func TestNegotiateError(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/", nil)
 	resp := httptest.NewRecorder()
-	ctx := humatest.NewContext(nil, req, resp)
+	ctx := humatest.NewContext(&huma.Operation{}, req, resp)
 	require.Error(t, huma.WriteErr(api, ctx, 400, "bad request"))
 }
 
@@ -98,7 +98,7 @@ func TestTransformError(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/", nil)
 	resp := httptest.NewRecorder()
-	ctx := humatest.NewContext(nil, req, resp)
+	ctx := humatest.NewContext(&huma.Operation{}, req, resp)
 
 	require.Error(t, huma.WriteErr(api, ctx, 400, "bad request"))
 }

--- a/huma.go
+++ b/huma.go
@@ -962,7 +962,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 							if f.Type() == reflect.TypeOf(values) {
 								f.Set(reflect.ValueOf(values))
 							} else {
-								//Change element type to support slice of string subtypes (enums)
+								// Change element type to support slice of string subtypes (enums)
 								enumValues := reflect.New(f.Type()).Elem()
 								for _, val := range values {
 									enumVal := reflect.New(f.Type().Elem()).Elem()
@@ -1407,7 +1407,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 				status = se.GetStatus()
 				err = se
 			} else {
-				err = NewError(http.StatusInternalServerError, err.Error())
+				err = NewErrorWithContext(ctx, http.StatusInternalServerError, "unexpected error occurred", err)
 			}
 
 			ct, _ := api.Negotiate(ctx.Header("Accept"))

--- a/huma_test.go
+++ b/huma_test.go
@@ -1372,7 +1372,7 @@ Content of example2.txt.
 					Method: http.MethodGet,
 					Path:   "/error",
 				}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
-					return nil, fmt.Errorf("whoops")
+					return nil, errors.New("whoops")
 				})
 			},
 			Method: http.MethodGet,

--- a/huma_test.go
+++ b/huma_test.go
@@ -1366,6 +1366,22 @@ Content of example2.txt.
 			},
 		},
 		{
+			Name: "handler-generic-error",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/error",
+				}, func(ctx context.Context, input *struct{}) (*struct{}, error) {
+					return nil, fmt.Errorf("whoops")
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/error",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusInternalServerError, resp.Code)
+			},
+		},
+		{
 			Name: "response-headers",
 			Register: func(t *testing.T, api huma.API) {
 				type Resp struct {

--- a/openapi.go
+++ b/openapi.go
@@ -863,7 +863,8 @@ type Operation struct {
 	// This is a convenience for handlers that return a fixed set of errors
 	// where you do not wish to provide each one as an OpenAPI response object.
 	// Each error specified here is expanded into a response object with the
-	// schema generated from the type returned by `huma.NewError()`.
+	// schema generated from the type returned by `huma.NewError()`
+	// or `huma.NewErrorWithContext`.
 	Errors []int `yaml:"-"`
 
 	// SkipValidateParams disables validation of path, query, and header


### PR DESCRIPTION
First of all, thank you for maintating the Huma framework active. I'm using it for personal projects, and I can write code more conveniently and elegantly than before.

# What is this PR?

This PR refactors error handling logic in `Register` function to use `WriteErr` function.

# Context

`Register` function can register handler and include handling logic for overall request-response lifecycle. If the registered handler returns an `error`, the error is handled according to the error type. For now, there is 2 types of error(`StatusError` and plain error).

In the previous code, if the error returned from the handler is `StatusError`  use it for response body, else(in case of plain `error`) instantiate response body using the `NewError` function. And then write response by calling the `transformAndWrite` function within the same file.


# Why do this?

I think if the returned from the handler is plain `error`, it should be use `NewErrorWithContext` instead of `NewError` to ensure consistent behavior within framework. That's exactly why the `NewErrorWithContext` and `WriteErr` functions exist for this as I understand. Error handling in other part of the function already use `WriteErr`, so the code in this PR may be changed together.

# What will be changed?
- Add `writeStatusError` function
For `StatusError`, it works as same before using new `writeStatusError` function. `writeStatusError` function acts like `WriteErr` function include content negotitation, set status code, but the only difference is that `NewErrorWithContext` does not create a response body, and the received `StatusError` by function parameter is used immediately for the response.

- Use `WriteErr` function for plain `error`
`WriteErr` function do the almost same thing with `transformAndWrite` function except the `transformAndWrite` function receive the response body by parameter. So I refactor this part to use `WriteErr` function.


# Expectations
- By using custom `NewErrorWIthContext`, Huma can intercept handler error. It will be a great support in implementing global error handler using Huma middleware or Sentry alerting using `context.Context` of request.


# What can do in next step?
I think the `StatusError` handling in the same part should also be able to use `huma.Context` so that every error inside Huma can be handled with consistent behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a centralized error handling function for improved status error management.
	- Added a new response writing function to enhance content type negotiation and error handling.
	- Implemented a test case for simulating and validating generic error responses.

- **Bug Fixes**
	- Improved robustness of error reporting and response structure.

- **Documentation**
	- Updated comments for clarity regarding error handling methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->