### PR TITLE
Don't embed embedded objects with valid JSON tags

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -703,7 +703,7 @@ func getFields(typ reflect.Type, visited map[reflect.Type]struct{}) []fieldInfo 
 			continue
 		}
 
-		if f.Anonymous {
+		if f.Anonymous && f.Tag.Get("json") == "" {
 			embedded = append(embedded, f)
 			continue
 		}

--- a/schema_test.go
+++ b/schema_test.go
@@ -772,6 +772,51 @@ func TestSchema(t *testing.T) {
 			}`,
 		},
 		{
+			name: "field-embed-tagged",
+			input: struct {
+				Embedded `json:"meta"`
+				Value2   string `json:"value2"`
+			}{},
+			expected: `{
+				"type": "object",
+				"additionalProperties": false,
+				"required": ["meta", "value2"],
+				"properties": {
+					"meta": {
+						"$ref": "#/components/schemas/Embedded"
+					},
+					"value2": {
+						"type": "string"
+					}
+				}
+			}`,
+		},
+		{
+			name: "field-embed-mixed",
+			input: struct {
+				Embedded      `json:"meta"`
+				EmbeddedChild `json:""`
+				Value3        string `json:"value3"`
+			}{},
+			expected: `{
+				"type": "object",
+				"additionalProperties": false,
+				"required": ["meta", "value3", "value"],
+				"properties": {
+					"meta": {
+						"$ref": "#/components/schemas/Embedded"
+					},
+					"value": {
+						"type": "string",
+						"description": "old doc"
+					},
+					"value3": {
+						"type": "string"
+					}
+				}
+			}`,
+		},
+		{
 			name: "field-pointer-example",
 			input: struct {
 				Int *int64  `json:"int" example:"123"`


### PR DESCRIPTION
Fixes #975/#492.

If an embedded object has a `json` tag, it **won't** be embedded.

This example:

```go
type Meta struct {
	CreatedAt time.Time `json:"created_at" db:"created_at"`
}

type GreetingOutput struct {
	Body        struct {
		Meta    `json:"meta"`
		Message string `json:"message" example:"Hello, world!" doc:"Greeting message"`
	}
}
```

Previously generated:

```json
{
  "$schema": "https://example.com/schemas/GreetingOutputBody.json",
  "message": "Hello, world!",
  "created_at": "2019-08-24T14:15:22Z"
}
```

When it should be:

```json
{
  "$schema": "https://example.com/schemas/GreetingOutputBody.json",
  "message": "Hello, world!",
  "meta": {
    "created_at": "2019-08-24T14:15:22Z"
  }
}
```

If no `JSON` tag is specified, it will still function as it did before (which is correct).