### PR TITLE
Add WithIndex to PathBuffer

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -129,6 +129,18 @@ func (b *PathBuffer) With(s string) string {
 	return tmp
 }
 
+// WithIndex is short for push index, convert to string, and pop. This is useful
+// when you want the location of the index given a path buffer as a prefix.
+//
+//	pb.Push("foo")
+//	pb.WithIndex(1) // return foo[1]
+func (b *PathBuffer) WithIndex(i int) string {
+	b.PushIndex(i)
+	tmp := b.String()
+	b.Pop()
+	return tmp
+}
+
 // Len returns the length of the current path.
 func (b *PathBuffer) Len() int {
 	return b.off

--- a/validate_test.go
+++ b/validate_test.go
@@ -1693,3 +1693,10 @@ func Test_validateWithDiscriminator(t *testing.T) {
 		})
 	}
 }
+
+func TestPathBuffer_WithIndex_ReturnsExpectedString(t *testing.T) {
+	pb := huma.NewPathBuffer([]byte(""), 0)
+	pb.Push("prefix")
+
+	assert.Equal(t, "prefix[1]", pb.WithIndex(1))
+}


### PR DESCRIPTION
Same as `With()`, but takes and int, calls `PushIndex`, converts to a string, then pops.

Found myself wishing for this functionality today, but not a deal breaker if it doesn't make it in. Just a little more convenient.

I did not see any tests for pathbuffer itself, but since this method wouldn't be covered elsewhere I added a test for it.