### PR TITLE
Remove default value in for Type in ErrorModel

### DIFF
--- a/error.go
+++ b/error.go
@@ -69,7 +69,7 @@ func (e *ErrorDetail) ErrorDetail() *ErrorDetail {
 //	}
 type ErrorModel struct {
 	// Type is a URI to get more information about the error type.
-	Type string `json:"type,omitempty" format:"uri" default:"about:blank" example:"https://example.com/errors/example" doc:"A URI reference to human-readable documentation for the error."`
+	Type string `json:"type,omitempty" format:"uri" example:"https://example.com/errors/example" doc:"A URI reference to human-readable documentation for the error."`
 
 	// Title provides a short static summary of the problem. Huma will default this
 	// to the HTTP response status code text if not present.


### PR DESCRIPTION
Hi,

I'm not sure if this "fix" is really necessary, but I faced an issue using `huma` with `openapigenerator`.

The thing is `about:blank` is not suitable for the most of uri validators (in my case one included in R client), so my solution was to remove it from the result openapi spec, probably it would be helpful to remove or update it here.

Thanks for your project, it's great!