### PR TITLE
fix: make order of SSE events stable in openapi

### DIFF
--- a/sse/sse.go
+++ b/sse/sse.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"reflect"
 	"runtime/debug"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -104,6 +106,10 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 
 		dataSchemas = append(dataSchemas, s)
 	}
+
+	slices.SortFunc(dataSchemas, func(b, c *huma.Schema) int {
+		return strings.Compare(b.Title, c.Title)
+	})
 
 	schema := &huma.Schema{
 		Title:       "Server Sent Events",

--- a/sse/sse_test.go
+++ b/sse/sse_test.go
@@ -131,39 +131,39 @@ data: {"error": "encode error: json: unsupported type: chan int"}
 			api.Adapter().ServeHTTP(w, req)
 		},
 	},
-	// {
-	// 	Title: "sse stable event order in openapi",
-	// 	TestFunc: func(t *testing.T) {
-	// 		_, api := humatest.New(t)
-	// 		sse.Register(api, huma.Operation{
-	// 			OperationID: "sse",
-	// 			Method:      http.MethodGet,
-	// 			Path:        "/sse",
-	// 		}, map[string]any{
-	// 			"message":    &DefaultMessage{},
-	// 			"userCreate": UserCreatedEvent{},
-	// 			"zMessage":   ZMessage{},
-	// 			"userDelete": UserDeletedEvent{},
-	// 			"aMessage":   AMessage{},
-	// 		}, func(ctx context.Context, input *struct{}, send sse.Sender) {
-	// 			send.Data(DefaultMessage{Message: "Hello, world!"})
-	// 		})
+	{
+		Title: "sse stable event order in openapi",
+		TestFunc: func(t *testing.T) {
+			_, api := humatest.New(t)
+			sse.Register(api, huma.Operation{
+				OperationID: "sse",
+				Method:      http.MethodGet,
+				Path:        "/sse",
+			}, map[string]any{
+				"message":    &DefaultMessage{},
+				"userCreate": UserCreatedEvent{},
+				"zMessage":   ZMessage{},
+				"userDelete": UserDeletedEvent{},
+				"aMessage":   AMessage{},
+			}, func(ctx context.Context, input *struct{}, send sse.Sender) {
+				send.Data(DefaultMessage{Message: "Hello, world!"})
+			})
 
-	// 		o := api.OpenAPI()
-	// 		events := o.Paths["/sse"].Get.Responses["200"].Content["text/event-stream"].Schema.Items.Extensions["oneOf"].([]*huma.Schema)
-	// 		titles := make([]string, len(events))
-	// 		for i, event := range events {
-	// 			titles[i] = event.Title
-	// 		}
-	// 		assert.Equal(t, []string{
-	// 			"Event aMessage",
-	// 			"Event message",
-	// 			"Event userCreate",
-	// 			"Event userDelete",
-	// 			"Event zMessage",
-	// 		}, titles)
-	// 	},
-	// },
+			o := api.OpenAPI()
+			events := o.Paths["/sse"].Get.Responses["200"].Content["text/event-stream"].Schema.Items.Extensions["oneOf"].([]*huma.Schema)
+			titles := make([]string, len(events))
+			for i, event := range events {
+				titles[i] = event.Title
+			}
+			assert.Equal(t, []string{
+				"Event aMessage",
+				"Event message",
+				"Event userCreate",
+				"Event userDelete",
+				"Event zMessage",
+			}, titles)
+		},
+	},
 }
 
 func TestSSE(t *testing.T) {

--- a/sse/sse_test.go
+++ b/sse/sse_test.go
@@ -7,12 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/humatest"
 	"github.com/danielgtaylor/huma/v2/sse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type DefaultMessage struct {
@@ -26,6 +25,9 @@ type UserEvent struct {
 
 type UserCreatedEvent UserEvent
 type UserDeletedEvent UserEvent
+
+type AMessage UserEvent
+type ZMessage UserEvent
 
 type DummyWriter struct {
 	writeErr    error
@@ -55,42 +57,49 @@ func (w *WrappedDeadliner) SetWriteDeadline(t time.Time) error {
 	return w.deadlineErr
 }
 
-func TestSSE(t *testing.T) {
-	_, api := humatest.New(t)
+type sseTest struct {
+	Title    string
+	TestFunc func(t *testing.T)
+}
 
-	sse.Register(api, huma.Operation{
-		OperationID: "sse",
-		Method:      http.MethodGet,
-		Path:        "/sse",
-	}, map[string]any{
-		"message":    &DefaultMessage{},
-		"userCreate": UserCreatedEvent{},
-		"userDelete": UserDeletedEvent{},
-	}, func(ctx context.Context, input *struct{}, send sse.Sender) {
-		send.Data(DefaultMessage{Message: "Hello, world!"})
+var sseTests = []sseTest{
+	{
+		Title: "sse",
+		TestFunc: func(t *testing.T) {
+			_, api := humatest.New(t)
+			sse.Register(api, huma.Operation{
+				OperationID: "sse",
+				Method:      http.MethodGet,
+				Path:        "/sse",
+			}, map[string]any{
+				"message":    &DefaultMessage{},
+				"userCreate": UserCreatedEvent{},
+				"userDelete": UserDeletedEvent{},
+			}, func(ctx context.Context, input *struct{}, send sse.Sender) {
+				send.Data(DefaultMessage{Message: "Hello, world!"})
 
-		send(sse.Message{
-			ID:    5,
-			Retry: 1000,
-			Data:  UserCreatedEvent{UserID: 1, Username: "foo"},
-		})
+				send(sse.Message{
+					ID:    5,
+					Retry: 1000,
+					Data:  UserCreatedEvent{UserID: 1, Username: "foo"},
+				})
 
-		send.Data(UserDeletedEvent{UserID: 2, Username: "bar"})
+				send.Data(UserDeletedEvent{UserID: 2, Username: "bar"})
 
-		// Unknown event type gets sent as the default. Still uses JSON encoding!
-		send.Data("unknown event")
+				// Unknown event type gets sent as the default. Still uses JSON encoding!
+				send.Data("unknown event")
 
-		// Encode failure should return an error.
-		require.Error(t, send(sse.Message{
-			Data: make(chan int),
-		}))
-	})
+				// Encode failure should return an error.
+				require.Error(t, send(sse.Message{
+					Data: make(chan int),
+				}))
+			})
 
-	resp := api.Get("/sse")
+			resp := api.Get("/sse")
 
-	assert.Equal(t, http.StatusOK, resp.Code)
-	assert.Equal(t, "text/event-stream", resp.Header().Get("Content-Type"))
-	assert.Equal(t, `data: {"message":"Hello, world!"}
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, "text/event-stream", resp.Header().Get("Content-Type"))
+			assert.Equal(t, `data: {"message":"Hello, world!"}
 
 id: 5
 retry: 1000
@@ -106,18 +115,61 @@ data: {"error": "encode error: json: unsupported type: chan int"}
 
 `, resp.Body.String())
 
-	// Test write error doesn't panic
-	w := &DummyWriter{writeErr: errors.New("whoops")}
-	req, _ := http.NewRequest(http.MethodGet, "/sse", nil)
-	api.Adapter().ServeHTTP(w, req)
+			// Test write error doesn't panic
+			w := &DummyWriter{writeErr: errors.New("whoops")}
+			req, _ := http.NewRequest(http.MethodGet, "/sse", nil)
+			api.Adapter().ServeHTTP(w, req)
 
-	// Test inability to flush doesn't panic
-	w = &DummyWriter{}
-	req, _ = http.NewRequest(http.MethodGet, "/sse", nil)
-	api.Adapter().ServeHTTP(w, req)
+			// Test inability to flush doesn't panic
+			w = &DummyWriter{}
+			req, _ = http.NewRequest(http.MethodGet, "/sse", nil)
+			api.Adapter().ServeHTTP(w, req)
 
-	// Test inability to set write deadline due to error doesn't panic
-	w = &DummyWriter{deadlineErr: errors.New("whoops")}
-	req, _ = http.NewRequest(http.MethodGet, "/sse", nil)
-	api.Adapter().ServeHTTP(w, req)
+			// Test inability to set write deadline due to error doesn't panic
+			w = &DummyWriter{deadlineErr: errors.New("whoops")}
+			req, _ = http.NewRequest(http.MethodGet, "/sse", nil)
+			api.Adapter().ServeHTTP(w, req)
+		},
+	},
+	// {
+	// 	Title: "sse stable event order in openapi",
+	// 	TestFunc: func(t *testing.T) {
+	// 		_, api := humatest.New(t)
+	// 		sse.Register(api, huma.Operation{
+	// 			OperationID: "sse",
+	// 			Method:      http.MethodGet,
+	// 			Path:        "/sse",
+	// 		}, map[string]any{
+	// 			"message":    &DefaultMessage{},
+	// 			"userCreate": UserCreatedEvent{},
+	// 			"zMessage":   ZMessage{},
+	// 			"userDelete": UserDeletedEvent{},
+	// 			"aMessage":   AMessage{},
+	// 		}, func(ctx context.Context, input *struct{}, send sse.Sender) {
+	// 			send.Data(DefaultMessage{Message: "Hello, world!"})
+	// 		})
+
+	// 		o := api.OpenAPI()
+	// 		events := o.Paths["/sse"].Get.Responses["200"].Content["text/event-stream"].Schema.Items.Extensions["oneOf"].([]*huma.Schema)
+	// 		titles := make([]string, len(events))
+	// 		for i, event := range events {
+	// 			titles[i] = event.Title
+	// 		}
+	// 		assert.Equal(t, []string{
+	// 			"Event aMessage",
+	// 			"Event message",
+	// 			"Event userCreate",
+	// 			"Event userDelete",
+	// 			"Event zMessage",
+	// 		}, titles)
+	// 	},
+	// },
+}
+
+func TestSSE(t *testing.T) {
+	for _, test := range sseTests {
+		t.Run(test.Title, func(t *testing.T) {
+			test.TestFunc(t)
+		})
+	}
 }


### PR DESCRIPTION
fixes #797