### PR TITLE
proposal: extend netip.Addr support to ipv6

### DIFF
--- a/docs/docs/features/request-inputs.md
+++ b/docs/docs/features/request-inputs.md
@@ -102,7 +102,7 @@ The following special types are supported out of the box:
 | `time.Time`       | `{"type": "string", "format": "date-time"}` | `"2020-01-01T12:00:00Z"`      |
 | `url.URL`         | `{"type": "string", "format": "uri"}`       | `"https://example.com"`       |
 | `net.IP`          | `{"type": "string", "format": "ipv4"}`      | `"127.0.0.1"`                 |
-| `netip.Addr`      | `{"type": "string", "format": "ipv4"}`      | `"127.0.0.1"`                 |
+| `netip.Addr`      | `{"type": "string", "format": "ip"}`        | `"127.0.0.1"` or `fe80::1`    |
 | `json.RawMessage` | `{}`                                        | `["whatever", "you", "want"]` |
 
 You can override this default behavior if needed as described in [Schema Customization](./schema-customization.md) and [Request Validation](./request-validation.md), e.g. setting a custom `format` tag for IPv6.

--- a/schema.go
+++ b/schema.go
@@ -722,7 +722,7 @@ func schemaFromType(r Registry, t reflect.Type) *Schema {
 	case ipType:
 		return &Schema{Type: TypeString, Nullable: isPointer, Format: "ipv4"}
 	case ipAddrType:
-		return &Schema{Type: TypeString, Nullable: isPointer, Format: "ipv4"}
+		return &Schema{Type: TypeString, Nullable: isPointer, Format: "ip"}
 	case rawMessageType:
 		return &Schema{}
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -190,7 +190,7 @@ func TestSchema(t *testing.T) {
 		{
 			name:     "ipAddr",
 			input:    netip.AddrFrom4([4]byte{127, 0, 0, 1}),
-			expected: `{"type": "string", "format": "ipv4"}`,
+			expected: `{"type": "string", "format": "ip"}`,
 		},
 		{
 			name:     "json.RawMessage",

--- a/validate.go
+++ b/validate.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net"
 	"net/mail"
+	"net/netip"
 	"net/url"
 	"reflect"
 	"regexp"
@@ -234,6 +235,10 @@ func validateFormat(path *PathBuffer, str string, s *Schema, res *ValidateResult
 	case "ipv6":
 		if ip := net.ParseIP(str); ip == nil || ip.To16() == nil {
 			res.Add(path, str, validation.MsgExpectedRFC2373IPv6)
+		}
+	case "ip":
+		if _, err := netip.ParseAddr(str); err != nil {
+			res.Add(path, str, validation.MsgExpectedRFCIPAddr)
 		}
 	case "uri", "uri-reference", "iri", "iri-reference":
 		if _, err := url.Parse(str); err != nil {

--- a/validate_test.go
+++ b/validate_test.go
@@ -434,6 +434,28 @@ var validateTests = []struct {
 		errs:  []string{"expected string to be RFC 2373 ipv6"},
 	},
 	{
+		name: "ipv4 success",
+		typ: reflect.TypeOf(struct {
+			Value string `json:"value" format:"ip"`
+		}{}),
+		input: map[string]any{"value": "127.0.0.1"},
+	},
+	{
+		name: "ipv6 success",
+		typ: reflect.TypeOf(struct {
+			Value string `json:"value" format:"ip"`
+		}{}),
+		input: map[string]any{"value": "2001:0db8:85a3:0000:0000:8a2e:0370:7334"},
+	},
+	{
+		name: "expected ipv4 or ipv6",
+		typ: reflect.TypeOf(struct {
+			Value string `json:"value" format:"ip"`
+		}{}),
+		input: map[string]any{"value": "1234"},
+		errs:  []string{"expected string to be either RFC 2673 ipv4 or RFC 2373 ipv6"},
+	},
+	{
 		name: "uri success",
 		typ: reflect.TypeOf(struct {
 			Value string `json:"value" format:"uri"`

--- a/validation/messages.go
+++ b/validation/messages.go
@@ -11,6 +11,7 @@ var (
 	MsgExpectedRFC5890Hostname            = "expected string to be RFC 5890 hostname"
 	MsgExpectedRFC2673IPv4                = "expected string to be RFC 2673 ipv4"
 	MsgExpectedRFC2373IPv6                = "expected string to be RFC 2373 ipv6"
+	MsgExpectedRFCIPAddr                  = "expected string to be either RFC 2673 ipv4 or RFC 2373 ipv6"
 	MsgExpectedRFC3986URI                 = "expected string to be RFC 3986 uri: %v"
 	MsgExpectedRFC4122UUID                = "expected string to be RFC 4122 uuid: %v"
 	MsgExpectedRFC6570URITemplate         = "expected string to be RFC 6570 uri-template"


### PR DESCRIPTION
[netip.Addr](https://pkg.go.dev/net/netip#Addr) supports parsing both ipv4 and ipv6 out of the box. So it is a bit surprising to have a `netip.Addr` field in an API only support ipv4 and no easy way to add "dual-stack" support for APIs.

I propose to extend the support for `netip.Addr` added in !396 and support ipv6 out of the box as well.

⚠️ The change in the `format` detection for `netip.Addr` fields may be considered breaking, since existing APIs will start accepting IPv6 addresses and people may be counting on that limitation. I'd argue that it's worth it, but if not, we can remove that single change, while still adding support for the `ip` dual-stack format, to be used explicitly.

WDYT?