### PR TITLE
proposal: support docs on separate adapter

### DIFF
--- a/adapters/humachi/humachi_test.go
+++ b/adapters/humachi/humachi_test.go
@@ -322,6 +322,9 @@ func TestChiRouterPrefix(t *testing.T) {
 	mux.Route("/api", func(r chi.Router) {
 		config := huma.DefaultConfig("My API", "1.0.0")
 		config.Servers = []*huma.Server{{URL: "http://localhost:8888/api"}}
+		// config.CreateHooks = []func(huma.Config) huma.Config{
+		// 	huma.DefaultSchemaLinkHook("/api"),
+		// }
 		api = New(r, config)
 	})
 

--- a/adapters/humachi/humachi_test.go
+++ b/adapters/humachi/humachi_test.go
@@ -350,7 +350,8 @@ func TestChiRouterPrefix(t *testing.T) {
 	// The docs HTML should point to the full URL including base path.
 	resp = tapi.Get("/api/docs")
 	assert.Equal(t, http.StatusOK, resp.Code)
-	assert.Contains(t, resp.Body.String(), "/api/openapi.yaml")
+	// The openapi.yaml should be a relative path.
+	assert.Contains(t, resp.Body.String(), `apiDescriptionUrl="openapi.yaml"`)
 }
 
 // func BenchmarkHumaV1Chi(t *testing.B) {

--- a/defaults.go
+++ b/defaults.go
@@ -3,7 +3,6 @@ package huma
 import (
 	"encoding/json"
 	"io"
-	"path"
 )
 
 // DefaultSchemaNamer is the default prefix used to reference schemas in the API spec.
@@ -76,7 +75,7 @@ func DefaultConfig(title, version string) Config {
 		Formats:       DefaultFormats,
 		DefaultFormat: "application/json",
 		CreateHooks: []func(Config) Config{
-			DefaultSchemaLinkHook(DefaultSchemaRefPrefix, ""),
+			DefaultSchemaLinkHook(""), // assume schemas are on mounted the root
 		},
 	}
 }
@@ -85,9 +84,9 @@ func DefaultConfig(title, version string) Config {
 // This adds `Link` headers and puts `$schema` fields in the response body which
 // point to the JSON Schema that describes the response structure.
 // This is a create hook so we get the latest schema path setting.
-func DefaultSchemaLinkHook(schemaRefPrefix, schemaPathPrefix string) func(c Config) Config {
+func DefaultSchemaLinkHook(schemaPathPrefix string) func(c Config) Config {
 	return func(c Config) Config {
-		linkTransformer := NewSchemaLinkTransformer(schemaRefPrefix, path.Join(schemaPathPrefix, c.SchemasPath))
+		linkTransformer := NewSchemaLinkTransformer(schemaPathPrefix, c.SchemasPath)
 		c.OpenAPI.OnAddOperation = append(c.OpenAPI.OnAddOperation, linkTransformer.OnAddOperation)
 		c.Transformers = append(c.Transformers, linkTransformer.Transform)
 		return c

--- a/transforms.go
+++ b/transforms.go
@@ -20,7 +20,7 @@ type schemaField struct {
 // as-you-type validation & completion of HTTP resources in editors like
 // VSCode.
 type SchemaLinkTransformer struct {
-	prefix      string
+	apiPrefix   string
 	schemasPath string
 	types       map[any]struct {
 		t      reflect.Type
@@ -36,9 +36,9 @@ type SchemaLinkTransformer struct {
 // to understand the structure of the response and enables things like
 // as-you-type validation & completion of HTTP resources in editors like
 // VSCode.
-func NewSchemaLinkTransformer(prefix, schemasPath string) *SchemaLinkTransformer {
+func NewSchemaLinkTransformer(apiPrefix, schemasPath string) *SchemaLinkTransformer {
 	return &SchemaLinkTransformer{
-		prefix:      prefix,
+		apiPrefix:   apiPrefix,
 		schemasPath: schemasPath,
 		types: map[any]struct {
 			t      reflect.Type
@@ -94,8 +94,10 @@ func (t *SchemaLinkTransformer) OnAddOperation(oapi *OpenAPI, op *Operation) {
 	// Figure out if there should be a base path prefix. This might be set when
 	// using a sub-router / group or if the gateway consumes a part of the path.
 	schemasPath := t.schemasPath
-	if prefix := getAPIPrefix(oapi); prefix != "" {
-		schemasPath = path.Join(prefix, schemasPath)
+	if apiPrefix := getAPIPrefix(oapi); apiPrefix != "" {
+		schemasPath = path.Join(apiPrefix, schemasPath)
+	} else if t.apiPrefix != "" {
+		schemasPath = path.Join(t.apiPrefix, schemasPath)
 	}
 
 	registry := oapi.Components.Schemas


### PR DESCRIPTION
This allows exposing the spec and docs on a separate adapter, potentially under a separate path and/or middleware stacks.

E.g.: (assuming `internalRouter` and `mainRouter` are two `chi.Router`)
```go
opts := huma.DefaultConfig("foo", "0.0.1")
opts.DocsAdapter = humachi.NewAdapter(internalRouter)
opts.CreateHooks = []func(huma.Config) huma.Config{
	huma.DefaultSchemaLinkHook(huma.DefaultSchemaRefPrefix, internalPrefix), // assuming internalRouter above is mounted under internalPrefix
}

adapter := humachi.NewAdapter(mainRouter)

huma.NewAPI(opts, adapter)
```

This is a bit of a WIP:
- I'm not 100% sure the removal of `getAPIPrefix` call in the stoplight template is really as harmless as I think
- the other remaining `getAPIPrefix` call will currently break the schema links if the API  is mounted somewhere other than the root.

But regardless of the limitations above: WDYT about the general idea?
