### PR TITLE
fix: Allow explicitely setting the "example" tag to the empty string

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -163,7 +163,7 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 		pfi.Schema = SchemaFromField(registry, f, "")
 
 		var example any
-		if value , present := f.Tag.Lookup("example"); present {
+		if value, ok := f.Tag.Lookup("example"); ok {
 			example = jsonTagValue(registry, f.Type.Name(), pfi.Schema, value)
 		}
 		if example == nil && len(pfi.Schema.Examples) > 0 {

--- a/huma.go
+++ b/huma.go
@@ -163,8 +163,8 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 		pfi.Schema = SchemaFromField(registry, f, "")
 
 		var example any
-		if e := f.Tag.Get("example"); e != "" {
-			example = jsonTagValue(registry, f.Type.Name(), pfi.Schema, f.Tag.Get("example"))
+		if value , present := f.Tag.Lookup("example"); present {
+			example = jsonTagValue(registry, f.Type.Name(), pfi.Schema, value)
 		}
 		if example == nil && len(pfi.Schema.Examples) > 0 {
 			example = pfi.Schema.Examples[0]

--- a/schema.go
+++ b/schema.go
@@ -558,7 +558,7 @@ func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Sch
 		fs.Default = defaultValue
 	}
 
-	if value , present := f.Tag.Lookup("example"); present {
+	if value, ok := f.Tag.Lookup("example"); ok {
 		if e := jsonTagValue(registry, f.Name, fs, value); e != nil {
 			fs.Examples = []any{e}
 		}

--- a/schema.go
+++ b/schema.go
@@ -558,7 +558,7 @@ func SchemaFromField(registry Registry, f reflect.StructField, hint string) *Sch
 		fs.Default = defaultValue
 	}
 
-	if value := f.Tag.Get("example"); value != "" {
+	if value , present := f.Tag.Lookup("example"); present {
 		if e := jsonTagValue(registry, f.Name, fs, value); e != nil {
 			fs.Examples = []any{e}
 		}


### PR DESCRIPTION
This simple patch allows to explicitly set the "example" tag of fields in both params an schemas to the empty string "" .