### PR TITLE
fix: better integer validation checks

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -428,8 +428,16 @@ func Validate(r Registry, s *Schema, path *PathBuffer, mode ValidateMode, v any,
 		case uint64:
 			num = float64(v)
 		default:
-			res.Add(path, v, validation.MsgExpectedNumber)
+			if s.Type == TypeInteger {
+				res.Add(path, v, validation.MsgExpectedInteger)
+			} else {
+				res.Add(path, v, validation.MsgExpectedNumber)
+			}
 			return
+		}
+
+		if s.Type == TypeInteger && num != math.Trunc(num) {
+			res.Add(path, v, validation.MsgExpectedInteger)
 		}
 
 		if s.Minimum != nil {

--- a/validate_test.go
+++ b/validate_test.go
@@ -123,7 +123,13 @@ var validateTests = []struct {
 		name:  "expected number int",
 		typ:   reflect.TypeOf(0),
 		input: "",
-		errs:  []string{"expected number"},
+		errs:  []string{"expected integer"},
+	},
+	{
+		name:  "expected number int from float64",
+		typ:   reflect.TypeOf(0),
+		input: float64(1.5),
+		errs:  []string{"expected integer"},
 	},
 	{
 		name:  "expected number float64",
@@ -731,13 +737,13 @@ var validateTests = []struct {
 		name:  "expected map item",
 		typ:   reflect.TypeOf(map[any]int{}),
 		input: map[string]any{"one": 1, "two": true},
-		errs:  []string{"expected number"},
+		errs:  []string{"expected integer"},
 	},
 	{
 		name:  "expected map any item",
 		typ:   reflect.TypeOf(map[any]int{}),
 		input: map[any]any{"one": 1, "two": true},
-		errs:  []string{"expected number"},
+		errs:  []string{"expected integer"},
 	},
 	{
 		name: "map minProps success",

--- a/validation/messages.go
+++ b/validation/messages.go
@@ -23,6 +23,7 @@ var (
 	MsgExpectedPropertyNameInObject       = "expected propertyName value to be present in object"
 	MsgExpectedBoolean                    = "expected boolean"
 	MsgExpectedNumber                     = "expected number"
+	MsgExpectedInteger                    = "expected integer"
 	MsgExpectedString                     = "expected string"
 	MsgExpectedBase64String               = "expected string to be base64 encoded"
 	MsgExpectedArray                      = "expected array"


### PR DESCRIPTION
This adds an additional check for integers using `math.Trunc(...)` to try and fail earlier with a more reasonable error message for users passing in floating point values for integers.

Fixes #745. (not entirely, but it's an improvement)