### PR TITLE
fix: use Body() instead of BodyRaw() in fiber to auto decompress the req body

### DIFF
--- a/adapters/humafiber/humafiber.go
+++ b/adapters/humafiber/humafiber.go
@@ -106,7 +106,7 @@ func (c *fiberWrapper) BodyReader() io.Reader {
 		// Streaming is enabled, so send the reader.
 		return orig.Request().BodyStream()
 	}
-	return bytes.NewReader(orig.BodyRaw())
+	return bytes.NewReader(orig.Body())
 }
 
 func (c *fiberWrapper) GetMultipartForm() (*multipart.Form, error) {


### PR DESCRIPTION
BodyRaw() does not automatically recognize the value in Content-Encoding to decompress the request body, and returns unexpected values in the case of request compression