### PR TITLE
fix: parse server vars on getAPIPrefix to avoid parsing URL panic

### DIFF
--- a/api.go
+++ b/api.go
@@ -19,7 +19,10 @@ import (
 	"github.com/danielgtaylor/huma/v2/negotiation"
 )
 
-var rxSchema = regexp.MustCompile(`#/components/schemas/([^"]+)`)
+var (
+	rxSchema       = regexp.MustCompile(`#/components/schemas/([^"]+)`)
+	rxServerURLVar = regexp.MustCompile(`(?i){([a-z0-9._~-]+)}`)
+)
 
 var ErrUnknownContentType = errors.New("unknown content type")
 
@@ -409,9 +412,11 @@ func getAPIPrefix(oapi *OpenAPI) string {
 			continue
 		}
 
-		serverURL, err := url.Parse(server.URL)
+		urlWithVars := getServerURLWithDefaultVars(*server)
+
+		serverURL, err := url.Parse(urlWithVars)
 		if err != nil {
-			panic("invalid server URL: " + server.URL + ": " + err.Error())
+			panic("invalid server URL: " + urlWithVars + " (" + server.URL + "): " + err.Error())
 		}
 
 		if serverURL.Path == "" {
@@ -424,6 +429,31 @@ func getAPIPrefix(oapi *OpenAPI) string {
 	}
 
 	return ""
+}
+
+func getServerURLWithDefaultVars(s Server) string {
+	if s.URL == "" || len(s.Variables) == 0 {
+		return s.URL
+	}
+
+	res := s.URL
+	matches := rxServerURLVar.FindAllStringSubmatch(s.URL, -1)
+
+	for _, m := range matches {
+		v, ok := s.Variables[m[1]]
+		if !ok {
+			continue
+		}
+
+		val := v.Default
+		if val == "" && len(v.Enum) > 0 {
+			val = v.Enum[0]
+		}
+
+		res = strings.ReplaceAll(res, m[0], val)
+	}
+
+	return res
 }
 
 func parseContentType(contentType string) (int, int, error) {

--- a/api_internal_test.go
+++ b/api_internal_test.go
@@ -1,0 +1,62 @@
+package huma
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetServerURLWithDefaultVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		vars     map[string]*ServerVariable
+		expected string
+	}{
+		{
+			name: "AbsURL",
+			url:  "http://localhost:{port}/api/{version}{ext}?{unknown_var}",
+			vars: map[string]*ServerVariable{
+				"port": {
+					Default: "8080",
+				},
+				"version": {
+					Enum: []string{"v1", "v2"},
+				},
+				"ext": {},
+			},
+			expected: "http://localhost:8080/api/v1?{unknown_var}",
+		},
+		{
+			name: "RelativeURL",
+			url:  "/{basepath}/{version}",
+			vars: map[string]*ServerVariable{
+				"basepath": {
+					Default: "api",
+				},
+				"version": {
+					Default: "v2",
+				},
+			},
+			expected: "/api/v2",
+		},
+		{
+			name:     "EmptyURL",
+			url:      "",
+			expected: "",
+		},
+		{
+			name:     "NoVars",
+			url:      "http://localhost:{port}/api/{version}",
+			expected: "http://localhost:{port}/api/{version}",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := Server{URL: test.url, Variables: test.vars}
+			url := getServerURLWithDefaultVars(server)
+
+			assert.Equal(t, test.expected, url)
+		})
+	}
+}

--- a/api_test.go
+++ b/api_test.go
@@ -317,7 +317,7 @@ func TestDocsRenderers(t *testing.T) {
 	})
 
 	t.Run("APIPrefixInvalidURL", func(t *testing.T) {
-		assert.PanicsWithValue(t, "invalid server URL:  :invalid: parse \" :invalid\": first path segment in URL cannot contain colon", func() {
+		assert.PanicsWithValue(t, "invalid server URL:  :invalid ( :invalid): parse \" :invalid\": first path segment in URL cannot contain colon", func() {
 			humatest.New(t, huma.Config{
 				OpenAPI: &huma.OpenAPI{
 					Servers: []*huma.Server{

--- a/api_test.go
+++ b/api_test.go
@@ -251,6 +251,35 @@ func TestDocsRenderers(t *testing.T) {
 		assert.Contains(t, resp.Body.String(), `apiDescriptionUrl="/api/v1/openapi.yaml"`)
 	})
 
+	t.Run("APIPrefixWithServerVars", func(t *testing.T) {
+		_, api := humatest.New(t, huma.Config{
+			OpenAPI: &huma.OpenAPI{
+				Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
+				Servers: []*huma.Server{
+					{
+						URL: "http://localhost:{port}/api/{version}",
+						Variables: map[string]*huma.ServerVariable{
+							"port": {
+								Default: "8080",
+							},
+							"version": {
+								Enum: []string{"v1", "v2"},
+							},
+						},
+					},
+				},
+			},
+			DocsPath:    "/docs",
+			OpenAPIPath: "/openapi",
+			Formats:     huma.DefaultFormats,
+		})
+
+		resp := api.Get("/docs")
+		assert.Equal(t, http.StatusOK, resp.Code)
+		// Elements uses apiDescriptionUrl=".../api/v1/openapi.yaml"
+		assert.Contains(t, resp.Body.String(), `apiDescriptionUrl="/api/v1/openapi.yaml"`)
+	})
+
 	t.Run("APIPrefixRelative", func(t *testing.T) {
 		_, api := humatest.New(t, huma.Config{
 			OpenAPI: &huma.OpenAPI{


### PR DESCRIPTION
Closes https://github.com/danielgtaylor/huma/issues/1026.

This change adds support for resolving OpenAPI server URL template variables (e.g. `{port}`, `{version}`) when computing the API prefix for documentation paths.