### PR TITLE
feat: allow string fields in MultipartFormFiles

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -1336,7 +1336,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 							res.Errors = append(res.Errors, &ErrorDetail{
 								Location: "body",
 								Message:  err.Error(),
-								Value:    string(body),
+								Value:    body,
 							})
 							parseErrCount++
 						} else {


### PR DESCRIPTION
Introduces ability to document, allow, and use fields of type string within MultipartFormFiles. Validation is limited to checking existence of the field in the form, and ensuring that at most one field with that name exists. In particular, requirements such as `minLength` are not considered.

Relates to #694.