### PR TITLE
Added exhaustive error code wrappers

### DIFF
--- a/error.go
+++ b/error.go
@@ -286,6 +286,11 @@ func Error401Unauthorized(msg string, errs ...error) StatusError {
 	return NewError(http.StatusUnauthorized, msg, errs...)
 }
 
+// Error402PaymentRequired returns a 402.
+func Error402PaymentRequired(msg string, errs ...error) StatusError {
+	return NewError(http.StatusPaymentRequired, msg, errs...)
+}
+
 // Error403Forbidden returns a 403.
 func Error403Forbidden(msg string, errs ...error) StatusError {
 	return NewError(http.StatusForbidden, msg, errs...)
@@ -306,6 +311,16 @@ func Error406NotAcceptable(msg string, errs ...error) StatusError {
 	return NewError(http.StatusNotAcceptable, msg, errs...)
 }
 
+// Error407ProxyAuthRequired returns a 407.
+func Error407ProxyAuthRequired(msg string, errs ...error) StatusError {
+	return NewError(http.StatusProxyAuthRequired, msg, errs...)
+}
+
+// Error408RequestTimeout returns a 408.
+func Error408RequestTimeout(msg string, errs ...error) StatusError {
+	return NewError(http.StatusRequestTimeout, msg, errs...)
+}
+
 // Error409Conflict returns a 409.
 func Error409Conflict(msg string, errs ...error) StatusError {
 	return NewError(http.StatusConflict, msg, errs...)
@@ -316,9 +331,24 @@ func Error410Gone(msg string, errs ...error) StatusError {
 	return NewError(http.StatusGone, msg, errs...)
 }
 
+// Error411LengthRequired returns a 411.
+func Error411LengthRequired(msg string, errs ...error) StatusError {
+	return NewError(http.StatusLengthRequired, msg, errs...)
+}
+
 // Error412PreconditionFailed returns a 412.
 func Error412PreconditionFailed(msg string, errs ...error) StatusError {
 	return NewError(http.StatusPreconditionFailed, msg, errs...)
+}
+
+// Error413RequestEntityTooLarge returns a 413.
+func Error413RequestEntityTooLarge(msg string, errs ...error) StatusError {
+	return NewError(http.StatusRequestEntityTooLarge, msg, errs...)
+}
+
+// Error414RequestURITooLong returns a 414.
+func Error414RequestURITooLong(msg string, errs ...error) StatusError {
+	return NewError(http.StatusRequestURITooLong, msg, errs...)
 }
 
 // Error415UnsupportedMediaType returns a 415.
@@ -326,14 +356,69 @@ func Error415UnsupportedMediaType(msg string, errs ...error) StatusError {
 	return NewError(http.StatusUnsupportedMediaType, msg, errs...)
 }
 
+// Error416RequestedRangeNotSatisfiable returns a 416.
+func Error416RequestedRangeNotSatisfiable(msg string, errs ...error) StatusError {
+	return NewError(http.StatusRequestedRangeNotSatisfiable, msg, errs...)
+}
+
+// Error417ExpectationFailed returns a 417.
+func Error417ExpectationFailed(msg string, errs ...error) StatusError {
+	return NewError(http.StatusExpectationFailed, msg, errs...)
+}
+
+// Error418Teapot returns a 418.
+func Error418Teapot(msg string, errs ...error) StatusError {
+	return NewError(http.StatusTeapot, msg, errs...)
+}
+
+// Error421MisdirectedRequest returns a 421.
+func Error421MisdirectedRequest(msg string, errs ...error) StatusError {
+	return NewError(http.StatusMisdirectedRequest, msg, errs...)
+}
+
 // Error422UnprocessableEntity returns a 422.
 func Error422UnprocessableEntity(msg string, errs ...error) StatusError {
 	return NewError(http.StatusUnprocessableEntity, msg, errs...)
 }
 
+// Error423Locked returns a 423.
+func Error423Locked(msg string, errs ...error) StatusError {
+	return NewError(http.StatusLocked, msg, errs...)
+}
+
+// Error424FailedDependency returns a 424.
+func Error424FailedDependency(msg string, errs ...error) StatusError {
+	return NewError(http.StatusFailedDependency, msg, errs...)
+}
+
+// Error425TooEarly returns a 425.
+func Error425TooEarly(msg string, errs ...error) StatusError {
+	return NewError(http.StatusTooEarly, msg, errs...)
+}
+
+// Error426UpgradeRequired returns a 426.
+func Error426UpgradeRequired(msg string, errs ...error) StatusError {
+	return NewError(http.StatusUpgradeRequired, msg, errs...)
+}
+
+// Error428PreconditionRequired returns a 428.
+func Error428PreconditionRequired(msg string, errs ...error) StatusError {
+	return NewError(http.StatusPreconditionRequired, msg, errs...)
+}
+
 // Error429TooManyRequests returns a 429.
 func Error429TooManyRequests(msg string, errs ...error) StatusError {
 	return NewError(http.StatusTooManyRequests, msg, errs...)
+}
+
+// Error431RequestHeaderFieldsTooLarge returns a 431.
+func Error431RequestHeaderFieldsTooLarge(msg string, errs ...error) StatusError {
+	return NewError(http.StatusRequestHeaderFieldsTooLarge, msg, errs...)
+}
+
+// Error451UnavailableForLegalReasons returns a 451.
+func Error451UnavailableForLegalReasons(msg string, errs ...error) StatusError {
+	return NewError(http.StatusUnavailableForLegalReasons, msg, errs...)
 }
 
 // Error500InternalServerError returns a 500.
@@ -359,6 +444,36 @@ func Error503ServiceUnavailable(msg string, errs ...error) StatusError {
 // Error504GatewayTimeout returns a 504.
 func Error504GatewayTimeout(msg string, errs ...error) StatusError {
 	return NewError(http.StatusGatewayTimeout, msg, errs...)
+}
+
+// Error505HTTPVersionNotSupported returns a 505.
+func Error505HTTPVersionNotSupported(msg string, errs ...error) StatusError {
+	return NewError(http.StatusHTTPVersionNotSupported, msg, errs...)
+}
+
+// Error506VariantAlsoNegotiates returns a 506.
+func Error506VariantAlsoNegotiates(msg string, errs ...error) StatusError {
+	return NewError(http.StatusVariantAlsoNegotiates, msg, errs...)
+}
+
+// Error507InsufficientStorage returns a 507.
+func Error507InsufficientStorage(msg string, errs ...error) StatusError {
+	return NewError(http.StatusInsufficientStorage, msg, errs...)
+}
+
+// Error508LoopDetected returns a 508.
+func Error508LoopDetected(msg string, errs ...error) StatusError {
+	return NewError(http.StatusLoopDetected, msg, errs...)
+}
+
+// Error510NotExtended returns a 510.
+func Error510NotExtended(msg string, errs ...error) StatusError {
+	return NewError(http.StatusNotExtended, msg, errs...)
+}
+
+// Error511NetworkAuthenticationRequired returns a 511.
+func Error511NetworkAuthenticationRequired(msg string, errs ...error) StatusError {
+	return NewError(http.StatusNetworkAuthenticationRequired, msg, errs...)
 }
 
 // ErrorFormatter is a function that formats an error message

--- a/error_test.go
+++ b/error_test.go
@@ -55,23 +55,49 @@ func TestErrorResponses(t *testing.T) {
 		constructor func(msg string, errs ...error) huma.StatusError
 		expected    int
 	}{
+		// Client errors.
 		{huma.Error400BadRequest, 400},
 		{huma.Error401Unauthorized, 401},
+		{huma.Error402PaymentRequired, 402},
 		{huma.Error403Forbidden, 403},
 		{huma.Error404NotFound, 404},
 		{huma.Error405MethodNotAllowed, 405},
 		{huma.Error406NotAcceptable, 406},
+		{huma.Error407ProxyAuthRequired, 407},
+		{huma.Error408RequestTimeout, 408},
 		{huma.Error409Conflict, 409},
 		{huma.Error410Gone, 410},
+		{huma.Error411LengthRequired, 411},
 		{huma.Error412PreconditionFailed, 412},
+		{huma.Error413RequestEntityTooLarge, 413},
+		{huma.Error414RequestURITooLong, 414},
 		{huma.Error415UnsupportedMediaType, 415},
+		{huma.Error416RequestedRangeNotSatisfiable, 416},
+		{huma.Error417ExpectationFailed, 417},
+		{huma.Error418Teapot, 418},
+		{huma.Error421MisdirectedRequest, 421},
 		{huma.Error422UnprocessableEntity, 422},
+		{huma.Error423Locked, 423},
+		{huma.Error424FailedDependency, 424},
+		{huma.Error425TooEarly, 425},
+		{huma.Error426UpgradeRequired, 426},
+		{huma.Error428PreconditionRequired, 428},
 		{huma.Error429TooManyRequests, 429},
+		{huma.Error431RequestHeaderFieldsTooLarge, 431},
+		{huma.Error451UnavailableForLegalReasons, 451},
+
+		// Server errors.
 		{huma.Error500InternalServerError, 500},
 		{huma.Error501NotImplemented, 501},
 		{huma.Error502BadGateway, 502},
 		{huma.Error503ServiceUnavailable, 503},
 		{huma.Error504GatewayTimeout, 504},
+		{huma.Error505HTTPVersionNotSupported, 505},
+		{huma.Error506VariantAlsoNegotiates, 506},
+		{huma.Error507InsufficientStorage, 507},
+		{huma.Error508LoopDetected, 508},
+		{huma.Error510NotExtended, 510},
+		{huma.Error511NetworkAuthenticationRequired, 511},
 	} {
 		err := item.constructor("test")
 		assert.Equal(t, item.expected, err.GetStatus())


### PR DESCRIPTION
I was working on validating an image payload and noticed there was no wrapper for code 413 (Request entity too large), so I added one for that and all other error codes defined in the standard library (including error 418 XD).