### PR TITLE
Adds support for slice query parameters using ParamWrapper types

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -648,6 +648,35 @@ func parseArrElement[T any](values []string, parse func(string) (T, error)) ([]T
 	return result, nil
 }
 
+// parseArrStructElement parses a slice of string values into a slice of
+// ParamWrapper struct elements. It sets the wrapper slice on f and returns the
+// unwrapped parsed values for validation.
+func parseArrStructElement(ctx Context, f reflect.Value, values []string, p paramFieldInfo) (any, error) {
+	recvType := reflect.New(f.Type().Elem()).Interface().(ParamWrapper).Receiver().Type()
+	elemP := paramFieldInfo{Type: recvType, TimeFormat: p.TimeFormat}
+	isReactor := reflect.PointerTo(f.Type().Elem()).Implements(reflect.TypeFor[ParamReactor]())
+
+	result := reflect.MakeSlice(f.Type(), len(values), len(values))
+	parsed := reflect.MakeSlice(reflect.SliceOf(recvType), len(values), len(values))
+	for i, val := range values {
+		elem := result.Index(i).Addr()
+		recv := elem.Interface().(ParamWrapper).Receiver()
+
+		pv, err := parseInto(ctx, recv, val, nil, elemP)
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+
+		if isReactor {
+			elem.Interface().(ParamReactor).OnParamSet(true, pv)
+		}
+		parsed.Index(i).Set(recv)
+	}
+
+	f.Set(result)
+	return parsed.Interface(), nil
+}
+
 // writeHeader is a utility function to write a header value to the response.
 // the `write` function should be either `ctx.SetHeader` or `ctx.AppendHeader`.
 func writeHeader(write func(string, string), info *headerInfo, f reflect.Value) {
@@ -1725,7 +1754,7 @@ func parseInto(ctx Context, f reflect.Value, value string, preSplit []string, p 
 				values = strings.Split(value, ",")
 			}
 		}
-		pv, err := parseSliceInto(f, values)
+		pv, err := parseSliceInto(ctx, f, values, p)
 		if err != nil {
 			if errors.Is(err, errUnparsable) {
 				break
@@ -1767,7 +1796,7 @@ func parseInto(ctx Context, f reflect.Value, value string, preSplit []string, p 
 
 // parseSliceInto converts a slice of string values into the expected type of f
 // and sets the result on f.
-func parseSliceInto(f reflect.Value, values []string) (any, error) {
+func parseSliceInto(ctx Context, f reflect.Value, values []string, p paramFieldInfo) (any, error) {
 	switch f.Type().Elem().Kind() {
 
 	case reflect.String:
@@ -1952,6 +1981,12 @@ func parseSliceInto(f reflect.Value, values []string) (any, error) {
 		}
 		f.Set(reflect.ValueOf(vs))
 		return vs, nil
+
+	case reflect.Struct:
+		if !reflect.PointerTo(f.Type().Elem()).Implements(reflect.TypeFor[ParamWrapper]()) {
+			return nil, errUnparsable
+		}
+		return parseArrStructElement(ctx, f, values, p)
 	}
 	return nil, errUnparsable
 }

--- a/huma_test.go
+++ b/huma_test.go
@@ -106,6 +106,19 @@ func (o *OptionalParam[T]) OnParamSet(isSet bool, parsed any) {
 	o.IsSet = isSet
 }
 
+// WrapperOnly implements ParamWrapper but not ParamReactor.
+type WrapperOnly[T any] struct {
+	Value T
+}
+
+func (w WrapperOnly[T]) Schema(r huma.Registry) *huma.Schema {
+	return huma.SchemaFromType(r, reflect.TypeOf(w.Value))
+}
+
+func (w *WrapperOnly[T]) Receiver() reflect.Value {
+	return reflect.ValueOf(w).Elem().Field(0)
+}
+
 // CountingInner is used to verify resolver traversal skips nil optional fields.
 type CountingInner struct{}
 
@@ -668,6 +681,123 @@ func TestFeatures(t *testing.T) {
 				})
 			},
 			URL:    "/test?param=2023-01-01T12:00:00Z",
+			Method: http.MethodGet,
+		},
+		{
+			Name: "parse-slice-with-param-receiver-int",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Params []OptionalParam[int] `query:"params"`
+				}) (*struct{}, error) {
+					assert.Equal(t, 3, len(i.Params))
+					assert.Equal(t, 1, i.Params[0].Value)
+					assert.True(t, i.Params[0].IsSet)
+					assert.Equal(t, 2, i.Params[1].Value)
+					assert.True(t, i.Params[1].IsSet)
+					assert.Equal(t, 3, i.Params[2].Value)
+					assert.True(t, i.Params[2].IsSet)
+					return nil, nil
+				})
+			},
+			URL:    "/test?params=1,2,3",
+			Method: http.MethodGet,
+		},
+		{
+			Name: "parse-slice-with-param-receiver-string",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Params []OptionalParam[string] `query:"params"`
+				}) (*struct{}, error) {
+					assert.Equal(t, 2, len(i.Params))
+					assert.Equal(t, "foo", i.Params[0].Value)
+					assert.True(t, i.Params[0].IsSet)
+					assert.Equal(t, "bar", i.Params[1].Value)
+					assert.True(t, i.Params[1].IsSet)
+					return nil, nil
+				})
+			},
+			URL:    "/test?params=foo,bar",
+			Method: http.MethodGet,
+		},
+		{
+			Name: "parse-slice-with-param-receiver-float",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Params []OptionalParam[float64] `query:"params"`
+				}) (*struct{}, error) {
+					assert.Equal(t, 2, len(i.Params))
+					assert.InDelta(t, 1.5, i.Params[0].Value, 1e-9)
+					assert.True(t, i.Params[0].IsSet)
+					assert.InDelta(t, 2.7, i.Params[1].Value, 1e-9)
+					assert.True(t, i.Params[1].IsSet)
+					return nil, nil
+				})
+			},
+			URL:    "/test?params=1.5,2.7",
+			Method: http.MethodGet,
+		},
+		{
+			Name: "parse-slice-with-param-receiver-exploded",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Params []OptionalParam[int] `query:"params,explode"`
+				}) (*struct{}, error) {
+					assert.Equal(t, 3, len(i.Params))
+					assert.Equal(t, 1, i.Params[0].Value)
+					assert.Equal(t, 2, i.Params[1].Value)
+					assert.Equal(t, 3, i.Params[2].Value)
+					return nil, nil
+				})
+			},
+			URL:    "/test?params=1&params=2&params=3",
+			Method: http.MethodGet,
+		},
+		{
+			Name: "parse-slice-with-param-receiver-invalid",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Params []OptionalParam[int] `query:"params"`
+				}) (*struct{}, error) {
+					return nil, nil
+				})
+			},
+			URL:    "/test?params=1,abc,3",
+			Method: http.MethodGet,
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, 422, resp.Code)
+			},
+		},
+		{
+			Name: "parse-slice-with-param-wrapper-only",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Params []WrapperOnly[int] `query:"params"`
+				}) (*struct{}, error) {
+					assert.Equal(t, 2, len(i.Params))
+					assert.Equal(t, 10, i.Params[0].Value)
+					assert.Equal(t, 20, i.Params[1].Value)
+					return nil, nil
+				})
+			},
+			URL:    "/test?params=10,20",
 			Method: http.MethodGet,
 		},
 		{

--- a/huma_test.go
+++ b/huma_test.go
@@ -692,7 +692,7 @@ func TestFeatures(t *testing.T) {
 				}, func(ctx context.Context, i *struct {
 					Params []OptionalParam[int] `query:"params"`
 				}) (*struct{}, error) {
-					assert.Equal(t, 3, len(i.Params))
+					assert.Len(t, i.Params, 3)
 					assert.Equal(t, 1, i.Params[0].Value)
 					assert.True(t, i.Params[0].IsSet)
 					assert.Equal(t, 2, i.Params[1].Value)
@@ -714,7 +714,7 @@ func TestFeatures(t *testing.T) {
 				}, func(ctx context.Context, i *struct {
 					Params []OptionalParam[string] `query:"params"`
 				}) (*struct{}, error) {
-					assert.Equal(t, 2, len(i.Params))
+					assert.Len(t, i.Params, 2)
 					assert.Equal(t, "foo", i.Params[0].Value)
 					assert.True(t, i.Params[0].IsSet)
 					assert.Equal(t, "bar", i.Params[1].Value)
@@ -734,7 +734,7 @@ func TestFeatures(t *testing.T) {
 				}, func(ctx context.Context, i *struct {
 					Params []OptionalParam[float64] `query:"params"`
 				}) (*struct{}, error) {
-					assert.Equal(t, 2, len(i.Params))
+					assert.Len(t, i.Params, 2)
 					assert.InDelta(t, 1.5, i.Params[0].Value, 1e-9)
 					assert.True(t, i.Params[0].IsSet)
 					assert.InDelta(t, 2.7, i.Params[1].Value, 1e-9)

--- a/huma_test.go
+++ b/huma_test.go
@@ -754,7 +754,7 @@ func TestFeatures(t *testing.T) {
 				}, func(ctx context.Context, i *struct {
 					Params []OptionalParam[int] `query:"params,explode"`
 				}) (*struct{}, error) {
-					assert.Equal(t, 3, len(i.Params))
+					assert.Len(t, i.Params, 3)
 					assert.Equal(t, 1, i.Params[0].Value)
 					assert.Equal(t, 2, i.Params[1].Value)
 					assert.Equal(t, 3, i.Params[2].Value)
@@ -791,7 +791,7 @@ func TestFeatures(t *testing.T) {
 				}, func(ctx context.Context, i *struct {
 					Params []WrapperOnly[int] `query:"params"`
 				}) (*struct{}, error) {
-					assert.Equal(t, 2, len(i.Params))
+					assert.Len(t, i.Params, 2)
 					assert.Equal(t, 10, i.Params[0].Value)
 					assert.Equal(t, 20, i.Params[1].Value)
 					return nil, nil


### PR DESCRIPTION
Adds support for slice query parameters using `ParamWrapper` types (e.g., `[]OptionalParam[int]`). Previously,
  `parseSliceInto` only handled primitive slice element kinds. Struct elements implementing `ParamWrapper` were
  returned as `errUnparsable`.

  ## Changes

  - Added `parseArrStructElement` helper that unwraps each slice element's `ParamWrapper.Receiver()` and
  delegates per-element parsing to `parseInto`, supporting all receiver types including `time.Time`, `url.URL`,
  and `TextUnmarshaler`
  - Added `case reflect.Struct` to `parseSliceInto` switch for `ParamWrapper`-implementing struct elements
  - Threaded `ctx` and `paramFieldInfo` through `parseSliceInto` so the struct case can call `parseInto` directly
  - `ParamReactor.OnParamSet` is called per element when implemented, with the unwrapped parsed value matching
  scalar behavior


I am a little unsure of the reflect unwrapping but there doesn't seem to be another approach other than implementing TextMarshal/Unmarshal to support slice query params of type struct.