### PR TITLE
fix: potential body error race

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -1336,7 +1336,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 							res.Errors = append(res.Errors, &ErrorDetail{
 								Location: "body",
 								Message:  err.Error(),
-								Value:    body,
+								Value:    string(body),
 							})
 							parseErrCount++
 						} else {


### PR DESCRIPTION
This attempts to fix a hard-to-repro race condition when returning an error due to marshaling that includes a reference to the body bytes that will get returned to the pool for re-use before the output is done. The fix here is to cast the bytes to a string, which creates a copy that is safe to reference later.

Fixes #685.