### PR TITLE
feat: allow arbitrary fields in MultipartFormFiles

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -126,7 +126,6 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 			pfi.Loc = "header"
 			name = h
 		} else if fo := f.Tag.Get("form"); fo != "" {
-			// TODO: clearify in README that "form" tag is REQUIRED
 			pfi.Loc = "form"
 			name = fo
 		} else if c := f.Tag.Get("cookie"); c != "" {

--- a/huma_test.go
+++ b/huma_test.go
@@ -1471,7 +1471,7 @@ Content of example2.txt.
 			},
 		},
 		{
-			Name: "request-body-multipart-file-decoded-with-formvalues-required",
+			Name: "request-body-multipart-file-decoded-with-formvalue-required",
 			Register: func(t *testing.T, api huma.API) {
 				huma.Register(api, huma.Operation{
 					Method: http.MethodPost,


### PR DESCRIPTION
@danielgtaylor I started working on #694. The first part of the work is a major refactoring that I submitted separately in #705. The second part is a feature where MultipartFormFiles also parses and validates multipart.Form.Value into the input struct. The diff is probably clearer in [this PR](https://github.com/b-kamphorst/huma/pull/1).

At time of writing, the added feature only parses fields that have a `form` tag, mostly because I copied the approach for parsing and validating other request parameters and I was not quite sure how to do that differently. Before I continue, I would much like to hear your thoughts:

1. Would you consider this feature for Huma?
2. If so, do you have any feedback on how to continue with this PR?

Closes #694.