### PR TITLE
fix: implement findRelativeRessourcePath function to fix PatchResourc…

### DIFF
--- a/autopatch/autopatch_test.go
+++ b/autopatch/autopatch_test.go
@@ -446,6 +446,11 @@ func TestFindRelativeResourcePath(t *testing.T) {
 			putPath:     "/things/{id}",
 			expected:    "/things/test",
 		},
+		{
+			requestPath: "/api/v1/test",
+			putPath:     "{id}",
+			expected:    "/api/v1/test", // we check that we falback to the request path if unsupported
+		},
 	}
 
 	for _, test := range tests {

--- a/autopatch/autopatch_test.go
+++ b/autopatch/autopatch_test.go
@@ -417,3 +417,38 @@ func TestMakeOptionalSchemaNestedSchemas(t *testing.T) {
 	assert.Empty(t, optionalNestedSchema.Required)
 	assert.Empty(t, optionalNestedSchema.Properties["nested"].Required)
 }
+
+type findRelativeResourcePathTest struct {
+	requestPath string
+	putPath     string
+	expected    string
+}
+
+func TestFindRelativeResourcePath(t *testing.T) {
+	tests := []findRelativeResourcePathTest{
+		{
+			requestPath: "/things/test",
+			putPath:     "/things/{id}",
+			expected:    "/things/test",
+		},
+		{
+			requestPath: "/api/things/test",
+			putPath:     "/things/{id}",
+			expected:    "/things/test",
+		},
+		{
+			requestPath: "/test",
+			putPath:     "/{id}",
+			expected:    "/test",
+		},
+		{
+			requestPath: "/api/v1/super/things/test",
+			putPath:     "/things/{id}",
+			expected:    "/things/test",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expected, findRelativeResourcePath(test.requestPath, test.putPath))
+	}
+}


### PR DESCRIPTION
This merge request fix issue #713 "Autopatch not working when a prefix is present in the path"

## Technical details

I implemented a new function `findRelativeRessourcePath` in the `autopatch` package that removes the prefix from the path before searching for the resource in the router by comparing the `PUT` path and request path.

It will strip the request path until the prefix of the `PUT` path prefix is found.

It think a better solution could be found if with a proper rework.

I wrote unit tests for the new function.

Fixes #713.