### PR TITLE
feat: enable WrappedContext for router specifics access points in Adapters

### DIFF
--- a/adapters/humabunrouter/humabunrouter.go
+++ b/adapters/humabunrouter/humabunrouter.go
@@ -34,6 +34,10 @@ func (c *bunContext) Operation() *huma.Operation {
 	return c.op
 }
 
+func (c *bunContext) WrappedContext() interface{} {
+	return c.r
+}
+
 func (c *bunContext) Context() context.Context {
 	return c.r.Context()
 }

--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -32,6 +32,10 @@ func (c *chiContext) Operation() *huma.Operation {
 	return c.op
 }
 
+func (c *chiContext) WrappedContext() interface{} {
+	return c.r
+}
+
 func (c *chiContext) Context() context.Context {
 	return c.r.Context()
 }

--- a/adapters/humaecho/humaecho.go
+++ b/adapters/humaecho/humaecho.go
@@ -31,6 +31,10 @@ func (c *echoCtx) Operation() *huma.Operation {
 	return c.op
 }
 
+func (c *echoCtx) WrappedContext() interface{} {
+	return c.orig
+}
+
 func (c *echoCtx) Context() context.Context {
 	return c.orig.Request().Context()
 }

--- a/adapters/humafiber/humafiber.go
+++ b/adapters/humafiber/humafiber.go
@@ -61,6 +61,10 @@ func (c *fiberCtx) Matched() string {
 	return c.orig.Route().Path
 }
 
+func (c *fiberCtx) WrappedContext() interface{} {
+	return c.orig
+}
+
 func (c *fiberCtx) Context() context.Context {
 	return &contextAdapter{
 		Ctx:  c.orig,

--- a/adapters/humaflow/humaflow.go
+++ b/adapters/humaflow/humaflow.go
@@ -30,6 +30,10 @@ func (c *goContext) Operation() *huma.Operation {
 	return c.op
 }
 
+func (c *goContext) WrappedContext() interface{} {
+	return c.r
+}
+
 func (c *goContext) Context() context.Context {
 	return c.r.Context()
 }

--- a/adapters/humagin/humagin.go
+++ b/adapters/humagin/humagin.go
@@ -31,6 +31,10 @@ func (c *ginCtx) Operation() *huma.Operation {
 	return c.op
 }
 
+func (c *ginCtx) WrappedContext() interface{} {
+	return c.orig
+}
+
 func (c *ginCtx) Context() context.Context {
 	return c.orig.Request.Context()
 }

--- a/adapters/humago/humago.go
+++ b/adapters/humago/humago.go
@@ -32,6 +32,10 @@ func (c *goContext) Operation() *huma.Operation {
 	return c.op
 }
 
+func (c *goContext) WrappedContext() interface{} {
+	return c.r
+}
+
 func (c *goContext) Context() context.Context {
 	return c.r.Context()
 }

--- a/adapters/humahttprouter/humahttprouter.go
+++ b/adapters/humahttprouter/humahttprouter.go
@@ -34,6 +34,10 @@ func (c *httprouterContext) Operation() *huma.Operation {
 	return c.op
 }
 
+func (c *httprouterContext) WrappedContext() interface{} {
+	return c.r
+}
+
 func (c *httprouterContext) Context() context.Context {
 	return c.r.Context()
 }

--- a/adapters/humamux/humamux.go
+++ b/adapters/humamux/humamux.go
@@ -32,6 +32,10 @@ func (c *gmuxContext) Operation() *huma.Operation {
 	return c.op
 }
 
+func (c *gmuxContext) WrappedContext() interface{} {
+	return c.r
+}
+
 func (c *gmuxContext) Context() context.Context {
 	return c.r.Context()
 }

--- a/api.go
+++ b/api.go
@@ -64,6 +64,12 @@ type Context interface {
 	// Operation returns the OpenAPI operation that matched the request.
 	Operation() *Operation
 
+	// WrappedContext returns the underlying Adapter original
+	// Request context. For example, `*http.Request` for the `http` adapter.
+	// This is useful for accessing router-specific information and
+	// transitioning existing handler functionality.
+	WrappedContext() interface{}
+
 	// Context returns the underlying request context.
 	Context() context.Context
 


### PR DESCRIPTION
Hey all,

During my time trying to transition my `Bring-your-own-Router` work, many of my handlers are specific to the frameworks we use in each project. For example, `func MyHandler(c echo.Context) error`. 

This would normally not be an issue, but the transition for the number of endpoints we have is difficult enough as is. Rather than doing them all up front, I'd rather like to have access to the underlying framework to reuse the existing code.

I'm not tied to the naming but this was easier than rewriting all of my handlers. Please comment and let me know what I can do to help out here.