### PR TITLE
fix oauth2-jwt.md mermaid rendering issue

### DIFF
--- a/docs/docs/how-to/oauth2-jwt.md
+++ b/docs/docs/how-to/oauth2-jwt.md
@@ -18,13 +18,13 @@ Huma does not provide any built-in access token issuing functionality. Instead, 
 
 ```mermaid
 graph LR
-	User -->|1. Login| Auth0
-	Auth0 -->|2. Issue access token| User
+	User -->|1: Login| Auth0
+	Auth0 -->|2: Issue access token| User
 	Auth0 -.->|Refresh JWKS| API
-	User --->|3. Make request| API
-	API -->|4. Verify access token & roles| Validate
-	Validate -->|5. Accept/reject| API
-	API --->|6. Success| Handler
+	User --->|3: Make request| API
+	API -->|4: Verify access token & roles| Validate
+	Validate -->|5: Accept/reject| API
+	API --->|6: Success| Handler
 ```
 
 The access token may be issued in different flavors & formats, but for the remainder of this document we will assume they are [JWTs](https://jwt.io/).


### PR DESCRIPTION
mermaid has some problem where `1.` is interpreted as markdown and doesn't render properly. Not sure if that's a recent problem, but it manifests like so:

![Screenshot 2024-12-04 at 11 36 41 PM](https://github.com/user-attachments/assets/1d4319a2-60ed-46df-bdc6-fba5aa111866)

changing to `1:` avoids this problem.