### PR TITLE
fix: make content negotiation more resilient to bad input

### DIFF
--- a/negotiation/negotiation_test.go
+++ b/negotiation/negotiation_test.go
@@ -50,6 +50,11 @@ func TestNoMatchFast(t *testing.T) {
 	assert.Equal(t, "", SelectQValueFast("a; q=1.0, b;q=1.0,c; q=0.3", []string{"d", "e"}))
 }
 
+func TestMalformedFast(t *testing.T) {
+	assert.Equal(t, "", SelectQValueFast("a;,", []string{"d", "e"}))
+	assert.Equal(t, "a", SelectQValueFast(",a ", []string{"a", "b"}))
+}
+
 var BenchResult string
 
 func BenchmarkMatch(b *testing.B) {

--- a/negotiation/negotiation_test.go
+++ b/negotiation/negotiation_test.go
@@ -53,6 +53,9 @@ func TestNoMatchFast(t *testing.T) {
 func TestMalformedFast(t *testing.T) {
 	assert.Equal(t, "", SelectQValueFast("a;,", []string{"d", "e"}))
 	assert.Equal(t, "a", SelectQValueFast(",a ", []string{"a", "b"}))
+	assert.Equal(t, "", SelectQValueFast("a;;", []string{"a", "b"}))
+	assert.Equal(t, "", SelectQValueFast(";,", []string{"a", "b"}))
+	assert.Equal(t, "a", SelectQValueFast("a;q=invalid", []string{"a", "b"}))
 }
 
 var BenchResult string


### PR DESCRIPTION
This PR fixes a bug that caused a panic in the content negotiation package due to bad input. The code has been modified to be more resilient to bad inputs and updated to not use the `-1` sentinel value which could in some cases cause index out of bound errors. Existing tests all pass and the newly added bad inputs also work now, either returning no match or ignoring the bad part of the accept header.

Performance is still good (about 304 -> 335 ns/op) and importantly fast matching remains zero allocation:

```sh
$ go test -bench=. ./negotiation
goos: darwin
goarch: arm64
pkg: github.com/danielgtaylor/huma/v2/negotiation
cpu: Apple M3 Pro
BenchmarkMatch-12        	 2725090	       386.2 ns/op	     320 B/op	       8 allocs/op
BenchmarkMatchFast-12    	 3572018	       335.0 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/danielgtaylor/huma/v2/negotiation	3.218s
```

Fixes #639.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced parsing logic for improved performance and clarity in handling header strings.
	- Introduced a new test case for handling malformed input in the negotiation functionality.

- **Bug Fixes**
	- Improved accuracy in identifying and processing content type names in header strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->