### PR TITLE
fix: prevent panic in uniqueItems validation for unhashable types (#1042)

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -608,12 +608,41 @@ func handleArray[T any](r Registry, s *Schema, path *PathBuffer, mode ValidateMo
 	}
 
 	if s.UniqueItems {
-		seen := make(map[any]struct{}, len(arr))
+		// uniqueItemsContains reports whether item already appears in seen.
+		// It uses a map[any]struct{} for O(1) lookups but falls back to a
+		// reflect.DeepEqual linear scan when item is a non-hashable type
+		// (e.g. map[string]interface{} from malformed JSON like [{}]).
+		// Without this guard, inserting an unhashable key panics with
+		// "hash of unhashable type" and crashes the server (issue #1042).
+		uniqueItemsContains := func(seen []any, item any) (found bool) {
+			defer func() {
+				if recover() != nil {
+					// item is unhashable (e.g. a map or slice): fall back to
+					// deep equality so we still catch genuine duplicates.
+					for _, s := range seen {
+						if reflect.DeepEqual(s, item) {
+							found = true
+							return
+						}
+					}
+				}
+			}()
+			// Fast path: attempt a map lookup. This will panic for unhashable
+			// types, which the deferred recover above will catch.
+			m := make(map[any]struct{}, len(seen)+1)
+			for _, s := range seen {
+				m[s] = struct{}{}
+			}
+			_, found = m[item]
+			return
+		}
+
+		seen := make([]any, 0, len(arr))
 		for _, item := range arr {
-			if _, ok := seen[item]; ok {
+			if uniqueItemsContains(seen, item) {
 				res.Add(path, arr, validation.MsgExpectedArrayItemsUnique)
 			}
-			seen[item] = struct{}{}
+			seen = append(seen, item)
 		}
 	}
 

--- a/validate.go
+++ b/validate.go
@@ -608,41 +608,48 @@ func handleArray[T any](r Registry, s *Schema, path *PathBuffer, mode ValidateMo
 	}
 
 	if s.UniqueItems {
-		// uniqueItemsContains reports whether item already appears in seen.
-		// It uses a map[any]struct{} for O(1) lookups but falls back to a
-		// reflect.DeepEqual linear scan when item is a non-hashable type
-		// (e.g. map[string]interface{} from malformed JSON like [{}]).
-		// Without this guard, inserting an unhashable key panics with
-		// "hash of unhashable type" and crashes the server (issue #1042).
-		uniqueItemsContains := func(seen []any, item any) (found bool) {
-			defer func() {
-				if recover() != nil {
-					// item is unhashable (e.g. a map or slice): fall back to
-					// deep equality so we still catch genuine duplicates.
-					for _, s := range seen {
-						if reflect.DeepEqual(s, item) {
-							found = true
-							return
-						}
+		// Hashable items are tracked in a map for O(1) lookups. Non-hashable
+		// items (e.g. map[string]interface{} from malformed JSON like [{}])
+		// can't be used as map keys and would panic with "hash of unhashable
+		// type" (issue #1042), so they are recorded separately and compared
+		// with reflect.DeepEqual. This keeps the common all-hashable case
+		// linear while still detecting duplicates among unhashable items.
+		seen := make(map[any]struct{}, len(arr))
+		var unhashable []any
+
+		// contains reports whether item was already seen, recording it if not.
+		contains := func(item any) (dup bool) {
+			hashable := true
+			func() {
+				defer func() {
+					if recover() != nil {
+						hashable = false
 					}
+				}()
+				if _, ok := seen[item]; ok {
+					dup = true
+				} else {
+					seen[item] = struct{}{}
 				}
 			}()
-			// Fast path: attempt a map lookup. This will panic for unhashable
-			// types, which the deferred recover above will catch.
-			m := make(map[any]struct{}, len(seen)+1)
-			for _, s := range seen {
-				m[s] = struct{}{}
+			if hashable {
+				return dup
 			}
-			_, found = m[item]
-			return
+
+			// Slow path for unhashable items only.
+			for _, u := range unhashable {
+				if reflect.DeepEqual(u, item) {
+					return true
+				}
+			}
+			unhashable = append(unhashable, item)
+			return false
 		}
 
-		seen := make([]any, 0, len(arr))
 		for _, item := range arr {
-			if uniqueItemsContains(seen, item) {
+			if contains(item) {
 				res.Add(path, arr, validation.MsgExpectedArrayItemsUnique)
 			}
-			seen = append(seen, item)
 		}
 	}
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -762,6 +762,41 @@ var validateTests = []struct {
 		errs:  []string{"expected array items to be unique"},
 	},
 	{
+		// Regression test for issue #1042:
+		// uniqueItems validation must NOT panic when array items are
+		// non-hashable types (e.g. objects decoded from JSON like [{}]).
+		// Expected: a 422 type-validation error, not a server crash.
+		name: "uniqueItems with unhashable object element must not panic",
+		typ: reflect.TypeFor[struct {
+			Value []string "json:\"value\" uniqueItems:\"true\""
+		}](),
+		input: map[string]any{"value": []any{map[string]any{"key": "val"}}},
+		errs:  []string{"expected string"},
+	},
+	{
+		// Regression test for issue #1042:
+		// Duplicate unhashable objects should still be detected as non-unique.
+		name: "uniqueItems detects duplicate unhashable objects",
+		typ: reflect.TypeFor[struct {
+			Value []any "json:\"value\" uniqueItems:\"true\""
+		}](),
+		input: map[string]any{"value": []any{
+			map[string]any{"a": 1},
+			map[string]any{"a": 1},
+		}},
+		errs: []string{"expected array items to be unique"},
+	},
+	{
+		// Regression test for issue #1042:
+		// Mixed arrays (some hashable, some not) must not panic.
+		name: "uniqueItems with mixed hashable and unhashable elements must not panic",
+		typ: reflect.TypeFor[struct {
+			Value []any "json:\"value\" uniqueItems:\"true\""
+		}](),
+		input: map[string]any{"value": []any{"ok", map[string]any{"k": "v"}}},
+	},
+
+	{
 		name:  "map success",
 		typ:   reflect.TypeFor[map[string]int](),
 		input: map[string]any{"one": 1, "two": 2},


### PR DESCRIPTION
## Summary

Fixes #1042

## Problem

The `uniqueItems` check in `handleArray` used `map[any]struct{}` as a hash set. When array items contain non-hashable types such as `map[string]interface{}` — produced by malformed JSON like `[{}]` for a `[]string` field — inserting into the map panics:

```
http: panic serving [::1]:59220: hash of unhashable type: map[string]interface {}
```

This caused the server to return **no response at all** instead of a `422 Unprocessable Entity`. The panic kills the goroutine serving the request.

**Reproduction:**
```bash
curl -X POST -H 'Content-Type: application/json' \
  -d '{"arrayOfStrings": [{}]}' \
  http://localhost:8888/demo
# Server logs: panic serving ...: hash of unhashable type: map[string]interface {}
```

## Fix

Introduce a `uniqueItemsContains` helper that:
1. **Fast path**: attempts an O(1) `map[any]` lookup (works for all hashable types — strings, ints, bools, etc.)
2. **Slow path**: a `deferred recover()` catches the panic for unhashable types and falls back to an O(n) `reflect.DeepEqual` linear scan

This means:
- ✅ Normal arrays of hashable items → same O(n) performance as before  
- ✅ Arrays with maps/slices → graceful O(n²) fallback, no panic  
- ✅ Duplicate unhashable objects → still detected correctly  
- ✅ Malformed `[{}]` for `[]string` → proper `422 expected string` error  

## Tests

Three regression tests added to `validate_test.go`:

| Test | Verifies |
|------|----------|
| `uniqueItems with unhashable object element must not panic` | `[{}]` for `[]string` returns `422`, not a panic |
| `uniqueItems detects duplicate unhashable objects` | `[{"a":1},{"a":1}]` is still detected as non-unique |
| `uniqueItems with mixed hashable and unhashable elements` | `["ok", {"k":"v"}]` does not panic |

All existing tests continue to pass.