### PR TITLE
fix: write errors/warnings to stderr rather than stdout

### DIFF
--- a/error.go
+++ b/error.go
@@ -265,7 +265,7 @@ func WriteErr(api API, ctx Context, status int, msg string, errs ...error) error
 	writeErr := writeResponse(api, ctx, status, "", err)
 	if writeErr != nil {
 		// If we can't write the error, log it so we know what happened.
-		fmt.Fprintf(os.Stderr, "could not write error: %s\n", writeErr)
+		fmt.Fprintf(os.Stderr, "could not write error: %v\n", writeErr)
 	}
 	return writeErr
 }

--- a/error.go
+++ b/error.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 )
 
 // ErrorDetailer returns error details for responses & debugging. This enables
@@ -264,7 +265,7 @@ func WriteErr(api API, ctx Context, status int, msg string, errs ...error) error
 	writeErr := writeResponse(api, ctx, status, "", err)
 	if writeErr != nil {
 		// If we can't write the error, log it so we know what happened.
-		fmt.Printf("could not write error: %s\n", writeErr)
+		fmt.Fprintf(os.Stderr, "could not write error: %s\n", writeErr)
 	}
 	return writeErr
 }

--- a/humacli/humacli.go
+++ b/humacli/humacli.go
@@ -298,7 +298,7 @@ func New[O any](onParsed func(Hooks, *O)) CLI {
 			// Server is done, just exit.
 		case <-quit:
 			if c.stop != nil {
-				fmt.Println("Gracefully shutting down the server...")
+				fmt.Fprintln(os.Stderr, "Gracefully shutting down the server...")
 				c.stop()
 			}
 		}

--- a/humacli/humacli.go
+++ b/humacli/humacli.go
@@ -165,7 +165,7 @@ func (c *cli[O]) setupOptions(t reflect.Type, path []int) {
 		if !field.IsExported() {
 			// This isn't a public field, so we cannot use reflect.Value.Set with
 			// it. This is usually a struct field with a lowercase name.
-			fmt.Println("warning: ignoring unexported options field", field.Name)
+			fmt.Fprintln(os.Stderr, "warning: ignoring unexported options field", field.Name)
 			continue
 		}
 

--- a/sse/sse.go
+++ b/sse/sse.go
@@ -177,7 +177,7 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 
 					event, ok := typeToEvent[deref(reflect.TypeOf(msg.Data))]
 					if !ok {
-						fmt.Println("error: unknown event type", reflect.TypeOf(msg.Data))
+						fmt.Fprintln(os.Stderr, "error: unknown event type", reflect.TypeOf(msg.Data))
 						debug.PrintStack()
 					}
 					if event != "" && event != "message" {

--- a/sse/sse.go
+++ b/sse/sse.go
@@ -161,10 +161,10 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 				send := func(msg Message) error {
 					if deadliner != nil {
 						if err := deadliner.SetWriteDeadline(time.Now().Add(WriteTimeout)); err != nil {
-							fmt.Fprintln(os.Stderr, "warning: unable to set write deadline: "+err.Error())
+							fmt.Fprintf(os.Stderr, "warning: unable to set write deadline: %v\n", err)
 						}
 					} else {
-						fmt.Fprintln(os.Stderr, "warning: unable to set write deadline")
+						fmt.Fprintln(os.Stderr, "write deadline not supported by underlying writer")
 					}
 
 					// Write optional fields
@@ -177,7 +177,7 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 
 					event, ok := typeToEvent[deref(reflect.TypeOf(msg.Data))]
 					if !ok {
-						fmt.Fprintln(os.Stderr, "error: unknown event type", reflect.TypeOf(msg.Data))
+						fmt.Fprintf(os.Stderr, "error: unknown event type %v\n", reflect.TypeOf(msg.Data))
 						debug.PrintStack()
 					}
 					if event != "" && event != "message" {

--- a/sse/sse.go
+++ b/sse/sse.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"reflect"
 	"runtime/debug"
 	"time"
@@ -160,10 +161,10 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 				send := func(msg Message) error {
 					if deadliner != nil {
 						if err := deadliner.SetWriteDeadline(time.Now().Add(WriteTimeout)); err != nil {
-							fmt.Println("warning: unable to set write deadline: " + err.Error())
+							fmt.Fprintln(os.Stderr, "warning: unable to set write deadline: "+err.Error())
 						}
 					} else {
-						fmt.Println("warning: unable to set write deadline")
+						fmt.Fprintln(os.Stderr, "warning: unable to set write deadline")
 					}
 
 					// Write optional fields
@@ -198,7 +199,7 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 					if flusher != nil {
 						flusher.Flush()
 					} else {
-						fmt.Println("error: unable to flush")
+						fmt.Fprintln(os.Stderr, "error: unable to flush")
 						return fmt.Errorf("unable to flush: %w", http.ErrNotSupported)
 					}
 					return nil

--- a/transforms.go
+++ b/transforms.go
@@ -3,6 +3,7 @@ package huma
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path"
 	"reflect"
 )
@@ -132,7 +133,7 @@ func (t *SchemaLinkTransformer) OnAddOperation(oapi *OpenAPI, op *Operation) {
 						// Catch some scenarios that just aren't supported in Go at the
 						// moment. Logs an error so people know what's going on.
 						// https://github.com/danielgtaylor/huma/issues/371
-						fmt.Println("Warning: unable to create schema link for type", typ, ":", r)
+						fmt.Fprintln(os.Stderr, "Warning: unable to create schema link for type", typ, ":", r)
 					}
 				}()
 				newType := reflect.StructOf(fields)


### PR DESCRIPTION
# What

Tiny PR to send Huma's (rare) direct error/warning output to `stderr` rather than `stdout`

# Why
1. It's customary to send errors and warnings to `stderr`
2. I stumbled upon this when using `go run . openapi > openapi.yaml` and the warnings from `transforms.go:135` were mucking up the Open API spec.

# How
Code should be obvious enough without further exposition

[1] I realize I still have to deal with the actual cause for the warnings in _my_ code, but they are incidentally also more visible when sent to `stderr`.

# Testing

AFAICT, the statements are not currently covered by test cases. IMHO the changes are too trivial to justify the cost of setting up explicit tests.

Thanks for considering this PR!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved error logging by directing messages to the standard error output, enhancing visibility of error reporting.

- **New Features**
	- Enhanced error handling in schema link operations, capturing and logging any panics that occur during processing.
	- Warnings related to unexported options fields are now logged to standard error for better visibility.
	- Error messages related to SSE operations are now consistently logged to standard error, improving clarity in reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->