### PR TITLE
refactor: split up huma.Register

### DIFF
--- a/formdata.go
+++ b/formdata.go
@@ -207,7 +207,7 @@ func multiPartFormFileSchema(t reflect.Type) *Schema {
 		Properties:  make(map[string]*Schema, nFields),
 		requiredMap: make(map[string]bool, nFields),
 	}
-	requiredFields := make([]string, nFields)
+	requiredFields := make([]string, 0, nFields)
 	for i := 0; i < nFields; i++ {
 		f := t.Field(i)
 		name := formDataFieldName(f)
@@ -226,7 +226,7 @@ func multiPartFormFileSchema(t reflect.Type) *Schema {
 		}
 
 		if _, ok := f.Tag.Lookup("required"); ok && boolTag(f, "required", false) {
-			requiredFields[i] = name
+			requiredFields = append(requiredFields, name)
 			schema.requiredMap[name] = true
 		}
 	}

--- a/huma.go
+++ b/huma.go
@@ -740,7 +740,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 
 				// Store raw body
 				if len(rawBodyIndex) > 0 {
-					f := getSubField(v, rawBodyIndex)
+					f := v.FieldByIndex(rawBodyIndex)
 					f.SetBytes(body)
 				}
 
@@ -1622,7 +1622,7 @@ func parseBodyInto(v reflect.Value, bodyIndex []int, u intoUnmarshaler, body []b
 	// second time is faster than `mapstructure.Decode` or any of the other
 	// common reflection-based approaches when using real-world medium-sized
 	// JSON payloads with lots of strings.
-	f := getSubField(v, bodyIndex)
+	f := v.FieldByIndex(bodyIndex)
 	if err := u(body, f.Addr().Interface()); err != nil {
 		return &ErrorDetail{
 			Location: "body",
@@ -1669,18 +1669,6 @@ func readBody(buf io.Writer, ctx Context, maxBytes int64) *contextError {
 		return &contextError{Code: http.StatusInternalServerError, Msg: "cannot read request body", Errs: []error{err}}
 	}
 	return nil
-}
-
-// getSubField extracts a nested field from v. The field of interest is
-// identified by its indices.
-//
-// For example, getSubField(v, [3, 1]) returns v.Field[3].Field[1]
-func getSubField(v reflect.Value, indices []int) reflect.Value {
-	f := v
-	for _, i := range indices {
-		f = f.Field(i)
-	}
-	return f
 }
 
 // AutoRegister auto-detects operation registration methods and registers them

--- a/huma.go
+++ b/huma.go
@@ -611,6 +611,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 	if op.Method == "" || op.Path == "" {
 		panic("method and path must be specified in operation")
 	}
+	initResponses(&op)
 
 	inputType := reflect.TypeOf((*I)(nil)).Elem()
 	if inputType.Kind() != reflect.Struct {
@@ -653,10 +654,6 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 
 	resolvers := findResolvers(resolverType, inputType)
 	defaults := findDefaults(registry, inputType)
-
-	if op.Responses == nil {
-		op.Responses = map[string]*Response{}
-	}
 
 	outputType := reflect.TypeOf((*O)(nil)).Elem()
 	if outputType.Kind() != reflect.Struct {
@@ -1083,6 +1080,13 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 			ctx.SetStatus(status)
 		}
 	})))
+}
+
+// initResponses initializes Responses if it was unset.
+func initResponses(op *Operation) {
+	if op.Responses == nil {
+		op.Responses = map[string]*Response{}
+	}
 }
 
 // ensureMaxBodyBytes sets the MaxBodyBytes to a default value if it was unset.

--- a/huma.go
+++ b/huma.go
@@ -1002,24 +1002,21 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 					}
 					f.SetBool(v)
 					pv = v
-				default:
-					if f.Type().Kind() == reflect.Slice {
-						var values []string
-						if p.Explode {
-							u := ctx.URL()
-							values = (&u).Query()[p.Name]
-						} else {
-							values = strings.Split(value, ",")
-						}
-						pvSlice, err := parseSliceInto(f, values)
-						pv = pvSlice
-						if err != nil && !errors.Is(err, errUnparsable) {
-							res.Add(pb, value, err.Error())
-							return
-						}
-						break
+				case reflect.Slice:
+					var values []string
+					if p.Explode {
+						u := ctx.URL()
+						values = (&u).Query()[p.Name]
+					} else {
+						values = strings.Split(value, ",")
 					}
-
+					pvSlice, err := parseSliceInto(f, values)
+					pv = pvSlice
+					if err != nil && !errors.Is(err, errUnparsable) {
+						res.Add(pb, value, err.Error())
+						return
+					}
+				default:
 					// Special case: time.Time
 					if f.Type() == timeType {
 						t, err := time.Parse(p.TimeFormat, value)

--- a/huma.go
+++ b/huma.go
@@ -693,14 +693,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 				return
 			}
 
-			s := splittableString{Raw: value}
-			if p.Explode {
-				u := ctx.URL()
-				s.Splitted = (&u).Query()[p.Name]
-			} else {
-				s.Splitted = strings.Split(value, ",")
-			}
-			pv, err := parseInto(f, s, *p)
+			pv, err := parseInto(ctx, f, value, *p)
 			if err != nil {
 				res.Add(pb, value, err.Error())
 			}
@@ -1232,17 +1225,9 @@ func getParamValue(p paramFieldInfo, ctx Context, cookies map[string]*http.Cooki
 
 var errUnparsable = errors.New("unparsable value")
 
-type splittableString struct {
-	Raw      string
-	Splitted []string
-}
-
-// parseInto converts the string s.Raw into the expected type using the parameter
-// field information p and sets the result on f. If s is to be parsed into a
-// slice of values, then the string encodings of those individual values should
-// be available in s.Splitted.
-func parseInto(f reflect.Value, s splittableString, p paramFieldInfo) (any, error) {
-	value := s.Raw
+// parseInto converts the string value into the expected type using the
+// parameter field information p and sets the result on f.
+func parseInto(ctx Context, f reflect.Value, value string, p paramFieldInfo) (any, error) {
 	// built-in types
 	switch p.Type.Kind() {
 	case reflect.String:
@@ -1277,7 +1262,14 @@ func parseInto(f reflect.Value, s splittableString, p paramFieldInfo) (any, erro
 		f.SetBool(v)
 		return v, nil
 	case reflect.Slice:
-		pv, err := parseSliceInto(f, s.Splitted)
+		var values []string
+		if p.Explode {
+			u := ctx.URL()
+			values = (&u).Query()[p.Name]
+		} else {
+			values = strings.Split(value, ",")
+		}
+		pv, err := parseSliceInto(f, values)
 		if err != nil {
 			if errors.Is(err, errUnparsable) {
 				break


### PR DESCRIPTION
The current [`huma.Register`](https://github.com/danielgtaylor/huma/blob/v2.27.0/huma.go#L607) function is 900+ lines of code and has [up to 9 levels of nesting](https://github.com/danielgtaylor/huma/blob/v2.27.0/huma.go#L1378). While working on #694 I found it really hard to understand the logic. In my effort to understand the function, I performed several refactorings and I thought that you may appreciate them as well.

Surely some parts are a matter of taste -- I don't mind changing them.

Looking forward to your thoughts.