### PR TITLE
fix: do not panic when encountering external schemas

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"strings"
 )
 
 type schemaField struct {
@@ -49,7 +50,7 @@ func NewSchemaLinkTransformer(prefix, schemasPath string) *SchemaLinkTransformer
 }
 
 func (t *SchemaLinkTransformer) addSchemaField(oapi *OpenAPI, content *MediaType) bool {
-	if content == nil || content.Schema == nil || content.Schema.Ref == "" {
+	if content == nil || content.Schema == nil || content.Schema.Ref == "" || !strings.HasPrefix(content.Schema.Ref, "#/") {
 		return true
 	}
 


### PR DESCRIPTION
This PR ensures the schema link transformer only runs when the ref is a valid intra-document (local) ref and not an external one. External ones are ignored.

Fixes #703.