### PR TITLE
Add merging of allOf schemas. Fixes #787

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -376,9 +376,7 @@ func Validate(r Registry, s *Schema, path *PathBuffer, mode ValidateMode, v any,
 	}
 
 	if s.AllOf != nil {
-		for _, sub := range s.AllOf {
-			Validate(r, sub, path, mode, v, res)
-		}
+		Validate(r, mergeAllOfSchemas(s.AllOf, r), path, mode, v, res)
 	}
 
 	if s.Not != nil {


### PR DESCRIPTION
Hey there!

I've prepared a fix for #787.

There are a few considerations that need to be taken into account:
- The proposed approach is quite basic.
- It covers the primitive-based schema types ( e.g., `Type: integer` ) and object types ( old tests are working; new added ). 
- It doesn't cover nested `AllOf` cases ( `AllOf` that has `AllOf` ).
- It merges only the `Properties`, `Required`, and `Min*/Max` fields for now.

I propose extending this logic case by case since covering every possible case ( or at least 90% of them ) is a time-consuming and complex task.


@danielgtaylor, please let me know what you think about this change.

Thank you.
