### PR TITLE
fix(api): use proper CSP hash for inline script in Swagger doc renderer

### DIFF
--- a/api.go
+++ b/api.go
@@ -653,7 +653,7 @@ func (a *api) registerDocsRoute() {
 			"form-action 'none'",
 			"frame-ancestors 'none'",
 			"sandbox allow-same-origin allow-scripts",
-			"script-src https://unpkg.com/swagger-ui-dist@5.31.1/swagger-ui-bundle.js 'sha256-pyvxInx2c2C9E/dNMA9dfGa9z3Lhk9YDz1ET62LbfZs='",
+			"script-src https://unpkg.com/swagger-ui-dist@5.31.1/swagger-ui-bundle.js 'sha256-loGQL86SKUDRkBgfqt+XGmcml9Plihleifquht4CLYE='",
 			"style-src https://unpkg.com/swagger-ui-dist@5.31.1/swagger-ui.css",
 		}
 


### PR DESCRIPTION
A last-minute, seemingly inconspicuous, addition[^0] was made to https://github.com/danielgtaylor/huma/pull/916 which resulted in changing the CSP hash for the inline script, effectively breaking Swagger Web UI spec rendering. This change updates to the correct hash.

[^0]: https://github.com/danielgtaylor/huma/compare/26af2c17e8cc3fca088c4a878611627c0389711a..b6a65071f8f3206a654dd37dabf2766ffab3e883