### PR TITLE
fix: allow providing a custom request schema

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -1024,16 +1024,17 @@ func setRequestBodyFromBody(op *Operation, registry Registry, fBody reflect.Stru
 	if c := fBody.Tag.Get("contentType"); c != "" {
 		contentType = c
 	}
-	hint := getHint(inputType, fBody.Name, op.OperationID+"Request")
-	if nameHint := fBody.Tag.Get("nameHint"); nameHint != "" {
-		hint = nameHint
-	}
-	s := SchemaFromField(registry, fBody, hint)
 	if op.RequestBody.Content[contentType] == nil {
 		op.RequestBody.Content[contentType] = &MediaType{}
 	}
-	op.RequestBody.Content[contentType].Schema = s
-
+	if op.RequestBody.Content[contentType].Schema == nil {
+		hint := getHint(inputType, fBody.Name, op.OperationID+"Request")
+		if nameHint := fBody.Tag.Get("nameHint"); nameHint != "" {
+			hint = nameHint
+		}
+		s := SchemaFromField(registry, fBody, hint)
+		op.RequestBody.Content[contentType].Schema = s
+	}
 }
 
 type rawBodyType int


### PR DESCRIPTION
This PR makes it possible to provide a custom request schema along with a body by preventing Huma from overwriting any existing schema for the default content type.