### PR TITLE
fix: use "http" URL scheme only if no TLS is used

### DIFF
--- a/transforms.go
+++ b/transforms.go
@@ -175,7 +175,7 @@ func (t *SchemaLinkTransformer) Transform(ctx Context, status string, v any) (an
 
 	// Set the `$schema` field.
 	buf := bufPool.Get().(*bytes.Buffer)
-	if len(host) >= 9 && (host[:9] == "localhost" || host[:9] == "127.0.0.1") {
+	if ctx.TLS() == nil && len(host) >= 9 && (host[:9] == "localhost" || host[:9] == "127.0.0.1") {
 		buf.WriteString("http://")
 	} else {
 		buf.WriteString("https://")


### PR DESCRIPTION
This fixes an issue where the "http" schema was incorrectly used for the "$schema" value when https://localhost or https://127.0.0.1 was requested.