### PR TITLE
fix: do not panic on client disconnect

### DIFF
--- a/huma_test.go
+++ b/huma_test.go
@@ -2122,7 +2122,7 @@ type BrokenWriter struct {
 }
 
 func (br *BrokenWriter) Write(p []byte) (n int, err error) {
-	return 0, fmt.Errorf("failed writing")
+	return 0, errors.New("failed writing")
 }
 
 func TestClientDisconnect(t *testing.T) {

--- a/huma_test.go
+++ b/huma_test.go
@@ -2117,6 +2117,39 @@ func TestCustomError(t *testing.T) {
 	assert.Equal(t, `{"$schema":"http://localhost/schemas/MyError.json","message":"not found","details":["some-other-error"]}`+"\n", resp.Body.String())
 }
 
+type BrokenWriter struct {
+	http.ResponseWriter
+}
+
+func (br *BrokenWriter) Write(p []byte) (n int, err error) {
+	return 0, fmt.Errorf("failed writing")
+}
+
+func TestClientDisconnect(t *testing.T) {
+	_, api := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+
+	huma.Get(api, "/error", func(ctx context.Context, i *struct{}) (*struct {
+		Body string
+	}, error) {
+		return &struct{ Body string }{Body: "test"}, nil
+	})
+
+	// Create and immediately cancel the context. This simulates a client
+	// that has disconnected.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "/error", nil)
+
+	// Also make the response writer fail when writing.
+	recorder := httptest.NewRecorder()
+	resp := &BrokenWriter{recorder}
+
+	// We do not want any panics as this is not a real error.
+	assert.NotPanics(t, func() {
+		api.Adapter().ServeHTTP(resp, req)
+	})
+}
+
 type NestedResolversStruct struct {
 	Field2 string `json:"field2"`
 }


### PR DESCRIPTION
This fix detects when a client has disconnected via a canceled context and prevents throwing and error/panic in that case.


Fixes #632.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for client disconnections, setting appropriate HTTP status codes.

- **Tests**
	- Introduced a new test case to simulate client disconnections and ensure graceful handling without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->