### PR TITLE
Improve $schema URL

### DIFF
--- a/api.go
+++ b/api.go
@@ -378,7 +378,7 @@ func (a *api) Middlewares() Middlewares {
 // spec. If no server URL is set, then an empty string is returned.
 func getAPIPrefix(oapi *OpenAPI) string {
 	for _, server := range oapi.Servers {
-		if u, err := url.Parse(server.URL); err == nil && u.Path != "" {
+		if u, err := url.Parse(server.URL); err == nil && u.Scheme != "" && u.Path != "" {
 			return u.Path
 		}
 	}

--- a/huma_test.go
+++ b/huma_test.go
@@ -2549,6 +2549,105 @@ Content-Type: text/plain
 			},
 		},
 		{
+			Name: "schema-url-openapi-server-fallback",
+			Transformers: []huma.Transformer{
+				huma.NewSchemaLinkTransformer("/", "/").Transform,
+			},
+			Register: func(t *testing.T, api huma.API) {
+				api.OpenAPI().Servers = []*huma.Server{
+					{URL: "https://api.production.com"},
+				}
+				huma.Get(api, "/test", func(ctx context.Context, i *struct{}) (*struct {
+					Body struct {
+						Field string `json:"field"`
+					}
+				}, error) {
+					return &struct {
+						Body struct {
+							Field string `json:"field"`
+						}
+					}{Body: struct {
+						Field string `json:"field"`
+					}{Field: "value"}}, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/test",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code)
+				var body map[string]any
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+				assert.Equal(t, "https://api.production.com/schemas/Get-testResponse.json", body["$schema"])
+			},
+		},
+		{
+			Name: "schema-url-openapi-server-without-scheme",
+			Transformers: []huma.Transformer{
+				huma.NewSchemaLinkTransformer("/", "/").Transform,
+			},
+			Register: func(t *testing.T, api huma.API) {
+				api.OpenAPI().Servers = []*huma.Server{
+					{URL: "api.production.com"},
+				}
+				huma.Get(api, "/test", func(ctx context.Context, i *struct{}) (*struct {
+					Body struct {
+						Field string `json:"field"`
+					}
+				}, error) {
+					return &struct {
+						Body struct {
+							Field string `json:"field"`
+						}
+					}{Body: struct {
+						Field string `json:"field"`
+					}{Field: "value"}}, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/test",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code)
+				var body map[string]any
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+				assert.Equal(t, "https://api.production.com/schemas/Get-testResponse.json", body["$schema"])
+			},
+		},
+		{
+			Name: "schema-url-forwarded-host-overrides-openapi-server",
+			Transformers: []huma.Transformer{
+				huma.NewSchemaLinkTransformer("/", "/").Transform,
+			},
+			Register: func(t *testing.T, api huma.API) {
+				api.OpenAPI().Servers = []*huma.Server{
+					{URL: "https://api.production.com"},
+				}
+				huma.Get(api, "/test", func(ctx context.Context, i *struct{}) (*struct {
+					Body struct {
+						Field string `json:"field"`
+					}
+				}, error) {
+					return &struct {
+						Body struct {
+							Field string `json:"field"`
+						}
+					}{Body: struct {
+						Field string `json:"field"`
+					}{Field: "value"}}, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/test",
+			Headers: map[string]string{
+				"X-Forwarded-Host": "custom.example.com",
+			},
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code)
+				var body map[string]any
+				require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &body))
+				assert.Equal(t, "https://custom.example.com/schemas/Get-testResponse.json", body["$schema"])
+			},
+		},
+		{
 			Name: "response-transform-error",
 			Transformers: []huma.Transformer{
 				func(ctx huma.Context, status string, v any) (any, error) {

--- a/transforms.go
+++ b/transforms.go
@@ -20,6 +20,7 @@ type schemaField struct {
 // as-you-type validation & completion of HTTP resources in editors like
 // VSCode.
 type SchemaLinkTransformer struct {
+	oapi        *OpenAPI
 	prefix      string
 	schemasPath string
 	types       map[any][]schemaLinkType
@@ -82,6 +83,8 @@ func (t *SchemaLinkTransformer) addSchemaField(oapi *OpenAPI, content *MediaType
 // enabling this transformer to precompute & cache information about the
 // response and schema.
 func (t *SchemaLinkTransformer) OnAddOperation(oapi *OpenAPI, op *Operation) {
+	t.oapi = oapi
+
 	// Update registry to be able to get the type from a schema ref.
 	// Register the type in t.types with the generated ref
 	if op.RequestBody != nil && op.RequestBody.Content != nil {
@@ -191,8 +194,8 @@ func (t *SchemaLinkTransformer) Transform(ctx Context, _ string, v any) (any, er
 	schemaURL := getSchemaHost(ctx)
 
 	if schemaURL == "" || strings.HasPrefix(schemaURL, "localhost") {
-		if len(ctx.Operation().Servers) > 0 && ctx.Operation().Servers[0].URL != "" {
-			schemaURL = ctx.Operation().Servers[0].URL
+		if t.oapi != nil && len(t.oapi.Servers) > 0 && t.oapi.Servers[0].URL != "" {
+			schemaURL = t.oapi.Servers[0].URL
 		} else if schemaURL == "" {
 			schemaURL = "localhost"
 		}


### PR DESCRIPTION
This PR adjusts the `$schema` transformer. Rather than only checking `ctx.Host()`, it checks forwarder headers, and defaults to the first OpenAPI server URL if all else fails.

This fixes #674. 