### PR TITLE
fix: body with ContentTypeFilter should update OpenAPI

### DIFF
--- a/huma_test.go
+++ b/huma_test.go
@@ -2024,7 +2024,7 @@ func TestContentTypeFilter(t *testing.T) {
 	})
 
 	responses := api.OpenAPI().Paths["/ct-filter"].Get.Responses["200"].Content
-	assert.Equal(t, 1, len(responses))
+	assert.Len(t, responses, 1)
 	for k := range responses {
 		assert.Equal(t, "application/custom+json", k)
 	}

--- a/huma_test.go
+++ b/huma_test.go
@@ -2005,6 +2005,31 @@ func TestOpenAPI(t *testing.T) {
 	})
 }
 
+type CTFilterBody struct {
+	Field string `json:"field"`
+}
+
+func (b *CTFilterBody) ContentType(ct string) string {
+	return "application/custom+json"
+}
+
+var _ huma.ContentTypeFilter = (*CTFilterBody)(nil)
+
+func TestContentTypeFilter(t *testing.T) {
+	_, api := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+	huma.Get(api, "/ct-filter", func(ctx context.Context, i *struct{}) (*struct {
+		Body CTFilterBody
+	}, error) {
+		return nil, nil
+	})
+
+	responses := api.OpenAPI().Paths["/ct-filter"].Get.Responses["200"].Content
+	assert.Equal(t, 1, len(responses))
+	for k := range responses {
+		assert.Equal(t, "application/custom+json", k)
+	}
+}
+
 type IntNot3 int
 
 func (i IntNot3) Resolve(ctx huma.Context, prefix *huma.PathBuffer) []error {


### PR DESCRIPTION
This PR takes into account when a response body has a `ContentTypeFilter` implemented and uses `application/json` as its input to determine the output content type to be used in the generated OpenAPI document.

Fixes #559.