### PR TITLE
Fix panic when sending an empty file field in a form

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -789,7 +789,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 								pb.Push(p.Name)
 
 								value, ok := form.Value[p.Name]
-								if !ok {
+								if !ok || (len(value) > 0 && value[0] == "") {
 									_, isFile := form.File[p.Name]
 									if !op.SkipValidateParams && p.Required && !isFile {
 										res.Add(pb, "", "required "+p.Loc+" parameter is missing")


### PR DESCRIPTION
# Fix panic on empty file field in RawBody

## Problem  
When an empty file field is submitted in a form (`multipart/form-data`), `form.Value` contains an empty string (`""`), but `form.File` is missing. This leads to a panic with the error:  `unsupported param type huma.FormFile`

## Solution  
Now, before accessing `form.Value[p.Name]`, we check if the value is an empty string and handle it correctly. If the parameter is required and not a valid file, a proper validation error is returned instead of causing a panic.  

