### PR TITLE
fix: export of embed properties when struct type is not exported

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -636,12 +636,13 @@ func getFields(typ reflect.Type, visited map[reflect.Type]struct{}) []fieldInfo 
 
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
-		if !f.IsExported() {
-			continue
-		}
 
 		if f.Anonymous {
 			embedded = append(embedded, f)
+			continue
+		}
+		// embeds can have exported fields
+		if !f.IsExported() {
 			continue
 		}
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -42,6 +42,10 @@ type EmbeddedChild struct {
 	Value string `json:"value" doc:"old doc"`
 }
 
+type embedWithExported struct {
+	Value string `json:"value" doc:"embed doc"`
+}
+
 type Embedded struct {
 	EmbeddedChild
 	Value string `json:"value" doc:"new doc"`
@@ -695,6 +699,28 @@ func TestSchema(t *testing.T) {
 			}`,
 		},
 		{
+			name: "field-embed-unexported",
+			input: struct {
+				// the embed is an unexported type, but it can contribute exported properties that will be in the JSON
+				*embedWithExported
+				Value2 string `json:"value2"`
+			}{},
+			expected: `{
+				"type": "object",
+				"additionalProperties": false,
+				"required": ["value2", "value"],
+				"properties": {
+					"value": {
+						"type": "string",
+						"description": "embed doc"
+					},
+					"value2": {
+						"type": "string"
+					}
+				}
+			}`,
+		},
+		{
 			name: "field-embed-override",
 			input: struct {
 				Embedded
@@ -1301,6 +1327,21 @@ func (o OmittableNullable[T]) Schema(r huma.Registry) *huma.Schema {
 	s := r.Schema(reflect.TypeOf(o.Value), true, "")
 	s.Nullable = true
 	return s
+}
+
+func TestUnexportedEmbed(t *testing.T) {
+	// shows value is serialized in the JSON
+	j, err := json.Marshal(struct {
+		*embedWithExported
+		Value2 string `json:"value2"`
+	}{
+		embedWithExported: &embedWithExported{
+			Value: "foo",
+		},
+		Value2: "bar",
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"value":"foo","value2":"bar"}`, string(j))
 }
 
 func TestCustomUnmarshalType(t *testing.T) {


### PR DESCRIPTION
TestUnexportedEmbed demonstrates how the JSON is serialized. This fixes the generated spec so those fields are documented.

Fixes #444