### PR TITLE
fix: enforce required=true for path parameters per OpenAPI spec

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -246,6 +246,12 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 			pfi.Required = boolTag(f, "required", false)
 		}
 
+		// Per OpenAPI 3.x spec, path parameters MUST always be required.
+		// Override any user-set `required:"false"` tag for path params.
+		if pfi.Loc == "path" {
+			pfi.Required = true
+		}
+
 		if pfi.Type == timeType {
 			timeFormat := time.RFC3339Nano
 			if pfi.Loc == "header" {

--- a/huma.go
+++ b/huma.go
@@ -241,7 +241,9 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 		pfi := pl.pfi
 		pfi.Schema = SchemaFromField(registry, f, "")
 
-		// While discouraged, make it possible to make query/header params required.
+		// While discouraged, make it possible to override `required` for non-path
+		// params via the struct tag. Path params are always required per the
+		// OpenAPI 3.x spec and are forced back to true below.
 		if _, ok = f.Tag.Lookup("required"); ok {
 			pfi.Required = boolTag(f, "required", false)
 		}

--- a/huma_test.go
+++ b/huma_test.go
@@ -600,6 +600,28 @@ func TestFeatures(t *testing.T) {
 			},
 		},
 		{
+			Name: "path-param-required-overrides-tag",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/items/{id}",
+				}, func(ctx context.Context, input *struct {
+					ID string `path:"id" required:"false"`
+				}) (*struct{}, error) {
+					return nil, nil
+				})
+
+				// Per OpenAPI 3.x spec, path parameters must always be required,
+				// even if the struct tag says otherwise. Regression test for #1009.
+				param := api.OpenAPI().Paths["/items/{id}"].Get.Parameters[0]
+				assert.Equal(t, "id", param.Name)
+				assert.Equal(t, "path", param.In)
+				assert.True(t, param.Required)
+			},
+			Method: http.MethodGet,
+			URL:    "/items/abc",
+		},
+		{
 			Name: "param-bypass-validation",
 			Register: func(t *testing.T, api huma.API) {
 				huma.Register(api, huma.Operation{


### PR DESCRIPTION
Fixes #1009

## Problem

Since v2.37.0, path parameters with `required:"false"` struct tag omit the `"required"` field from the generated OpenAPI spec. Per the [OpenAPI 3.x specification](https://spec.openapis.org/oas/v3.1.0#parameter-object):

> If the parameter location is "path", this property is REQUIRED and its value MUST be true.

The initial `Required = true` set for path params (line 149) was being overridden by the generic `required` tag processing (lines 245-246).

## Fix

Add post-override enforcement that always sets `Required = true` for path parameters, regardless of the struct tag value. This restores the pre-v2.37.0 behavior where `required:"false"` on path parameters was silently ignored.