### PR TITLE
fix(sse): flush response headers before user handler runs

### DIFF
--- a/sse/sse.go
+++ b/sse/sse.go
@@ -132,6 +132,9 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 		return &huma.StreamResponse{
 			Body: func(ctx huma.Context) {
 				ctx.SetHeader("Content-Type", "text/event-stream")
+				// Commit response headers immediately so the client's
+				// EventSource.onopen fires without waiting for the first event.
+				ctx.SetStatus(http.StatusOK)
 				bw := ctx.BodyWriter()
 				encoder := json.NewEncoder(bw)
 
@@ -148,6 +151,9 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 					} else {
 						break
 					}
+				}
+				if flusher != nil {
+					flusher.Flush()
 				}
 
 				var deadliner writeDeadliner

--- a/sse/sse_test.go
+++ b/sse/sse_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 
@@ -55,6 +56,35 @@ type WrappedDeadliner struct {
 
 func (w *WrappedDeadliner) SetWriteDeadline(t time.Time) error {
 	return w.deadlineErr
+}
+
+// orderedWriter records the order in which WriteHeader, Write, and Flush
+// are called so tests can assert headers are committed before body writes.
+type orderedWriter struct {
+	events []string
+	status int
+}
+
+func (w *orderedWriter) Header() http.Header {
+	return http.Header{}
+}
+
+func (w *orderedWriter) Write(p []byte) (int, error) {
+	w.events = append(w.events, "write")
+	return len(p), nil
+}
+
+func (w *orderedWriter) WriteHeader(statusCode int) {
+	w.status = statusCode
+	w.events = append(w.events, "writeHeader")
+}
+
+func (w *orderedWriter) Flush() {
+	w.events = append(w.events, "flush")
+}
+
+func (w *orderedWriter) SetWriteDeadline(t time.Time) error {
+	return nil
 }
 
 type sseTest struct {
@@ -129,6 +159,50 @@ data: {"error": "encode error: json: unsupported type: chan int"}
 			w = &DummyWriter{deadlineErr: errors.New("whoops")}
 			req, _ = http.NewRequest(http.MethodGet, "/sse", nil)
 			api.Adapter().ServeHTTP(w, req)
+		},
+	},
+	{
+		Title: "sse flushes headers before first event",
+		TestFunc: func(t *testing.T) {
+			_, api := humatest.New(t)
+			started := make(chan struct{})
+			release := make(chan struct{})
+			sse.Register(api, huma.Operation{
+				OperationID: "sse",
+				Method:      http.MethodGet,
+				Path:        "/sse",
+			}, map[string]any{
+				"message": &DefaultMessage{},
+			}, func(ctx context.Context, input *struct{}, send sse.Sender) {
+				close(started)
+				<-release
+			})
+
+			w := &orderedWriter{}
+			req, _ := http.NewRequest(http.MethodGet, "/sse", nil)
+			done := make(chan struct{})
+			go func() {
+				api.Adapter().ServeHTTP(w, req)
+				close(done)
+			}()
+			<-started
+			// At this point the user handler is running but has not sent any
+			// events yet. Headers must already be committed and flushed so
+			// that EventSource.onopen fires on the client.
+			eventsBeforeRelease := append([]string(nil), w.events...)
+			close(release)
+			<-done
+
+			assert.Equal(t, http.StatusOK, w.status)
+			require.Contains(t, eventsBeforeRelease, "writeHeader",
+				"WriteHeader must be called before the user handler blocks")
+			require.Contains(t, eventsBeforeRelease, "flush",
+				"Flush must be called before the user handler blocks")
+			whIdx := slices.Index(eventsBeforeRelease, "writeHeader")
+			flushIdx := slices.Index(eventsBeforeRelease, "flush")
+			assert.Less(t, whIdx, flushIdx, "WriteHeader must precede Flush")
+			assert.NotContains(t, eventsBeforeRelease, "write",
+				"no body write should occur before the user handler sends an event")
 		},
 	},
 	{


### PR DESCRIPTION
## Summary

- `sse.Register` set `Content-Type: text/event-stream` but never committed the response status or flushed before invoking the user handler.
- For handlers that wait on a channel before sending the first event, the browser's `EventSource.onopen` did not fire until the first event arrived — headers stayed buffered.
- Fix: call `ctx.SetStatus(http.StatusOK)` and `flusher.Flush()` right after the flusher is discovered, so headers are pushed to the client immediately.

Fixes #1037

## Root cause

1. `huma.Register` skips `ctx.SetStatus(status)` on the `outBodyFunc` path ([huma.go:1166-1168](https://github.com/danielgtaylor/huma/blob/main/huma.go#L1166-L1168)), so `WriteHeader(200)` is never called for streaming responses.
2. `sse.Register`'s `Body` callback only flushed inside `send()` after writing event data, so until the first event the client saw no response headers.

## Why this matters — spec references

**[WHATWG HTML Living Standard §9.2 Server-sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html)** binds `onopen` to the arrival of the response headers, not to the first event. Once the response is verified as `200` with `Content-Type: text/event-stream`, the user agent must *announce the connection*:

> When a user agent is to **announce the connection**, the user agent must queue a task which, if the `readyState` attribute is set to a value other than `CLOSED`, sets the `readyState` attribute to `OPEN` and **fires an event named `open`** at the `EventSource` object.

**[MDN — EventSource: open event](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/open_event)** restates the same contract:

> The `open` event is fired when a connection with an event source is opened. This occurs **after the initial HTTP connection to the server has been successfully established**.

In Go's `net/http`, response headers are not put on the wire until `WriteHeader` is called *and* an `http.Flusher.Flush()` pushes the buffered bytes. Without both, a handler that blocks waiting for the first event leaves the client stuck in `CONNECTING` — violating the spec's expected timing.

## Test plan

- [x] `go test ./sse/... -count=1` — all existing tests pass
- [x] New regression test `sse flushes headers before first event` uses an `orderedWriter` to assert `WriteHeader(200)` and `Flush` both happen before the user handler blocks on a channel
- [x] Verified the new test fails on `main` without the fix and passes with it