### PR TITLE
fix: avoid chi route context reuse

### DIFF
--- a/autopatch/autopatch.go
+++ b/autopatch/autopatch.go
@@ -10,6 +10,7 @@ package autopatch
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -20,10 +21,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/danielgtaylor/huma/v2"
-	"github.com/danielgtaylor/huma/v2/casing"
 	"github.com/danielgtaylor/shorthand/v2"
 	jsonpatch "github.com/evanphx/json-patch/v5"
+	"github.com/go-chi/chi/v5"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/casing"
 )
 
 const MergePatchNullabilityExtension = "x-merge-patch-nullability"
@@ -41,6 +44,22 @@ func RegisterNullabilityExtension(api huma.API, stringRepresentationOfNull strin
 		Enabled:                    true,
 		StringRepresentationOfNull: stringRepresentationOfNull,
 	}
+}
+
+type internalRequestContext struct {
+	context.Context
+}
+
+func (c internalRequestContext) Value(key any) any {
+	if key == chi.RouteCtxKey {
+		return nil
+	}
+
+	return c.Context.Value(key)
+}
+
+func autopatchRequestContext(ctx context.Context) context.Context {
+	return internalRequestContext{Context: ctx}
 }
 
 func replaceNulls(data []byte, settings MergePatchNullabilitySettings) ([]byte, error) {
@@ -264,7 +283,7 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 		resourcePath := findRelativeResourcePath(ctx.URL().Path, put.Path)
 
 		// Perform the get!
-		origReq, err := http.NewRequestWithContext(ctx.Context(), http.MethodGet, resourcePath, nil)
+		origReq, err := http.NewRequestWithContext(autopatchRequestContext(ctx.Context()), http.MethodGet, resourcePath, nil)
 		if err != nil {
 			huma.WriteErr(api, ctx, http.StatusInternalServerError, "Unable to get resource", err)
 			return
@@ -390,7 +409,7 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 		}
 
 		// Write the updated data back to the server!
-		putReq, err := http.NewRequestWithContext(ctx.Context(), http.MethodPut, resourcePath, bytes.NewReader(patched))
+		putReq, err := http.NewRequestWithContext(autopatchRequestContext(ctx.Context()), http.MethodPut, resourcePath, bytes.NewReader(patched))
 		if err != nil {
 			huma.WriteErr(api, ctx, http.StatusInternalServerError, "Unable to put modified resource", err)
 			return


### PR DESCRIPTION
This fixes a regression introduced by creating autopatch internal GET/PUT requests with the incoming request context.

Using http.NewRequestWithContext(ctx.Context(), ...) preserves user context values, but with humachi it also preserves chi.RouteContext. When autopatch serves the internal GET/PUT through the same adapter/router, chi sees an existing route context and reuses stale routing state from the outer PATCH request. As a result, the internal GET can be routed back to the generated PATCH handler, causing recursion and eventually a panic when the nested request has no body.

Example failure:

```
PATCH /resource/{id}
autopatch -> internal GET /resource/{id}
chi reuses outer RouteContext with PATCH route state
internal GET hits PATCH handler again
io.ReadAll(nil) panic
```

Fix

Wrap the incoming context for autopatch internal requests and filter out chi.RouteCtxKey, while preserving all other context behavior and values.

This keeps the intent of [#1019](https://github.com/danielgtaylor/huma/pull/1019):

request-scoped context values are still available;
cancellation and deadlines are preserved;
router-specific state from chi is not leaked into nested internal requests.

Notes:

This is my first PR to a community-driven library, so I may have missed some project-specific code style or contribution conventions. I also did not have much time to review the code style deeply, so I am open to adjusting the implementation if needed.

I tested this fork in my project and confirmed that it fixes the autopatch recursion issue with `humachi/chi`. However, my original issue was not about preserving context values for the internal GET/PUT requests, so I cannot be 100% sure that this does not affect the behavior intended by the previous PR. The goal of this change is to preserve the incoming context while filtering out the chi routing state that causes the nested request to be routed incorrectly.