### PR TITLE
refactor: simplify error handling for multipart form reading

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -1245,7 +1245,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 
 			if rawBodyMultipart || rawBodyDecodedMultipart {
 				form, err := ctx.GetMultipartForm()
-				if err != nil || form == nil {
+				if err != nil {
 					res.Errors = append(res.Errors, &ErrorDetail{
 						Location: "body",
 						Message:  "cannot read multipart form: " + err.Error(),


### PR DESCRIPTION
If `err` is `nil`, `form` can't be `nil`.

If `err` is `nil` and `form` is `nil`, there will be a panic on the line:

```go
			Message:  "cannot read multipart form: " + err.Error(),
```