### PR TITLE
feat: support context unwrapping

### DIFF
--- a/adapters/humabunrouter/humabunrouter.go
+++ b/adapters/humabunrouter/humabunrouter.go
@@ -20,6 +20,15 @@ import (
 // form data.
 var MultipartMaxMemory int64 = 8 * 1024
 
+// Unwrap extracts the underlying HTTP request and response writer from a Huma
+// context. If passed a context from a different adapter it will panic.
+func Unwrap(ctx huma.Context) (bunrouter.Request, http.ResponseWriter) {
+	if c, ok := ctx.(*bunContext); ok {
+		return c.Unwrap()
+	}
+	panic("not a humabunrouter context")
+}
+
 type bunContext struct {
 	op     *huma.Operation
 	r      bunrouter.Request
@@ -29,6 +38,10 @@ type bunContext struct {
 
 // check that bunContext implements huma.Context
 var _ huma.Context = &bunContext{}
+
+func (c *bunContext) Unwrap() (bunrouter.Request, http.ResponseWriter) {
+	return c.r, c.w
+}
 
 func (c *bunContext) Operation() *huma.Operation {
 	return c.op

--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -18,6 +18,15 @@ import (
 // form data.
 var MultipartMaxMemory int64 = 8 * 1024
 
+// Unwrap extracts the underlying HTTP request and response writer from a Huma
+// context. If passed a context from a different adapter it will panic.
+func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
+	if c, ok := ctx.(*chiContext); ok {
+		return c.Unwrap()
+	}
+	panic("not a humachi context")
+}
+
 type chiContext struct {
 	op     *huma.Operation
 	r      *http.Request
@@ -27,6 +36,10 @@ type chiContext struct {
 
 // check that chiContext implements huma.Context
 var _ huma.Context = &chiContext{}
+
+func (c *chiContext) Unwrap() (*http.Request, http.ResponseWriter) {
+	return c.r, c.w
+}
 
 func (c *chiContext) Operation() *huma.Operation {
 	return c.op

--- a/adapters/humaecho/humaecho.go
+++ b/adapters/humaecho/humaecho.go
@@ -18,6 +18,15 @@ import (
 // form data.
 var MultipartMaxMemory int64 = 8 * 1024
 
+// Unwrap extracts the underlying Echo context from a Huma context. If passed a
+// context from a different adapter it will panic.
+func Unwrap(ctx huma.Context) echo.Context {
+	if c, ok := ctx.(*echoCtx); ok {
+		return c.Unwrap()
+	}
+	panic("not a humaecho context")
+}
+
 type echoCtx struct {
 	op     *huma.Operation
 	orig   echo.Context
@@ -26,6 +35,10 @@ type echoCtx struct {
 
 // check that echoCtx implements huma.Context
 var _ huma.Context = &echoCtx{}
+
+func (c *echoCtx) Unwrap() echo.Context {
+	return c.orig
+}
 
 func (c *echoCtx) Operation() *huma.Operation {
 	return c.op

--- a/adapters/humafiber/humafiber.go
+++ b/adapters/humafiber/humafiber.go
@@ -15,6 +15,18 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
+// Unwrap extracts the underlying Fiber context from a Huma context. If passed a
+// context from a different adapter it will panic. Keep in mind the limitations
+// of the underlying Fiber/fasthttp libraries and how that impacts
+// memory-safety: https://docs.gofiber.io/#zero-allocation. Do not keep
+// references to the underlying context or its values!
+func Unwrap(ctx huma.Context) *fiber.Ctx {
+	if c, ok := ctx.(*fiberWrapper); ok {
+		return c.Unwrap()
+	}
+	panic("context does not implement humafiber.ContextUnwrapper")
+}
+
 type fiberAdapter struct {
 	tester requestTester
 	router router
@@ -29,6 +41,10 @@ type fiberWrapper struct {
 
 // check that fiberCtx implements huma.Context
 var _ huma.Context = &fiberWrapper{}
+
+func (c *fiberWrapper) Unwrap() *fiber.Ctx {
+	return c.orig
+}
 
 func (c *fiberWrapper) Operation() *huma.Operation {
 	return c.op

--- a/adapters/humaflow/humaflow.go
+++ b/adapters/humaflow/humaflow.go
@@ -19,11 +19,27 @@ import (
 // form data.
 var MultipartMaxMemory int64 = 8 * 1024
 
+// Unwrap extracts the underlying HTTP request and response writer from a Huma
+// context. If passed a context from a different adapter it will panic.
+func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
+	if c, ok := ctx.(*goContext); ok {
+		return c.Unwrap()
+	}
+	panic("not a humaflow context")
+}
+
 type goContext struct {
 	op     *huma.Operation
 	r      *http.Request
 	w      http.ResponseWriter
 	status int
+}
+
+// check that goContext implements huma.Context
+var _ huma.Context = &goContext{}
+
+func (c *goContext) Unwrap() (*http.Request, http.ResponseWriter) {
+	return c.r, c.w
 }
 
 func (c *goContext) Operation() *huma.Operation {

--- a/adapters/humagin/humagin.go
+++ b/adapters/humagin/humagin.go
@@ -18,6 +18,15 @@ import (
 // form data.
 var MultipartMaxMemory int64 = 8 * 1024
 
+// Unwrap extracts the underlying Gin context from a Huma context. If passed a
+// context from a different adapter it will panic.
+func Unwrap(ctx huma.Context) *gin.Context {
+	if c, ok := ctx.(*ginCtx); ok {
+		return c.Unwrap()
+	}
+	panic("not a humagin context")
+}
+
 type ginCtx struct {
 	op     *huma.Operation
 	orig   *gin.Context
@@ -26,6 +35,10 @@ type ginCtx struct {
 
 // check that ginCtx implements huma.Context
 var _ huma.Context = &ginCtx{}
+
+func (c *ginCtx) Unwrap() *gin.Context {
+	return c.orig
+}
 
 func (c *ginCtx) Operation() *huma.Operation {
 	return c.op

--- a/adapters/humago/humago.go
+++ b/adapters/humago/humago.go
@@ -18,6 +18,15 @@ import (
 // form data.
 var MultipartMaxMemory int64 = 8 * 1024
 
+// Unwrap extracts the underlying HTTP request and response writer from a Huma
+// context. If passed a context from a different adapter it will panic.
+func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
+	if c, ok := ctx.(*goContext); ok {
+		return c.Unwrap()
+	}
+	panic("not a humago context")
+}
+
 type goContext struct {
 	op     *huma.Operation
 	r      *http.Request
@@ -27,6 +36,10 @@ type goContext struct {
 
 // check that goContext implements huma.Context
 var _ huma.Context = &goContext{}
+
+func (c *goContext) Unwrap() (*http.Request, http.ResponseWriter) {
+	return c.r, c.w
+}
 
 func (c *goContext) Operation() *huma.Operation {
 	return c.op

--- a/adapters/humahttprouter/humahttprouter.go
+++ b/adapters/humahttprouter/humahttprouter.go
@@ -19,6 +19,15 @@ import (
 // form data.
 var MultipartMaxMemory int64 = 8 * 1024
 
+// Unwrap extracts the underlying HTTP request and response writer from a Huma
+// context. If passed a context from a different adapter it will panic.
+func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter, httprouter.Params) {
+	if c, ok := ctx.(*httprouterContext); ok {
+		return c.Unwrap()
+	}
+	panic("not an httprouter context")
+}
+
 type httprouterContext struct {
 	op     *huma.Operation
 	r      *http.Request
@@ -29,6 +38,10 @@ type httprouterContext struct {
 
 // check that httprouterContext implements huma.Context
 var _ huma.Context = &httprouterContext{}
+
+func (c *httprouterContext) Unwrap() (*http.Request, http.ResponseWriter, httprouter.Params) {
+	return c.r, c.w, c.ps
+}
 
 func (c *httprouterContext) Operation() *huma.Operation {
 	return c.op

--- a/adapters/humamux/humamux.go
+++ b/adapters/humamux/humamux.go
@@ -18,6 +18,15 @@ import (
 // form data.
 var MultipartMaxMemory int64 = 8 * 1024
 
+// Unwrap extracts the underlying HTTP request and response writer from a Huma
+// context. If passed a context from a different adapter it will panic.
+func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
+	if c, ok := ctx.(*gmuxContext); ok {
+		return c.Unwrap()
+	}
+	panic("not a humamux context")
+}
+
 type gmuxContext struct {
 	op     *huma.Operation
 	r      *http.Request
@@ -27,6 +36,10 @@ type gmuxContext struct {
 
 // check that gmuxContext implements huma.Context
 var _ huma.Context = &gmuxContext{}
+
+func (c *gmuxContext) Unwrap() (*http.Request, http.ResponseWriter) {
+	return c.r, c.w
+}
 
 func (c *gmuxContext) Operation() *huma.Operation {
 	return c.op

--- a/docs/docs/features/bring-your-own-router.md
+++ b/docs/docs/features/bring-your-own-router.md
@@ -99,7 +99,7 @@ graph LR
 	OperationHandler[Operation Handler]
 
 	Request --> Router
-	Router -->|http.Request\nfiber.Ctx\netc| huma.Adapter
+	Router -->|http.Request<br>fiber.Ctx<br>etc| huma.Adapter
 	subgraph huma.API
 		huma.Adapter -->|huma.Context| OperationHandler
 	end

--- a/docs/docs/features/request-resolvers.md
+++ b/docs/docs/features/request-resolvers.md
@@ -93,6 +93,10 @@ func (i *MyInput) Resolve(ctx huma.Context) []error {
 
     Exhaustive errors lessen frustration for users. It's better to return three errors in response to one request than to have the user make three requests which each return a new different error.
 
+### Unwrapping
+
+While generally not recommended, if you need to access the underlying router-specific request and response objects, you can `Unwrap()` them using the router-specific adapter package you used to create the API instance. See the [middleware documentation](./middleware.md#unwrapping) for more information.
+
 ## Implementation Check
 
 There is a Go trick for ensuring that a struct implements a certain interface, and you can utilize it to ensure your resolvers will be called as expected. For example:


### PR DESCRIPTION
This PR is an alternative to #699 which enables unwrapping a `huma.Context` back into its router-specific request/response object or router-specific context, effectively escaping Huma and giving back full control to the user. It's generally recommended to not do this, but there are legitimate use-cases where this could be handy to have as an option. Example:

```go
router := http.NewServeMux()
api := humago.New(router, huma.DefaultConfig("My API", "1.0.0"))

api.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
	r, w := humago.Unwrap(ctx)
	fmt.Println("Request started", r.Method, r.URL)
	w.Header().Set("X-Request-Start", time.Now().Format(time.RFC3339))
	next(ctx)
})
```

This implementation does not modify any interfaces in Huma itself, nor does it require manually casting `any` or things like that. Each adapter simply provides a convenience `Unwrap()` function that returns the underlying data.

This should also make it fairly simple to switch routers as you can find/replace the router-specific package (e.g. `humachi` → `humago`) and things will just work or provide a compile-time error if the return types changed, making it easy to fix, instead of waiting for a runtime error.