### PR TITLE
fix: marking visited types in findInType

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -402,7 +402,6 @@ func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T]
 		if _, ok := visited[t]; ok {
 			return
 		}
-		visited[t] = struct{}{}
 		for i := 0; i < t.NumField(); i++ {
 			f := t.Field(i)
 			if !f.IsExported() {
@@ -425,7 +424,9 @@ func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T]
 				// Always process embedded structs and named fields which are not
 				// structs. If `recurseFields` is true then we also process named
 				// struct fields recursively.
+				visited[t] = struct{}{}
 				_findInType(f.Type, fi, result, onType, onField, recurseFields, visited, ignore...)
+				delete(visited, t)
 			}
 		}
 	case reflect.Slice:

--- a/huma_test.go
+++ b/huma_test.go
@@ -72,6 +72,10 @@ type BodyContainer struct {
 
 type CustomStringParam string
 
+type StructWithDefaultField struct {
+	Field string `json:"field" default:"default"`
+}
+
 func TestFeatures(t *testing.T) {
 	for _, feature := range []struct {
 		Name         string
@@ -628,6 +632,11 @@ func TestFeatures(t *testing.T) {
 							ID       int  `json:"id"`
 							Verified bool `json:"verified,omitempty" default:"true"`
 						} `json:"items,omitempty"`
+						// Test defaults for fields in the same linked struct. Even though
+						// we have seen the struct before we still need to set the default
+						// since it's a new/different field.
+						S1 StructWithDefaultField `json:"s1,omitempty"`
+						S2 StructWithDefaultField `json:"s2,omitempty"`
 					}
 				}) (*struct{}, error) {
 					assert.Equal(t, "Huma", input.Body.Name)
@@ -636,6 +645,8 @@ func TestFeatures(t *testing.T) {
 					assert.Equal(t, []int{1, 2, 3}, input.Body.Numbers)
 					assert.Equal(t, 1, input.Body.Items[0].ID)
 					assert.True(t, input.Body.Items[0].Verified)
+					assert.Equal(t, "default", input.Body.S1.Field)
+					assert.Equal(t, "default", input.Body.S2.Field)
 					return nil, nil
 				})
 			},


### PR DESCRIPTION
This fixes a bug where `findInType` would skip fields of a type it had already seen, when the correct behavior is only to skip fields in a recursive chain it had already seen. This moves the `visited` map modification tightly around the recursive case and adds a test to ensure multiple defaults for the same type used in different fields are indeed set correctly.

Fixes #630.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced parameter finding and validation logic for nested and complex types.
	- Introduced a new struct with default field values for improved request handling.

- **Bug Fixes**
	- Improved handling of visited types to prevent infinite loops during recursive processing.
	- Enhanced error handling and validation checks for parameters.

- **Tests**
	- Added tests for new struct behavior and default values, ensuring correct integration with request bodies and middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->