### PR TITLE
chore: enable unconvert and tenv linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,8 @@ linters:
     - nolintlint
     - perfsprint
     - prealloc
+    - tenv
     - testifylint
     - unparam
+    - unconvert
     - wastedassign

--- a/huma.go
+++ b/huma.go
@@ -1091,7 +1091,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 								if err != nil {
 									return 0, err
 								}
-								return int64(val), nil
+								return val, nil
 							})
 							if err != nil {
 								res.Add(pb, value, "invalid integer")
@@ -1151,7 +1151,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 								if err != nil {
 									return 0, err
 								}
-								return uint64(val), nil
+								return val, nil
 							})
 							if err != nil {
 								res.Add(pb, value, "invalid integer")

--- a/humacli/humacli_test.go
+++ b/humacli/humacli_test.go
@@ -95,14 +95,9 @@ func TestCLIEnv(t *testing.T) {
 		Port  int
 	}
 
-	os.Setenv("SERVICE_DEBUG", "true")
-	os.Setenv("SERVICE_HOST", "localhost")
-	os.Setenv("SERVICE_PORT", "8001")
-	defer func() {
-		os.Unsetenv("SERVICE_DEBUG")
-		os.Unsetenv("SERVICE_HOST")
-		os.Unsetenv("SERVICE_PORT")
-	}()
+	t.Setenv("SERVICE_DEBUG", "true")
+	t.Setenv("SERVICE_HOST", "localhost")
+	t.Setenv("SERVICE_PORT", "8001")
 
 	cli := humacli.New(func(hooks humacli.Hooks, options *Options) {
 		assert.True(t, options.Debug)


### PR DESCRIPTION
The PR enables [`unconvert`](https://golangci-lint.run/usage/linters/#unconvert) and [`tenv`](https://golangci-lint.run/usage/linters/#tenv) linters in golangci-lint config and fixes appeared lint issues.