### PR TITLE
feat: #843 Allow 406 Not Acceptable with NoFormatFallback config

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -499,8 +499,6 @@ func writeResponse(api API, ctx Context, status int, ct string, body any) error 
 		if ctf, ok := body.(ContentTypeFilter); ok {
 			ct = ctf.ContentType(ct)
 		}
-
-		ctx.SetHeader("Content-Type", ct)
 	}
 
 	if err := transformAndWrite(api, ctx, status, ct, body); err != nil {
@@ -544,6 +542,9 @@ func transformAndWrite(api API, ctx Context, status int, ct string, body any) er
 			return fmt.Errorf("error marshaling response for %s %s %d: %w", ctx.Operation().Method, ctx.Operation().Path, status, merr)
 		}
 	}
+
+	ctx.SetHeader("Content-Type", ct)
+
 	return nil
 }
 


### PR DESCRIPTION
PR for #843 

- Added `NoFormatFallback` field to `Config` to control format fallback.
- Added positive and negative test for unknown/invalid Accept header (had to modify test harness for `Config`).
- Fixed a bug(?) with how Content-Type was _not_ set for 406 responses by moving setting of the Content-Type into the `transformWrite()`.