### PR TITLE
feat: groups

### DIFF
--- a/docs/docs/features/groups.md
+++ b/docs/docs/features/groups.md
@@ -1,0 +1,78 @@
+---
+description: Group operations with common prefixes, middleware, transformers, and more.
+---
+
+# Groups
+
+## Groups { .hidden }
+
+Operations can be grouped under common route prefixes and share middleware, operation modifier functions, and response transformers. This is done using the `huma.Group` wrapper around a `huma.API` instance, which can then be passed to `huma.Register` and its convenience wrappers like `huma.Get`, `huma.Post`, etc.
+
+```go
+grp := huma.NewGroup(api, "/v1")
+grp.UseMiddleware(authMiddleware)
+
+huma.Get(grp, "/users", func(ctx context.Context, input *struct{}) ([]User, error) {
+	// ...
+})
+```
+
+The above example will register a `GET /v1/users` operation with the `authMiddleware` running before the operation handler.
+
+!!! info "Groups & Documentation"
+
+    Groups assume that `api.AddOperation` is invoked for any operation you want to register and have documented in the OpenAPI. This is done by default with `huma.Register` & its convenience functions. If you use custom registration functions you may need to manually add operations to the OpenAPI.
+
+## Group Features
+
+Groups support the following features:
+
+-   One or more path prefixes for all operations in the group.
+-   Middleware that runs before each operation in the group.
+-   Operation modifiers that run at operation registration time.
+-   Response transformers that run after each operation in the group.
+
+## Middleware
+
+Middleware functions are run before each operation handler in the group. They can be used for common tasks like authentication, logging, and error handling. Middleware functions are registered using the `UseMiddleware` method on a group.
+
+```go
+grp.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
+	// Do something before the operation runs
+	return next(ctx, input)
+})
+```
+
+## Operation Modifiers
+
+Operation modifiers are functions that run at operation registration time. They can be used to modify the operation before it is registered. Operation modifiers are registered using the `UseOperationModifier` method on a group.
+
+```go
+grp.UseOperationModifier(func(op *huma.Operation) {
+	op.Summary = "A summary for all operations in this group"
+	op.Tags = []string{"my-tag"}
+})
+```
+
+## Response Transformers
+
+Response transformers are functions that run after each operation handler in the group. They can be used to modify the response before it is returned to the client. Response transformers are registered using the `UseResponseTransformer` method on a group.
+
+```go
+grp.UseTransformer(func(ctx huma.Context, status string, v any) (any, error) {
+	// Do something with the output
+	return output, nil
+})
+```
+
+## Dive Deeper
+
+-   Features
+    -   [Operations](./operations.md) registration & workflows
+    -   [Middleware](./middleware.md) for operations
+    -   [Response Transformers](./response-transformers.md) to modify response bodies
+-   Reference
+    -   [`huma.Register`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Register) register an operation
+    -   [`huma.Middlewares`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Middlewares) list of middleware
+    -   [`huma.Transformer`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Transformer) response transformers
+    -   [`huma.API`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#API) the API instance

--- a/docs/docs/features/groups.md
+++ b/docs/docs/features/groups.md
@@ -21,7 +21,7 @@ The above example will register a `GET /v1/users` operation with the `authMiddle
 
 !!! info "Groups & Documentation"
 
-    Groups assume that `api.AddOperation` is invoked for any operation you want to register and have documented in the OpenAPI. This is done by default with `huma.Register` & its convenience functions. If you use custom registration functions you may need to manually add operations to the OpenAPI.
+    Groups assume that `OpenAPI().AddOperation(...)` is invoked for any operation you want to register and have documented in the OpenAPI. This is done by default with `huma.Register` & its convenience functions. If you use custom registration functions you may need to manually invoke `OpenAPI().OnAddOperation` to ensure the operation is documented. Note: you should not manually modify the group's OpenAPI, as this may not be propagated to the parent API's OpenAPI.
 
 ## Group Features
 
@@ -45,10 +45,20 @@ grp.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
 
 ## Operation Modifiers
 
-Operation modifiers are functions that run at operation registration time. They can be used to modify the operation before it is registered. Operation modifiers are registered using the `UseOperationModifier` method on a group.
+Operation modifiers are functions that run at operation registration time. They can be used to modify the operation before it is registered. Operation modifiers are registered using the `UseModifier` method on a group.
 
 ```go
-grp.UseOperationModifier(func(op *huma.Operation) {
+grp.UseModifier(func(op *huma.Operation, next(*huma.Operation)) {
+	op.Summary = "A summary for all operations in this group"
+	op.Tags = []string{"my-tag"}
+    next(op)
+})
+```
+
+There is also a simplified form you can use:
+
+```go
+grp.UseSimpleModifier(func(op *huma.Operation)) {
 	op.Summary = "A summary for all operations in this group"
 	op.Tags = []string{"my-tag"}
 })

--- a/docs/docs/features/groups.md
+++ b/docs/docs/features/groups.md
@@ -39,7 +39,7 @@ Middleware functions are run before each operation handler in the group. They ca
 ```go
 grp.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
 	// Do something before the operation runs
-	return next(ctx, input)
+	next(ctx)
 })
 ```
 

--- a/docs/docs/features/groups.md
+++ b/docs/docs/features/groups.md
@@ -65,7 +65,7 @@ grp.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
 Operation modifiers are functions that run at operation registration time. They can be used to modify the operation before it is registered. Operation modifiers are registered using the `UseModifier` method on a group.
 
 ```go
-grp.UseModifier(func(op *huma.Operation, next(*huma.Operation)) {
+grp.UseModifier(func(op *huma.Operation, next func(*huma.Operation)) {
 	op.Summary = "A summary for all operations in this group"
 	op.Tags = []string{"my-tag"}
     next(op)

--- a/docs/docs/features/middleware.md
+++ b/docs/docs/features/middleware.md
@@ -100,7 +100,7 @@ func MyMiddleware(ctx huma.Context, next func(huma.Context)) {
 
 Then you can get the value in the handler context:
 
-``` go title="handler.go"
+```go title="handler.go"
 huma.Get(api, "/greeting/{name}", func(ctx context.Context, input *struct{
 		Name string `path:"name" maxLength:"30" example:"world" doc:"Name to greet"`
 	}) (*GreetingOutput, error) {
@@ -201,7 +201,7 @@ It's also possible for global middleware to run only for certain paths by checki
 
 -   Reference
     -   [`huma.Context`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Context) a router-agnostic request/response context
-    -   [`huma.Middlewares`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Middlewares) the API instance
+    -   [`huma.Middlewares`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#Middlewares) list of middleware
     -   [`huma.ReadCookie`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#ReadCookie) reads a named cookie from a request
     -   [`huma.ReadCookies`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#ReadCookies) reads cookies from a request
     -   [`huma.WriteErr`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#WriteErr) function to write error responses

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
           - "Model Validation": features/model-validation.md
       - "Operations":
           - "Operations": features/operations.md
+          - "Groups": features/groups.md
           - "Requests":
               - "Request Inputs": features/request-inputs.md
               - "Validation": features/request-validation.md
@@ -46,8 +47,8 @@ nav:
               - "Streaming": features/response-streaming.md
               - "Transformers": features/response-transformers.md
       - "Extra Packages":
-          - "Conditional Requests": features/conditional-requests.md
           - "Auto PATCH Operations": features/auto-patch.md
+          - "Conditional Requests": features/conditional-requests.md
           - "Server Sent Events (SSE)": features/server-sent-events-sse.md
           - "Test Utilities": features/test-utilities.md
       - "Clients":

--- a/group.go
+++ b/group.go
@@ -1,19 +1,26 @@
 package huma
 
-import "strings"
+import (
+	"strings"
+)
 
-// modifyOperation modifies an operation to include the group's prefix and
-// operation ID as well as runs any supplied operation modifier functions.
-func modifyOperation(g *Group, prefix string, op *Operation) {
-	if prefix != "" {
-		friendlyPrefix := strings.ReplaceAll(strings.Trim(prefix, "/"), "/", "-")
-		op.OperationID = friendlyPrefix + "-" + op.OperationID
-		tags := append([]string{}, op.Tags...)
-		op.Tags = append(tags, friendlyPrefix)
-		op.Path = prefix + op.Path
-	}
-	for _, modifier := range g.opModifiers {
-		modifier(op)
+// PrefixModifier provides a fan-out to register one or more operations with
+// the given prefix for every one operation added to a group.
+func PrefixModifier(prefixes []string) func(o *Operation, next func(*Operation)) {
+	return func(o *Operation, next func(*Operation)) {
+		for _, prefix := range prefixes {
+			modified := *o
+			if len(prefixes) > 1 && prefix != "" {
+				// If there are multiple prefixes, update the ID and tags so you can
+				// differentiate between them in clients & the UI.
+				friendlyPrefix := strings.ReplaceAll(strings.Trim(prefix, "/"), "/", "-")
+				modified.OperationID = friendlyPrefix + "-" + modified.OperationID
+				tags := append([]string{}, modified.Tags...)
+				modified.Tags = append(tags, friendlyPrefix)
+			}
+			modified.Path = prefix + modified.Path
+			next(&modified)
+		}
 	}
 }
 
@@ -25,12 +32,9 @@ type groupAdapter struct {
 }
 
 func (a *groupAdapter) Handle(op *Operation, handler func(Context)) {
-	// Make sure the router handles each full route (prefix + operation path).
-	for _, prefix := range a.group.prefixes {
-		modified := *op
-		modifyOperation(a.group, prefix, &modified)
-		a.Adapter.Handle(&modified, handler)
-	}
+	a.group.ModifyOperation(op, func(op *Operation) {
+		a.Adapter.Handle(op, handler)
+	})
 }
 
 // Group is a collection of routes that share a common prefix and set of
@@ -43,7 +47,7 @@ type Group struct {
 	API
 	prefixes     []string
 	adapter      Adapter
-	opModifiers  []func(o *Operation)
+	modifiers    []func(o *Operation, next func(*Operation))
 	middlewares  Middlewares
 	transformers []Transformer
 }
@@ -59,11 +63,11 @@ type Group struct {
 //		// Your code here...
 //	})
 func NewGroup(api API, prefixes ...string) *Group {
-	if len(prefixes) == 0 {
-		prefixes = append(prefixes, "")
-	}
 	group := &Group{API: api, prefixes: prefixes}
 	group.adapter = &groupAdapter{Adapter: api.Adapter(), group: group}
+	if len(prefixes) > 0 {
+		group.UseModifier(PrefixModifier(prefixes))
+	}
 	return group
 }
 
@@ -71,29 +75,61 @@ func (g *Group) Adapter() Adapter {
 	return g.adapter
 }
 
+// OpenAPI returns the group's OpenAPI, which acts as a passthrough to the
+// underlying API's OpenAPI. You should not modify this directly as changes
+// may not be propagated to the underlying API. Instead, only modify the
+// original API's OpenAPI directly.
 func (g *Group) OpenAPI() *OpenAPI {
 	// Provide a callback that `huma.Register` will call, and take the operation
-	// that is added and modify it as needed for each prefix, registering it with
-	// the real underlying OpenAPI document. This ensure the documentation
-	// matches the server behavior!
-	// The one caveat is that this *only* works for operations which invoke
-	// the `OpenAPI.AddOperation(...)` call.
+	// that is added and modify it as needed, registering it with the real
+	// underlying OpenAPI document. This ensure the documentation matches the
+	// server behavior! The one caveat is that this *only* works for operations
+	// which invoke the `OpenAPI.AddOperation(...)` call.
 	openapi := *g.API.OpenAPI()
-	openapi.OnAddOperation = append(openapi.OnAddOperation, func(oapi *OpenAPI, op *Operation) {
-		for _, prefix := range g.prefixes {
-			modified := *op
-			modifyOperation(g, prefix, &modified)
-			g.API.OpenAPI().AddOperation(&modified)
-		}
-	})
+	openapi.Paths = nil
+	openapi.OnAddOperation = []AddOpFunc{
+		func(oapi *OpenAPI, op *Operation) {
+			oapi.Paths = nil // discourage manual edits
+			g.ModifyOperation(op, func(op *Operation) {
+				g.API.OpenAPI().AddOperation(op)
+			})
+		},
+	}
 	return &openapi
 }
 
-// UseOperationModifier adds an operation modifier function to the group that
+// UseModifier adds an operation modifier function to the group that will be run
+// on all operations in the group. Use this to modify the operation before it is
+// registered with the router or OpenAPI document. This behaves similar to
+// middleware in that you should invoke `next` to continue the chain. Skip it
+// to prevent the operation from being registered, and call multiple times for
+// a fan-out effect.
+func (g *Group) UseModifier(modifier func(o *Operation, next func(*Operation))) {
+	g.modifiers = append(g.modifiers, modifier)
+}
+
+// UseSimpleModifier adds an operation modifier function to the group that
 // will be run on all operations in the group. Use this to modify the operation
 // before it is registered with the router or OpenAPI document.
-func (g *Group) UseOperationModifier(handler func(o *Operation)) {
-	g.opModifiers = append(g.opModifiers, handler)
+func (g *Group) UseSimpleModifier(modifier func(o *Operation)) {
+	g.modifiers = append(g.modifiers, func(o *Operation, next func(*Operation)) {
+		modifier(o)
+		next(o)
+	})
+}
+
+// ModifyOperation runs all operation modifiers in the group on the given
+// operation, in the order they were added. This is useful for modifying an
+// operation before it is registered with the router or OpenAPI document.
+func (g *Group) ModifyOperation(op *Operation, next func(*Operation)) {
+	chain := next
+	for i := len(g.modifiers) - 1; i >= 0; i-- {
+		// Use an inline func to provide a closure around the index & chain.
+		func(i int, n func(*Operation)) {
+			chain = func(op *Operation) { g.modifiers[i](op, n) }
+		}(i, chain)
+	}
+	chain(op)
 }
 
 // UseMiddleware adds one or more middleware functions to the group that will be

--- a/group.go
+++ b/group.go
@@ -1,0 +1,129 @@
+package huma
+
+import "strings"
+
+// modifyOperation modifies an operation to include the group's prefix and
+// operation ID as well as runs any supplied operation modifier functions.
+func modifyOperation(g *Group, prefix string, op *Operation) {
+	if prefix != "" {
+		friendlyPrefix := strings.ReplaceAll(strings.Trim(prefix, "/"), "/", "-")
+		op.OperationID = friendlyPrefix + "-" + op.OperationID
+		tags := append([]string{}, op.Tags...)
+		op.Tags = append(tags, friendlyPrefix)
+		op.Path = prefix + op.Path
+	}
+	for _, modifier := range g.opModifiers {
+		modifier(op)
+	}
+}
+
+// groupAdapter is an Adapter wrapper that registers multiple operation handlers
+// with the underlying adapter based on the group's prefixes.
+type groupAdapter struct {
+	Adapter
+	group *Group
+}
+
+func (a *groupAdapter) Handle(op *Operation, handler func(Context)) {
+	// Make sure the router handles each full route (prefix + operation path).
+	for _, prefix := range a.group.prefixes {
+		modified := *op
+		modifyOperation(a.group, prefix, &modified)
+		a.Adapter.Handle(&modified, handler)
+	}
+}
+
+// Group is a collection of routes that share a common prefix and set of
+// operation modifiers, middlewares, and transformers.
+//
+// This is useful for grouping related routes together and applying common
+// settings to them. For example, you might create a group for all routes that
+// require authentication.
+type Group struct {
+	API
+	prefixes     []string
+	adapter      Adapter
+	opModifiers  []func(o *Operation)
+	middlewares  Middlewares
+	transformers []Transformer
+}
+
+// NewGroup creates a new group of routes with the given prefixes, if any. A
+// group enables a collection of operations to have the same prefix and share
+// operation modifiers, middlewares, and transformers.
+//
+//	grp := huma.NewGroup(api, "/v1")
+//	grp.UseMiddleware(authMiddleware)
+//
+//	huma.Get(grp, "/users", func(ctx huma.Context, input *MyInput) (*MyOutput, error) {
+//		// Your code here...
+//	})
+func NewGroup(api API, prefixes ...string) *Group {
+	if len(prefixes) == 0 {
+		prefixes = append(prefixes, "")
+	}
+	group := &Group{API: api, prefixes: prefixes}
+	group.adapter = &groupAdapter{Adapter: api.Adapter(), group: group}
+	return group
+}
+
+func (g *Group) Adapter() Adapter {
+	return g.adapter
+}
+
+func (g *Group) OpenAPI() *OpenAPI {
+	// Provide a callback that `huma.Register` will call, and take the operation
+	// that is added and modify it as needed for each prefix, registering it with
+	// the real underlying OpenAPI document. This ensure the documentation
+	// matches the server behavior!
+	// The one caveat is that this *only* works for operations which invoke
+	// the `OpenAPI.AddOperation(...)` call.
+	openapi := *g.API.OpenAPI()
+	openapi.OnAddOperation = append(openapi.OnAddOperation, func(oapi *OpenAPI, op *Operation) {
+		for _, prefix := range g.prefixes {
+			modified := *op
+			modifyOperation(g, prefix, &modified)
+			g.API.OpenAPI().AddOperation(&modified)
+		}
+	})
+	return &openapi
+}
+
+// UseOperationModifier adds an operation modifier function to the group that
+// will be run on all operations in the group. Use this to modify the operation
+// before it is registered with the router or OpenAPI document.
+func (g *Group) UseOperationModifier(handler func(o *Operation)) {
+	g.opModifiers = append(g.opModifiers, handler)
+}
+
+// UseMiddleware adds one or more middleware functions to the group that will be
+// run on all operations in the group. Use this to add common functionality to
+// all operations in the group, e.g. authentication/authorization.
+func (g *Group) UseMiddleware(middlewares ...func(ctx Context, next func(Context))) {
+	g.middlewares = append(g.middlewares, middlewares...)
+}
+
+func (g *Group) Middlewares() Middlewares {
+	m := append(Middlewares{}, g.API.Middlewares()...)
+	return append(m, g.middlewares...)
+}
+
+// UseTransformer adds one or more transformer functions to the group that will
+// be run on all responses in the group.
+func (g *Group) UseTransformer(transformers ...Transformer) {
+	g.transformers = append(g.transformers, transformers...)
+}
+
+func (g *Group) Transform(ctx Context, status string, v any) (any, error) {
+	v, err := g.API.Transform(ctx, status, v)
+	if err != nil {
+		return v, err
+	}
+	for _, transformer := range g.transformers {
+		v, err = transformer(ctx, status, v)
+		if err != nil {
+			return v, err
+		}
+	}
+	return v, nil
+}

--- a/group_test.go
+++ b/group_test.go
@@ -2,7 +2,7 @@ package huma_test
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -87,7 +87,7 @@ type FailingTransformAPI struct {
 }
 
 func (a *FailingTransformAPI) Transform(ctx huma.Context, status string, v any) (any, error) {
-	return nil, fmt.Errorf("whoops")
+	return nil, errors.New("whoops")
 }
 
 func TestGroupTransformUnderlyingError(t *testing.T) {
@@ -112,7 +112,7 @@ func TestGroupTransformError(t *testing.T) {
 	grp := huma.NewGroup(api, "/v1")
 
 	grp.UseTransformer(func(ctx huma.Context, status string, v any) (any, error) {
-		return v, fmt.Errorf("whoops")
+		return v, errors.New("whoops")
 	})
 
 	huma.Get(grp, "/users", func(ctx context.Context, input *struct{}) (*struct {

--- a/group_test.go
+++ b/group_test.go
@@ -1,0 +1,127 @@
+package huma_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroupNoPrefix(t *testing.T) {
+	_, api := humatest.New(t)
+
+	grp := huma.NewGroup(api)
+
+	huma.Get(grp, "/users", func(ctx context.Context, input *struct{}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	assert.NotNil(t, api.OpenAPI().Paths["/users"])
+
+	resp := api.Get("/users")
+	assert.Equal(t, http.StatusNoContent, resp.Result().StatusCode)
+}
+
+func TestGroupMultiPrefix(t *testing.T) {
+	_, api := humatest.New(t)
+
+	grp := huma.NewGroup(api, "/v1", "/v2")
+
+	huma.Get(grp, "/users", func(ctx context.Context, input *struct{}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	assert.Nil(t, api.OpenAPI().Paths["/users"])
+	assert.NotNil(t, api.OpenAPI().Paths["/v1/users"])
+	assert.NotNil(t, api.OpenAPI().Paths["/v2/users"])
+	assert.NotEqual(t, api.OpenAPI().Paths["/v1/users"].Get.OperationID, api.OpenAPI().Paths["/v2/users"].Get.OperationID)
+
+	resp := api.Get("/v1/users")
+	assert.Equal(t, http.StatusNoContent, resp.Result().StatusCode)
+
+	resp = api.Get("/v2/users")
+	assert.Equal(t, http.StatusNoContent, resp.Result().StatusCode)
+}
+
+func TestGroupCustomizations(t *testing.T) {
+	_, api := humatest.New(t)
+
+	grp := huma.NewGroup(api, "/v1")
+
+	opModifierCalled := false
+	middlewareCalled := false
+	transformerCalled := false
+	grp.UseOperationModifier(func(op *huma.Operation) {
+		opModifierCalled = true
+	})
+
+	grp.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
+		middlewareCalled = true
+		next(ctx)
+	})
+
+	grp.UseTransformer(func(ctx huma.Context, status string, v any) (any, error) {
+		transformerCalled = true
+		return v, nil
+	})
+
+	huma.Get(grp, "/users", func(ctx context.Context, input *struct{}) (*struct {
+		Body string
+	}, error) {
+		return &struct{ Body string }{Body: ""}, nil
+	})
+
+	resp := api.Get("/v1/users")
+	assert.Equal(t, 200, resp.Result().StatusCode)
+	assert.True(t, opModifierCalled)
+	assert.True(t, middlewareCalled)
+	assert.True(t, transformerCalled)
+}
+
+type FailingTransformAPI struct {
+	huma.API
+}
+
+func (a *FailingTransformAPI) Transform(ctx huma.Context, status string, v any) (any, error) {
+	return nil, fmt.Errorf("whoops")
+}
+
+func TestGroupTransformUnderlyingError(t *testing.T) {
+	_, api := humatest.New(t)
+
+	grp := huma.NewGroup(&FailingTransformAPI{API: api}, "/v1")
+
+	huma.Get(grp, "/users", func(ctx context.Context, input *struct{}) (*struct {
+		Body string
+	}, error) {
+		return &struct{ Body string }{Body: ""}, nil
+	})
+
+	assert.Panics(t, func() {
+		api.Get("/v1/users")
+	})
+}
+
+func TestGroupTransformError(t *testing.T) {
+	_, api := humatest.New(t)
+
+	grp := huma.NewGroup(api, "/v1")
+
+	grp.UseTransformer(func(ctx huma.Context, status string, v any) (any, error) {
+		return v, fmt.Errorf("whoops")
+	})
+
+	huma.Get(grp, "/users", func(ctx context.Context, input *struct{}) (*struct {
+		Body string
+	}, error) {
+		return &struct{ Body string }{Body: ""}, nil
+	})
+
+	assert.Panics(t, func() {
+		api.Get("/v1/users")
+	})
+}

--- a/huma.go
+++ b/huma.go
@@ -640,8 +640,13 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 	}
 	defineErrors(&op, registry)
 
-	if !op.Hidden {
-		oapi.AddOperation(&op)
+	if documenter, ok := api.(OperationDocumenter); ok {
+		// Enables customization of OpenAPI documentation behavior for operations.
+		documenter.DocumentOperation(&op)
+	} else {
+		if !op.Hidden {
+			oapi.AddOperation(&op)
+		}
 	}
 
 	resolvers := findResolvers(resolverType, inputType)


### PR DESCRIPTION
This PR adds a new `Group` struct & feature that takes the functionality of the excellent https://github.com/cardinalby/hureg library and ports it into Huma's core. Basic functionality looks like this:

```go
grp := huma.NewGroup(api, "/v1")
grp.UseMiddleware(authMiddleware)

huma.Get(grp, "/users", func(ctx context.Context, input *struct{}) ([]User, error) {
	// ...
})
```

Check out the included docs for more info!

Related to #719.
Fixes #489.