### PR TITLE
Revert "fix: export of embed properties when struct type is not exported"

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -636,13 +636,12 @@ func getFields(typ reflect.Type, visited map[reflect.Type]struct{}) []fieldInfo 
 
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
+		if !f.IsExported() {
+			continue
+		}
 
 		if f.Anonymous {
 			embedded = append(embedded, f)
-			continue
-		}
-		// embeds can have exported fields
-		if !f.IsExported() {
 			continue
 		}
 


### PR DESCRIPTION
Reverts danielgtaylor/huma#822. With some additional testing this appears to not be working correctly. The stdlib JSON serializer is ignoring these private embedded fields. We should revisit this and see if there is a solution that can work.