### PR TITLE
fix: override group modifier

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -2039,8 +2039,14 @@ func convenience[I, O any](api API, method, path string, handler func(context.Co
 		Path:        path,
 		Metadata:    map[string]any{},
 	}
-	for _, oh := range operationHandlers {
-		oh(&operation)
+	if grp, ok := api.(*Group); ok {
+		for _, oh := range operationHandlers {
+			grp.UseSimpleModifier(oh)
+		}
+	} else {
+		for _, oh := range operationHandlers {
+			oh(&operation)
+		}
 	}
 	// If not modified, hint that these were auto-generated!
 	if operation.OperationID == opID {


### PR DESCRIPTION
```go
	grp := huma.NewGroup(api, "/users")
	grp.UseSimpleModifier(func(o *huma.Operation) {
		o.Summary = "User Summary"
	})

	// Register the router here
	huma.Get(grp, "/current", h.GetCurrent, func(o *huma.Operation) {
		o.Summary = "Current User"
	})

```