### PR TITLE
fix: [security vulnerability] upgrade fiber version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.8.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-chi/chi/v5 v5.2.2
-	github.com/gofiber/fiber/v2 v2.52.7
+	github.com/gofiber/fiber/v2 v2.52.9
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/julienschmidt/httprouter v1.3.0


### PR DESCRIPTION
There was a vulnerability in Fiber framework that was reported back in August 2025. 

For more details see:
https://pkg.go.dev/vuln/GO-2025-3845
https://github.com/gofiber/fiber/security/advisories/GHSA-qx2q-88mx-vhg7
This has been fixed with version 2.52.9.