### PR TITLE
omit patternDescription from yaml schema

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -112,7 +112,7 @@ type Schema struct {
 	MinLength            *int                `yaml:"minLength,omitempty"`
 	MaxLength            *int                `yaml:"maxLength,omitempty"`
 	Pattern              string              `yaml:"pattern,omitempty"`
-	PatternDescription   string              `yaml:"patternDescription,omitempty"`
+	PatternDescription   string              `yaml:"-"`
 	MinItems             *int                `yaml:"minItems,omitempty"`
 	MaxItems             *int                `yaml:"maxItems,omitempty"`
 	UniqueItems          bool                `yaml:"uniqueItems,omitempty"`


### PR DESCRIPTION
[JSON Schema Validation](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-01) defines the [pattern](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-01#name-pattern) keyword, but does not define any patternDescription keyword. This keyword seems to be used only by Huma.