### PR TITLE
Fix adapter.Unwrap() not working after huma.WithContext() 

### DIFF
--- a/adapters/adapters_test.go
+++ b/adapters/adapters_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/uptrace/bunrouter"
 )
 
+type key struct{}
+
 // Test the various input types (path, query, header, body).
 type TestInput struct {
 	Group   string `path:"group"`
@@ -90,7 +92,7 @@ func TestAdapters(t *testing.T) {
 		return huma.DefaultConfig("Test", "1.0.0")
 	}
 
-	wrap := func(h huma.API, isFiber bool) huma.API {
+	wrap := func(h huma.API, isFiber bool, unwrapper func(ctx huma.Context)) huma.API {
 		h.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
 			assert.Nil(t, ctx.TLS())
 			v := ctx.Version()
@@ -101,6 +103,14 @@ func TestAdapters(t *testing.T) {
 			} else {
 				assert.Equal(t, "http", v.Proto)
 			}
+
+			// Make sure huma.WithValue works correctly
+			ctx = huma.WithContext(ctx, context.WithValue(ctx.Context(), key{}, "value"))
+
+			next(ctx)
+		}, func(ctx huma.Context, next func(huma.Context)) {
+			// Make sure the Unwrap func does not panic even when the context is wrapped by WithContext
+			assert.NotPanics(t, func() { unwrapper(ctx) })
 			next(ctx)
 		})
 		return h
@@ -110,14 +120,32 @@ func TestAdapters(t *testing.T) {
 		name string
 		new  func() huma.API
 	}{
-		{"chi", func() huma.API { return wrap(humachi.New(chi.NewMux(), config()), false) }},
-		{"echo", func() huma.API { return wrap(humaecho.New(echo.New(), config()), false) }},
-		{"fiber", func() huma.API { return wrap(humafiber.New(fiber.New(), config()), true) }},
-		{"gin", func() huma.API { return wrap(humagin.New(gin.New(), config()), false) }},
-		{"httprouter", func() huma.API { return wrap(humahttprouter.New(httprouter.New(), config()), false) }},
-		{"mux", func() huma.API { return wrap(humamux.New(mux.NewRouter(), config()), false) }},
-		{"bunrouter", func() huma.API { return wrap(humabunrouter.New(bunrouter.New(), config()), false) }},
-		{"bunroutercompat", func() huma.API { return wrap(humabunrouter.NewCompat(bunrouter.New().Compat(), config()), false) }},
+		{"chi", func() huma.API {
+			return wrap(humachi.New(chi.NewMux(), config()), false, func(ctx huma.Context) { humachi.Unwrap(ctx) })
+		}},
+		{"echo", func() huma.API {
+			return wrap(humaecho.New(echo.New(), config()), false, func(ctx huma.Context) { humaecho.Unwrap(ctx) })
+		}},
+		{"fiber", func() huma.API {
+			return wrap(humafiber.New(fiber.New(), config()), true, func(ctx huma.Context) { humafiber.Unwrap(ctx) })
+		}},
+		{"gin", func() huma.API {
+			return wrap(humagin.New(gin.New(), config()), false, func(ctx huma.Context) { humagin.Unwrap(ctx) })
+		}},
+		{"httprouter", func() huma.API {
+			return wrap(humahttprouter.New(httprouter.New(), config()), false, func(ctx huma.Context) { humahttprouter.Unwrap(ctx) })
+		}},
+		{"mux", func() huma.API {
+			return wrap(humamux.New(mux.NewRouter(), config()), false, func(ctx huma.Context) { humamux.Unwrap(ctx) })
+		}},
+		{"bunrouter", func() huma.API {
+			return wrap(humabunrouter.New(bunrouter.New(), config()), false, func(ctx huma.Context) { humabunrouter.Unwrap(ctx) })
+		}},
+		{"bunroutercompat", func() huma.API {
+			return wrap(humabunrouter.NewCompat(bunrouter.New().Compat(), config()), false, func(ctx huma.Context) {
+				// FIXME: humabunrouter.Unwrap(ctx) doesn't work with compat mode
+			})
+		}},
 	} {
 		t.Run(adapter.name, func(t *testing.T) {
 			testAdapter(t, adapter.new())

--- a/adapters/adapters_test.go
+++ b/adapters/adapters_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/danielgtaylor/huma/v2/adapters/humaecho"
 	"github.com/danielgtaylor/huma/v2/adapters/humafiber"
 	"github.com/danielgtaylor/huma/v2/adapters/humagin"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/danielgtaylor/huma/v2/adapters/humahttprouter"
 	"github.com/danielgtaylor/huma/v2/adapters/humamux"
 	"github.com/danielgtaylor/huma/v2/humatest"
@@ -96,6 +97,7 @@ func TestAdapters(t *testing.T) {
 		h.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
 			assert.Nil(t, ctx.TLS())
 			v := ctx.Version()
+
 			if !isFiber {
 				assert.Equal(t, "HTTP/1.1", v.Proto)
 				assert.Equal(t, 1, v.ProtoMajor)
@@ -128,6 +130,9 @@ func TestAdapters(t *testing.T) {
 		}},
 		{"fiber", func() huma.API {
 			return wrap(humafiber.New(fiber.New(), config()), true, func(ctx huma.Context) { humafiber.Unwrap(ctx) })
+		}},
+		{"go", func() huma.API {
+			return wrap(humago.New(http.NewServeMux(), config()), false, func(ctx huma.Context) { humago.Unwrap(ctx) })
 		}},
 		{"gin", func() huma.API {
 			return wrap(humagin.New(gin.New(), config()), false, func(ctx huma.Context) { humagin.Unwrap(ctx) })

--- a/adapters/humabunrouter/humabunrouter.go
+++ b/adapters/humabunrouter/humabunrouter.go
@@ -23,7 +23,8 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (bunrouter.Request, http.ResponseWriter) {
-	if c, ok := ctx.(*bunContext); ok {
+	originalCtx := huma.OriginalContext(ctx)
+	if c, ok := originalCtx.(*bunContext); ok {
 		return c.Unwrap()
 	}
 	panic("not a humabunrouter context")

--- a/adapters/humabunrouter/humabunrouter.go
+++ b/adapters/humabunrouter/humabunrouter.go
@@ -23,8 +23,14 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (bunrouter.Request, http.ResponseWriter) {
-	originalCtx := huma.OriginalContext(ctx)
-	if c, ok := originalCtx.(*bunContext); ok {
+	for {
+		if c, ok := ctx.(interface{ Unwrap() huma.Context }); ok {
+			ctx = c.Unwrap()
+			continue
+		}
+		break
+	}
+	if c, ok := ctx.(*bunContext); ok {
 		return c.Unwrap()
 	}
 	panic("not a humabunrouter context")

--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -21,7 +21,7 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
-	if c, ok := ctx.(*chiContext); ok {
+	if c, ok := huma.OriginalContext(ctx).(*chiContext); ok {
 		return c.Unwrap()
 	}
 	panic("not a humachi context")

--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -21,7 +21,14 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
-	if c, ok := huma.OriginalContext(ctx).(*chiContext); ok {
+	for {
+		if c, ok := ctx.(interface{ Unwrap() huma.Context }); ok {
+			ctx = c.Unwrap()
+			continue
+		}
+		break
+	}
+	if c, ok := ctx.(*chiContext); ok {
 		return c.Unwrap()
 	}
 	panic("not a humachi context")

--- a/adapters/humaecho/humaecho.go
+++ b/adapters/humaecho/humaecho.go
@@ -21,7 +21,14 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying Echo context from a Huma context. If passed a
 // context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) echo.Context {
-	if c, ok := huma.OriginalContext(ctx).(*echoCtx); ok {
+	for {
+		if c, ok := ctx.(interface{ Unwrap() huma.Context }); ok {
+			ctx = c.Unwrap()
+			continue
+		}
+		break
+	}
+	if c, ok := ctx.(*echoCtx); ok {
 		return c.Unwrap()
 	}
 	panic("not a humaecho context")

--- a/adapters/humaecho/humaecho.go
+++ b/adapters/humaecho/humaecho.go
@@ -21,7 +21,7 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying Echo context from a Huma context. If passed a
 // context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) echo.Context {
-	if c, ok := ctx.(*echoCtx); ok {
+	if c, ok := huma.OriginalContext(ctx).(*echoCtx); ok {
 		return c.Unwrap()
 	}
 	panic("not a humaecho context")

--- a/adapters/humafiber/humafiber.go
+++ b/adapters/humafiber/humafiber.go
@@ -21,7 +21,14 @@ import (
 // memory-safety: https://docs.gofiber.io/#zero-allocation. Do not keep
 // references to the underlying context or its values!
 func Unwrap(ctx huma.Context) *fiber.Ctx {
-	if c, ok := huma.OriginalContext(ctx).(*fiberWrapper); ok {
+	for {
+		if c, ok := ctx.(interface{ Unwrap() huma.Context }); ok {
+			ctx = c.Unwrap()
+			continue
+		}
+		break
+	}
+	if c, ok := ctx.(*fiberWrapper); ok {
 		return c.Unwrap()
 	}
 	panic("not a humafiber context")

--- a/adapters/humafiber/humafiber.go
+++ b/adapters/humafiber/humafiber.go
@@ -21,7 +21,7 @@ import (
 // memory-safety: https://docs.gofiber.io/#zero-allocation. Do not keep
 // references to the underlying context or its values!
 func Unwrap(ctx huma.Context) *fiber.Ctx {
-	if c, ok := ctx.(*fiberWrapper); ok {
+	if c, ok := huma.OriginalContext(ctx).(*fiberWrapper); ok {
 		return c.Unwrap()
 	}
 	panic("not a humafiber context")

--- a/adapters/humaflow/humaflow.go
+++ b/adapters/humaflow/humaflow.go
@@ -22,7 +22,7 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
-	if c, ok := ctx.(*goContext); ok {
+	if c, ok := huma.OriginalContext(ctx).(*goContext); ok {
 		return c.Unwrap()
 	}
 	panic("not a humaflow context")

--- a/adapters/humaflow/humaflow.go
+++ b/adapters/humaflow/humaflow.go
@@ -22,7 +22,14 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
-	if c, ok := huma.OriginalContext(ctx).(*goContext); ok {
+	for {
+		if c, ok := ctx.(interface{ Unwrap() huma.Context }); ok {
+			ctx = c.Unwrap()
+			continue
+		}
+		break
+	}
+	if c, ok := ctx.(*goContext); ok {
 		return c.Unwrap()
 	}
 	panic("not a humaflow context")

--- a/adapters/humagin/humagin.go
+++ b/adapters/humagin/humagin.go
@@ -21,7 +21,14 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying Gin context from a Huma context. If passed a
 // context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) *gin.Context {
-	if c, ok := huma.OriginalContext(ctx).(*ginCtx); ok {
+	for {
+		if c, ok := ctx.(interface{ Unwrap() huma.Context }); ok {
+			ctx = c.Unwrap()
+			continue
+		}
+		break
+	}
+	if c, ok := ctx.(*ginCtx); ok {
 		return c.Unwrap()
 	}
 	panic("not a humagin context")

--- a/adapters/humagin/humagin.go
+++ b/adapters/humagin/humagin.go
@@ -21,7 +21,7 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying Gin context from a Huma context. If passed a
 // context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) *gin.Context {
-	if c, ok := ctx.(*ginCtx); ok {
+	if c, ok := huma.OriginalContext(ctx).(*ginCtx); ok {
 		return c.Unwrap()
 	}
 	panic("not a humagin context")

--- a/adapters/humago/humago.go
+++ b/adapters/humago/humago.go
@@ -21,7 +21,7 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
-	if c, ok := ctx.(*goContext); ok {
+	if c, ok := huma.OriginalContext(ctx).(*goContext); ok {
 		return c.Unwrap()
 	}
 	panic("not a humago context")

--- a/adapters/humago/humago.go
+++ b/adapters/humago/humago.go
@@ -21,7 +21,14 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
-	if c, ok := huma.OriginalContext(ctx).(*goContext); ok {
+	for {
+		if c, ok := ctx.(interface{ Unwrap() huma.Context }); ok {
+			ctx = c.Unwrap()
+			continue
+		}
+		break
+	}
+	if c, ok := ctx.(*goContext); ok {
 		return c.Unwrap()
 	}
 	panic("not a humago context")

--- a/adapters/humahttprouter/humahttprouter.go
+++ b/adapters/humahttprouter/humahttprouter.go
@@ -22,7 +22,7 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter, httprouter.Params) {
-	if c, ok := ctx.(*httprouterContext); ok {
+	if c, ok := huma.OriginalContext(ctx).(*httprouterContext); ok {
 		return c.Unwrap()
 	}
 	panic("not an httprouter context")

--- a/adapters/humahttprouter/humahttprouter.go
+++ b/adapters/humahttprouter/humahttprouter.go
@@ -22,7 +22,14 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter, httprouter.Params) {
-	if c, ok := huma.OriginalContext(ctx).(*httprouterContext); ok {
+	for {
+		if c, ok := ctx.(interface{ Unwrap() huma.Context }); ok {
+			ctx = c.Unwrap()
+			continue
+		}
+		break
+	}
+	if c, ok := ctx.(*httprouterContext); ok {
 		return c.Unwrap()
 	}
 	panic("not an httprouter context")

--- a/adapters/humamux/humamux.go
+++ b/adapters/humamux/humamux.go
@@ -21,7 +21,14 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
-	if c, ok := huma.OriginalContext(ctx).(*gmuxContext); ok {
+	for {
+		if c, ok := ctx.(interface{ Unwrap() huma.Context }); ok {
+			ctx = c.Unwrap()
+			continue
+		}
+		break
+	}
+	if c, ok := ctx.(*gmuxContext); ok {
 		return c.Unwrap()
 	}
 	panic("not a humamux context")

--- a/adapters/humamux/humamux.go
+++ b/adapters/humamux/humamux.go
@@ -21,7 +21,7 @@ var MultipartMaxMemory int64 = 8 * 1024
 // Unwrap extracts the underlying HTTP request and response writer from a Huma
 // context. If passed a context from a different adapter it will panic.
 func Unwrap(ctx huma.Context) (*http.Request, http.ResponseWriter) {
-	if c, ok := ctx.(*gmuxContext); ok {
+	if c, ok := huma.OriginalContext(ctx).(*gmuxContext); ok {
 		return c.Unwrap()
 	}
 	panic("not a humamux context")

--- a/api.go
+++ b/api.go
@@ -143,9 +143,9 @@ func (c subContext) Context() context.Context {
 	return c.override
 }
 
-func (c subContext) HumaContext() humaContext {
+func (c subContext) humaCtx() humaContext {
 	if sub, ok := c.humaContext.(subContext); ok {
-		return sub.HumaContext()
+		return sub.humaCtx()
 	}
 	return c.humaContext
 }
@@ -168,7 +168,7 @@ func WithValue(ctx Context, key, value any) Context {
 func OriginalContext(ctx Context) Context {
 	// If the context is a sub-context, return the original context.
 	if sub, ok := ctx.(subContext); ok {
-		return sub.HumaContext()
+		return sub.humaCtx()
 	}
 	return ctx
 }

--- a/api.go
+++ b/api.go
@@ -143,10 +143,9 @@ func (c subContext) Context() context.Context {
 	return c.override
 }
 
-func (c subContext) humaCtx() humaContext {
-	if sub, ok := c.humaContext.(subContext); ok {
-		return sub.humaCtx()
-	}
+// Unwrap returns the underlying Huma context, which enables you to access
+// the original adapter-specific request context.
+func (c subContext) Unwrap() Context {
 	return c.humaContext
 }
 
@@ -162,15 +161,6 @@ func WithContext(ctx Context, override context.Context) Context {
 // set request-scoped values.
 func WithValue(ctx Context, key, value any) Context {
 	return WithContext(ctx, context.WithValue(ctx.Context(), key, value))
-}
-
-// OriginalContext returns the original `huma.Context` if the given context is a sub-context result of WithValue, otherwise it returns the context itself.
-func OriginalContext(ctx Context) Context {
-	// If the context is a sub-context, return the original context.
-	if sub, ok := ctx.(subContext); ok {
-		return sub.humaCtx()
-	}
-	return ctx
 }
 
 // Transformer is a function that can modify a response body before it is

--- a/api.go
+++ b/api.go
@@ -143,6 +143,13 @@ func (c subContext) Context() context.Context {
 	return c.override
 }
 
+func (c subContext) HumaContext() humaContext {
+	if sub, ok := c.humaContext.(subContext); ok {
+		return sub.HumaContext()
+	}
+	return c.humaContext
+}
+
 // WithContext returns a new `huma.Context` with the underlying `context.Context`
 // replaced with the given one. This is useful for middleware that needs to
 // modify the request context.
@@ -155,6 +162,15 @@ func WithContext(ctx Context, override context.Context) Context {
 // set request-scoped values.
 func WithValue(ctx Context, key, value any) Context {
 	return WithContext(ctx, context.WithValue(ctx.Context(), key, value))
+}
+
+// OriginalContext returns the original `huma.Context` if the given context is a sub-context result of WithValue, otherwise it returns the context itself.
+func OriginalContext(ctx Context) Context {
+	// If the context is a sub-context, return the original context.
+	if sub, ok := ctx.(subContext); ok {
+		return sub.HumaContext()
+	}
+	return ctx
 }
 
 // Transformer is a function that can modify a response body before it is


### PR DESCRIPTION
Closes https://github.com/danielgtaylor/huma/issues/790
Closes https://github.com/danielgtaylor/huma/issues/784

Since I was also affected by this issue I decided to open a PR

I used the (very naive) strategy of exposing a func to extract the original `huma.Context` from a `subContext`, and made use of it in every `adapter.Unwrap(ctx)` func.

I updated the adapters test to make sure all adapters don't panic while adding a simple context value (and added the missing `humago` test case)

While updating the test I also discovered that  `humabunrouter.Unwrap(ctx)` simply doesn't work with Bun in compat mode. I didn't fix it since it's not really related to this change, and I wasn't sure on the preferred way (duplicated func? new package? return *http.Request for both context implementations?)
