### PR TITLE
Fix examples

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -646,7 +646,10 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 		if op.RequestBody.Content == nil {
 			op.RequestBody.Content = map[string]*MediaType{}
 		}
-		op.RequestBody.Content[contentType] = &MediaType{Schema: s}
+		if op.RequestBody.Content[contentType] == nil {
+			op.RequestBody.Content[contentType] = &MediaType{}
+		}
+		op.RequestBody.Content[contentType].Schema = s
 
 		if op.BodyReadTimeout == 0 {
 			// 5 second default


### PR DESCRIPTION
In v2.22.1, I used the display of examples in the swagger.
In v2.23.0 this was broken by adding the line 

```
op.RequestBody.Content[contentType] = &MediaType{Schema: s}
```
https://github.com/danielgtaylor/huma/compare/v2.22.1...v2.23.0#diff-34398007f1f21b0bc55b2fe31480add48b936399f37e1ae49662d9e4dbf33a98R598

Now with the upgrade to v2.23.0+ all my examples are being overwritten and not displayed in swagger.

Made a small fix to make it work for me as before.

Or is there another more correct way to display examples?