### PR TITLE
feat: add humagin.NewContext

### DIFF
--- a/adapters/humagin/humagin.go
+++ b/adapters/humagin/humagin.go
@@ -130,6 +130,11 @@ func (c *ginCtx) Version() huma.ProtoVersion {
 	}
 }
 
+// NewContext creates a new Huma context from an HTTP request and response.
+func NewContext(op *huma.Operation, c *gin.Context) huma.Context {
+	return &ginCtx{op: op, orig: c}
+}
+
 // Router is an interface that wraps the Gin router's Handle method.
 type Router interface {
 	Handle(string, string, ...gin.HandlerFunc) gin.IRoutes


### PR DESCRIPTION
Ran into difficulties testing a middleware that used `humagin.Unwrap` Since `ginCtx` is not exported, it's not easy to create a huma.Context compatible with humagin.Unwrap.

Adding `NewContext` like some of the other adapters seems logical