### PR TITLE
feat: Tag instructed recursive params finding

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -439,7 +439,7 @@ func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T]
 					result.Paths = append(result.Paths, findResultPath[T]{fi, v})
 				}
 			}
-			if f.Anonymous || recurseFields || deref(f.Type).Kind() != reflect.Struct {
+			if f.Anonymous || recurseFields || deref(f.Type).Kind() != reflect.Struct || f.Tag.Get("recursive") == "true" {
 				// Always process embedded structs and named fields which are not
 				// structs. If `recurseFields` is true then we also process named
 				// struct fields recursively.


### PR DESCRIPTION
Closes #811 

Allow input struct to have fields tagged with `recursive:"true"` to enable a deeper params finding.

With this change, the input struct composing can now incorperate generic type parameters which are normally unable to get embedded. 
And with limited knowledge, I would conservatively say this change does not break existing behaviours.