### PR TITLE
Allow empty path in group operations

### DIFF
--- a/group_test.go
+++ b/group_test.go
@@ -26,6 +26,24 @@ func TestGroupNoPrefix(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, resp.Result().StatusCode)
 }
 
+func TestGroupEmptyPath(t *testing.T) {
+	_, api := humatest.New(t)
+
+	grp := huma.NewGroup(api, "/users")
+
+	huma.Get(grp, "", func(ctx context.Context, input *struct{}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	assert.Nil(t, api.OpenAPI().Paths["/"])
+	assert.Nil(t, api.OpenAPI().Paths[""])
+	assert.NotNil(t, api.OpenAPI().Paths["/users"])
+
+	resp := api.Get("/users")
+	assert.Equal(t, http.StatusNoContent, resp.Result().StatusCode)
+
+}
+
 func TestGroupMultiPrefix(t *testing.T) {
 	_, api := humatest.New(t)
 

--- a/huma.go
+++ b/huma.go
@@ -622,8 +622,13 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 	oapi := api.OpenAPI()
 	registry := oapi.Components.Schemas
 
-	if op.Method == "" || op.Path == "" {
-		panic("method and path must be specified in operation")
+	if op.Method == "" {
+		panic("method must be specified in operation")
+	}
+	if op.Path == "" {
+		if grp, ok := api.(*Group); !ok || len(grp.prefixes) == 0 {
+			panic("path must be specified in operation")
+		}
 	}
 	initResponses(&op)
 


### PR DESCRIPTION
Hello! I recently found out the validation of the `path` parameter prevented the use of an empty string in the path.

In my use case I found myself in this situation:
- I wanted to create a `/resource` API Group, with CRUD for `resource`, plus some sets of endpoints for sub-resources (ie: `/resource/:id/stuff`)
- I got a `StripSlashes` middleware (required to handle legacy clients), which trims any `/` from incoming requests
- Since I have `StripSlashes`, If I want to add a  `POST /resource/` I need to actually define the route as `POST /resource`
- The above is not possible because of the strict validation done in `Register`
   https://github.com/danielgtaylor/huma/blob/6bfeebae55ed05e1e909041c5e3692dc168cd066/huma.go#L625-L626

With this PR I relaxed the validation of the `Path` parameter, allowing the empty string in the case of operations defined for a Group with at least a prefix defined

