### PR TITLE
fix: do not HTML escape JSON output by default

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -15,7 +15,9 @@ import (
 //	}
 var DefaultJSONFormat = Format{
 	Marshal: func(w io.Writer, v any) error {
-		return json.NewEncoder(w).Encode(v)
+		enc := json.NewEncoder(w)
+		enc.SetEscapeHTML(false)
+		return enc.Encode(v)
 	},
 	Unmarshal: json.Unmarshal,
 }

--- a/huma_test.go
+++ b/huma_test.go
@@ -3002,7 +3002,7 @@ func TestCustomSchemaErrors(t *testing.T) {
 	resp := api.Post("/test", map[string]any{"test": 1})
 
 	assert.Equal(t, http.StatusUnprocessableEntity, resp.Result().StatusCode)
-	assert.Contains(t, resp.Body.String(), `expected number \u003e= 10`)
+	assert.Contains(t, resp.Body.String(), `expected number >= 10`)
 }
 
 func TestBodyRace(t *testing.T) {


### PR DESCRIPTION
Be default, JSON output is escaped to better support embedding it into HTML. This is extremely unlikely to be needed for HTTP APIs as they have different access patterns. This changes the default behavior to not escape, while letting people who do need the feature set it up in their `huma.Config.Formats` map as needed.

For example, `expected number \u003e= 10` becomes `expected number >= 10` after this change.