### PR TITLE
Update OpenAPI media types to newer standard format

### DIFF
--- a/api.go
+++ b/api.go
@@ -426,7 +426,7 @@ func NewAPI(config Config, a Adapter) API {
 			Method: http.MethodGet,
 			Path:   config.OpenAPIPath + ".json",
 		}, func(ctx Context) {
-			ctx.SetHeader("Content-Type", "application/vnd.oai.openapi+json")
+			ctx.SetHeader("Content-Type", "application/openapi+json")
 			if specJSON == nil {
 				specJSON, _ = json.Marshal(newAPI.OpenAPI())
 			}
@@ -437,7 +437,7 @@ func NewAPI(config Config, a Adapter) API {
 			Method: http.MethodGet,
 			Path:   config.OpenAPIPath + "-3.0.json",
 		}, func(ctx Context) {
-			ctx.SetHeader("Content-Type", "application/vnd.oai.openapi+json")
+			ctx.SetHeader("Content-Type", "application/openapi+json")
 			if specJSON30 == nil {
 				specJSON30, _ = newAPI.OpenAPI().Downgrade()
 			}
@@ -448,7 +448,7 @@ func NewAPI(config Config, a Adapter) API {
 			Method: http.MethodGet,
 			Path:   config.OpenAPIPath + ".yaml",
 		}, func(ctx Context) {
-			ctx.SetHeader("Content-Type", "application/vnd.oai.openapi+yaml")
+			ctx.SetHeader("Content-Type", "application/openapi+yaml")
 			if specYAML == nil {
 				specYAML, _ = newAPI.OpenAPI().YAML()
 			}
@@ -459,7 +459,7 @@ func NewAPI(config Config, a Adapter) API {
 			Method: http.MethodGet,
 			Path:   config.OpenAPIPath + "-3.0.yaml",
 		}, func(ctx Context) {
-			ctx.SetHeader("Content-Type", "application/vnd.oai.openapi+yaml")
+			ctx.SetHeader("Content-Type", "application/openapi+yaml")
 			if specYAML30 == nil {
 				specYAML30, _ = newAPI.OpenAPI().DowngradeYAML()
 			}


### PR DESCRIPTION
Replace deprecated vendor-specific media types with standardized ones:
- `application/vnd.oai.openapi+json` → `application/openapi+json`
- `application/vnd.oai.openapi+yaml` → `application/openapi+yaml`

This aligns with the latest OpenAPI specification recommendations.

Fixes #898