### PR TITLE
Added uuid to have a default `format: uuid`

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2/validation"
+	"github.com/google/uuid"
 )
 
 // ErrSchemaInvalid is sent when there is a problem building the schema.
@@ -45,6 +46,7 @@ var (
 	ipAddrType     = reflect.TypeOf(netip.Addr{})
 	urlType        = reflect.TypeOf(url.URL{})
 	rawMessageType = reflect.TypeOf(json.RawMessage{})
+	uuidType       = reflect.TypeOf(uuid.UUID{})
 )
 
 func deref(t reflect.Type) reflect.Type {
@@ -713,7 +715,7 @@ func schemaFromType(r Registry, t reflect.Type) *Schema {
 		return custom
 	}
 
-	// Handle special cases for known stdlib types.
+	// Handle special cases for known types.
 	switch t {
 	case timeType:
 		return &Schema{Type: TypeString, Nullable: isPointer, Format: "date-time"}
@@ -723,6 +725,8 @@ func schemaFromType(r Registry, t reflect.Type) *Schema {
 		return &Schema{Type: TypeString, Nullable: isPointer, Format: "ipv4"}
 	case ipAddrType:
 		return &Schema{Type: TypeString, Nullable: isPointer, Format: "ipv4"}
+	case uuidType:
+		return &Schema{Type: TypeString, Nullable: isPointer, Format: "uuid"}
 	case rawMessageType:
 		return &Schema{}
 	}

--- a/schema_test.go
+++ b/schema_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -191,6 +192,11 @@ func TestSchema(t *testing.T) {
 			name:     "ipAddr",
 			input:    netip.AddrFrom4([4]byte{127, 0, 0, 1}),
 			expected: `{"type": "string", "format": "ipv4"}`,
+		},
+		{
+			name:     "uuid",
+			input:    uuid.UUID{},
+			expected: `{"type": "string", "format": "uuid"}`,
 		},
 		{
 			name:     "json.RawMessage",


### PR DESCRIPTION
Addresses https://github.com/danielgtaylor/huma/issues/868

Since `uuid` is a standard format, I added `format: uuid` so that you do not need to define a schema for this common type. 

Let me know if other [built-in string types](https://github.com/danielgtaylor/huma/blob/badf024b0795f089518475622985ca899c98e41e/docs/docs/features/request-validation.md?plain=1#L128-L146) need default formats