### PR TITLE
fix: useless assertion in TestFeatures/response-image

### DIFF
--- a/huma_test.go
+++ b/huma_test.go
@@ -1661,7 +1661,7 @@ Content of example2.txt.
 
 				// Ensure the OpenAPI spec is correct.
 				assert.Len(t, api.OpenAPI().Paths["/response-image"].Get.Responses["200"].Content, 1)
-				assert.NotEmpty(t, "binary", api.OpenAPI().Paths["/response-image"].Get.Responses["200"].Content["image/png"])
+				assert.NotEmpty(t, api.OpenAPI().Paths["/response-image"].Get.Responses["200"].Content["image/png"])
 			},
 			Method: http.MethodGet,
 			URL:    "/response-image",


### PR DESCRIPTION
The PR fixes the assertion for `TestFeatures/response-image`.

`assert.NotEmpty(t, "binary", api.OpenAPI().Paths["/response-image"].Get.Responses["200"].Content["image/png"])` checks that `"binary"` is not empty, which is useless.