### PR TITLE
fix: use epsilon tolerance in multipleOf float validation

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -493,7 +493,7 @@ func Validate(r Registry, s *Schema, path *PathBuffer, mode ValidateMode, v any,
 			}
 		}
 		if s.MultipleOf != nil {
-			if math.Mod(num, *s.MultipleOf) != 0 {
+			if r := math.Mod(num, *s.MultipleOf); math.Abs(r) > 1e-9 && math.Abs(r-*s.MultipleOf) > 1e-9 {
 				res.Add(path, v, s.msgMultipleOf)
 			}
 		}

--- a/validate_test.go
+++ b/validate_test.go
@@ -213,6 +213,13 @@ var validateTests = []struct {
 		errs:  []string{"expected number to be a multiple of 5"},
 	},
 	{
+		name: "multiple of float success",
+		typ: reflect.TypeFor[struct {
+			Value float64 "json:\"value\" multipleOf:\"0.01\""
+		}](),
+		input: map[string]any{"value": 0.36},
+	},
+	{
 		name:  "string success",
 		typ:   reflect.TypeFor[string](),
 		input: "",


### PR DESCRIPTION
`math.Mod(num, *s.MultipleOf) != 0` rejects valid floats like `0.36` with `multipleOf: 0.01` because IEEE 754 arithmetic produces tiny non-zero remainders (~2.78e-17). This replaces the exact comparison with an epsilon tolerance check.

Fixes #988