### PR TITLE
Handle contentEncoding and contentMediaType keys

### DIFF
--- a/openapi.go
+++ b/openapi.go
@@ -1639,6 +1639,11 @@ func downgradeSpec(input any) {
 				continue
 			}
 
+			if k == "contentEncoding" || k == "contentMediaType" {
+				m["x-" + k] = m[k]
+				delete(m, k)
+			}
+			
 			downgradeSpec(v)
 		}
 	case []any:


### PR DESCRIPTION
See #919

The contentEncoding and contentMediaType are not OS3.0 compliant in an ObjectSchema. These fields need to be set as extensions instead when downgrading the spec.