### PR TITLE
Chi is a dep even for pure go implementations, refactor its usage in the main package to pure go.

### DIFF
--- a/adapters/humachi/humachi_test.go
+++ b/adapters/humachi/humachi_test.go
@@ -13,7 +13,9 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
 	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
 )
 
 var lastModified = time.Now()
@@ -312,6 +314,43 @@ func BenchmarkRawChiFast(b *testing.B) {
 		w.Body.Reset()
 		r.ServeHTTP(w, req)
 	}
+}
+
+func TestChiRouterPrefix(t *testing.T) {
+	mux := chi.NewMux()
+	var api huma.API
+	mux.Route("/api", func(r chi.Router) {
+		config := huma.DefaultConfig("My API", "1.0.0")
+		config.Servers = []*huma.Server{{URL: "http://localhost:8888/api"}}
+		api = New(r, config)
+	})
+
+	type TestOutput struct {
+		Body struct {
+			Field string `json:"field"`
+		}
+	}
+
+	// Register a simple hello world operation in the API.
+	huma.Get(api, "/test", func(ctx context.Context, input *struct{}) (*TestOutput, error) {
+		return &TestOutput{}, nil
+	})
+
+	// Create a test API around the underlying router to make easier requests.
+	tapi := humatest.Wrap(t, New(mux, huma.DefaultConfig("Test", "1.0.0")))
+
+	// The top-level router should respond to the full path even though the
+	// operation was registered with just `/test`.
+	resp := tapi.Get("/api/test")
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	// The transformer should generate links with the full URL path.
+	assert.Contains(t, resp.Header().Get("Link"), "/api/schemas/TestOutputBody.json")
+
+	// The docs HTML should point to the full URL including base path.
+	resp = tapi.Get("/api/docs")
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Contains(t, resp.Body.String(), "/api/openapi.yaml")
 }
 
 // func BenchmarkHumaV1Chi(t *testing.B) {

--- a/autoregister_test.go
+++ b/autoregister_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
-	"github.com/go-chi/chi/v5"
 )
 
 // Item represents a single item with a unique ID.
@@ -40,7 +39,7 @@ func (s *ItemsHandler) RegisterListItems(api huma.API) {
 
 func ExampleAutoRegister() {
 	// Create the router and API.
-	router := chi.NewMux()
+	router := http.NewServeMux()
 	api := NewExampleAPI(router, huma.DefaultConfig("My Service", "1.0.0"))
 
 	// Create the item handler and register all of its operations.

--- a/humacli/humacli_test.go
+++ b/humacli/humacli_test.go
@@ -219,7 +219,7 @@ func TestCLIShutdown(t *testing.T) {
 
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		p.Kill()
+		p.Signal(os.Interrupt)
 	}()
 
 	cli.Root().SetArgs([]string{})

--- a/humacli/humacli_test.go
+++ b/humacli/humacli_test.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"syscall"
 	"testing"
 	"time"
 
@@ -213,9 +212,14 @@ func TestCLIShutdown(t *testing.T) {
 		})
 	})
 
+	p, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("failed to find process: %v", os.Getpid())
+	}
+
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+		p.Kill()
 	}()
 
 	cli.Root().SetArgs([]string{})

--- a/humacli/humacli_test.go
+++ b/humacli/humacli_test.go
@@ -12,9 +12,8 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
-	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/danielgtaylor/huma/v2/humacli"
-	"github.com/go-chi/chi/v5"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
@@ -33,8 +32,8 @@ func ExampleCLI() {
 			opts.Debug, opts.Host, opts.Port)
 
 		// Set up the router & API
-		router := chi.NewRouter()
-		api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))
+		mux := http.NewServeMux()
+		api := humago.New(mux, huma.DefaultConfig("My API", "1.0.0"))
 
 		huma.Register(api, huma.Operation{
 			OperationID: "hello",
@@ -47,7 +46,7 @@ func ExampleCLI() {
 
 		srv := &http.Server{
 			Addr:    fmt.Sprintf("%s:%d", opts.Host, opts.Port),
-			Handler: router,
+			Handler: mux,
 			// TODO: Set up timeouts!
 		}
 

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
-	"github.com/go-chi/chi/v5"
 )
 
 // Step 1: Create your input struct where you want to do additional validation.
@@ -35,7 +34,7 @@ func (b *ExampleInputBody) Resolve(ctx huma.Context, prefix *huma.PathBuffer) []
 
 func ExampleResolver() {
 	// Create the API.
-	r := chi.NewRouter()
+	r := http.NewServeMux()
 	api := NewExampleAPI(r, huma.DefaultConfig("Example API", "1.0.0"))
 
 	huma.Register(api, huma.Operation{

--- a/sse/sse_example_test.go
+++ b/sse/sse_example_test.go
@@ -5,9 +5,8 @@ import (
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
-	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/danielgtaylor/huma/v2/sse"
-	"github.com/go-chi/chi/v5"
 )
 
 func ExampleRegister_sse() {
@@ -25,8 +24,8 @@ func ExampleRegister_sse() {
 	type UserDeletedEvent UserEvent
 
 	// 2. Set up the API.
-	router := chi.NewMux()
-	api := humachi.New(router, huma.DefaultConfig("My API", "1.0.0"))
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("My API", "1.0.0"))
 
 	// 3. Register an SSE operation.
 	sse.Register(api, huma.Operation{


### PR DESCRIPTION
For starters, this project is awesome. I wish it existed in 2020 when I was over hauling an app.

I noticed chi in my deps when I was playing around with this, gave me an excuse to look into your code base.  After this change I confirmed chi is removed from my deps. I didn't see a great place for `TestChiRouterPrefix`, I went with adapters as that felt fitting. However, you all only have benches in there at the moment and it's not broken into it's own test package.

If you have some idea's, I'd be happy put them in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced testing capabilities for the Huma API framework.
	- Added a new test function to verify API routing behavior.

- **Bug Fixes**
	- Streamlined test files by removing outdated tests and imports, improving clarity and efficiency.

- **Refactor**
	- Replaced the HTTP router implementation across multiple test files, ensuring compatibility with the updated adapter while maintaining core functionality.
	- Updated API initialization to utilize the new adapter consistently across tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->