### PR TITLE
fix: dump body directly if json indent fails

### DIFF
--- a/humatest/humatest.go
+++ b/humatest/humatest.go
@@ -345,7 +345,10 @@ func dumpBody(body io.ReadCloser, buf *bytes.Buffer) (io.ReadCloser, error) {
 	}
 	body.Close()
 	if strings.Contains(buf.String(), "json") {
-		json.Indent(buf, b, "", "  ")
+		if err := json.Indent(buf, b, "", "  "); err != nil {
+			// Indent failed, so just write the buffer.
+			buf.Write(b)
+		}
 	} else {
 		buf.Write(b)
 	}

--- a/humatest/humatest_test.go
+++ b/humatest/humatest_test.go
@@ -151,7 +151,7 @@ func TestNewAPI(t *testing.T) {
 }
 
 func TestDumpBodyError(t *testing.T) {
-	req, _ := http.NewRequest(http.MethodGet, "http://example.com/foo?bar=baz", nil)
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/foo?bar=baz", nil)
 	req.Header.Set("Foo", "bar")
 	req.Host = "example.com"
 	req.Body = io.NopCloser(iotest.ErrReader(io.ErrUnexpectedEOF))
@@ -163,6 +163,17 @@ func TestDumpBodyError(t *testing.T) {
 	// Error should be passed through.
 	_, err = io.ReadAll(req.Body)
 	require.Error(t, err)
+}
+
+func TestDumpBodyInvalidJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/foo?bar=baz", nil)
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "example.com"
+	req.Body = io.NopCloser(strings.NewReader("invalid json"))
+
+	b, err := DumpRequest(req)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "invalid json")
 }
 
 func TestOpenAPIRequired(t *testing.T) {


### PR DESCRIPTION
Small fix for when the JSON is invalid (or not actually JSON). This makes sure it is still put into the response rather than accidentally dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling during JSON indentation to ensure valid output even when formatting fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->