### PR TITLE
fix(autopatch): prevent chi route-context reuse in internal requests

### DIFF
--- a/adapters/humachi/humachi.go
+++ b/adapters/humachi/humachi.go
@@ -165,6 +165,31 @@ func (a *chiAdapter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	a.router.ServeHTTP(w, r)
 }
 
+// noRouteContext shadows chi's route-context key so a request re-dispatched
+// through this adapter is routed afresh. chi's Mux.ServeHTTP reuses an existing
+// *chi.Context found under chi.RouteCtxKey instead of matching again, so a
+// context propagated from an in-flight request (e.g. huma's autopatch internal
+// GET/PUT) would otherwise inherit the caller's matched route and recurse into
+// the same handler.
+type noRouteContext struct {
+	context.Context
+}
+
+func (c noRouteContext) Value(key any) any {
+	if key == chi.RouteCtxKey {
+		return nil
+	}
+	return c.Context.Value(key)
+}
+
+// SanitizeInternalContext implements the optional interface used by huma's
+// autopatch feature: it strips chi's matched-route state so an internal
+// sub-request re-dispatched through this adapter is routed fresh. All other
+// context values, deadlines, and cancellation are preserved.
+func (a *chiAdapter) SanitizeInternalContext(ctx context.Context) context.Context {
+	return noRouteContext{Context: ctx}
+}
+
 // NewAdapter creates a new adapter for the given chi router.
 func NewAdapter(r chi.Router) huma.Adapter {
 	return &chiAdapter{router: r}

--- a/autopatch/autopatch.go
+++ b/autopatch/autopatch.go
@@ -10,6 +10,7 @@ package autopatch
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -25,6 +26,27 @@ import (
 	"github.com/danielgtaylor/shorthand/v2"
 	jsonpatch "github.com/evanphx/json-patch/v5"
 )
+
+// internalContextSanitizer is an optional interface an adapter may implement to
+// strip router-specific state from a context before autopatch re-dispatches an
+// internal GET/PUT sub-request through that same adapter. Some routers (e.g.
+// chi) store their matched-route state in the request context and reuse it
+// instead of routing again; left unsanitized, the internal request would
+// inherit the original PATCH route and recurse into the same handler.
+type internalContextSanitizer interface {
+	SanitizeInternalContext(ctx context.Context) context.Context
+}
+
+// internalRequestContext returns the context to use for autopatch's internal
+// GET/PUT sub-requests. It gives the adapter a chance to remove any routing
+// state that must not leak into a request re-dispatched through it; adapters
+// that don't need this leave the context unchanged.
+func internalRequestContext(adapter huma.Adapter, ctx context.Context) context.Context {
+	if s, ok := adapter.(internalContextSanitizer); ok {
+		return s.SanitizeInternalContext(ctx)
+	}
+	return ctx
+}
 
 const MergePatchNullabilityExtension = "x-merge-patch-nullability"
 
@@ -264,7 +286,7 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 		resourcePath := findRelativeResourcePath(ctx.URL().Path, put.Path)
 
 		// Perform the get!
-		origReq, err := http.NewRequestWithContext(ctx.Context(), http.MethodGet, resourcePath, nil)
+		origReq, err := http.NewRequestWithContext(internalRequestContext(adapter, ctx.Context()), http.MethodGet, resourcePath, nil)
 		if err != nil {
 			huma.WriteErr(api, ctx, http.StatusInternalServerError, "Unable to get resource", err)
 			return
@@ -390,7 +412,7 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 		}
 
 		// Write the updated data back to the server!
-		putReq, err := http.NewRequestWithContext(ctx.Context(), http.MethodPut, resourcePath, bytes.NewReader(patched))
+		putReq, err := http.NewRequestWithContext(internalRequestContext(adapter, ctx.Context()), http.MethodPut, resourcePath, bytes.NewReader(patched))
 		if err != nil {
 			huma.WriteErr(api, ctx, http.StatusInternalServerError, "Unable to put modified resource", err)
 			return

--- a/autopatch/autopatch_chi_test.go
+++ b/autopatch/autopatch_chi_test.go
@@ -1,0 +1,82 @@
+package autopatch
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+)
+
+// TestPatchChiNoRouteContextReuse is a regression test for a panic that occurred
+// when autopatch ran on the chi adapter. chi stores its matched-route state in
+// the request context and reuses it instead of routing again, so propagating
+// the PATCH request's context to the internal GET caused that bodyless GET to be
+// routed back into the generated PATCH handler, recursing and panicking on
+// io.ReadAll(nil). The chi adapter's SanitizeInternalContext strips that state
+// so internal sub-requests route fresh.
+func TestPatchChiNoRouteContextReuse(t *testing.T) {
+	db := map[string]*ThingModel{
+		"test": {ID: "test", Price: 1.00},
+	}
+
+	r := chi.NewRouter()
+	api := humachi.New(r, huma.DefaultConfig("Test", "1.0.0"))
+
+	type ThingResponse struct {
+		ETag string `header:"ETag"`
+		Body *ThingModel
+	}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-thing",
+		Method:      http.MethodGet,
+		Path:        "/things/{thing-id}",
+		Errors:      []int{404},
+	}, func(ctx context.Context, input *struct {
+		ThingIDParam
+	}) (*ThingResponse, error) {
+		thing := db[input.ThingID]
+		if thing == nil {
+			return nil, huma.Error404NotFound("Not found")
+		}
+		return &ThingResponse{ETag: thing.ETag(), Body: thing}, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "put-thing",
+		Method:      http.MethodPut,
+		Path:        "/things/{thing-id}",
+		Errors:      []int{404, 412},
+	}, func(ctx context.Context, input *struct {
+		ThingIDParam
+		Body    ThingModel
+		IfMatch []string `header:"If-Match"`
+	}) (*ThingResponse, error) {
+		db[input.ThingID] = &input.Body
+		return &ThingResponse{ETag: db[input.ThingID].ETag(), Body: db[input.ThingID]}, nil
+	})
+
+	AutoPatch(api)
+
+	// Send a real PATCH through the chi router. Before the fix, the internal GET
+	// reused the PATCH route context and recursed into the PATCH handler,
+	// panicking on io.ReadAll of the bodyless internal request.
+	req := httptest.NewRequest(http.MethodPatch, "/things/test",
+		strings.NewReader(`{"price": 1.23}`))
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+	w := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() {
+		r.ServeHTTP(w, req)
+	})
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, "test1.23[][]", w.Result().Header.Get("ETag"))
+}


### PR DESCRIPTION
PR #1019 propagated the incoming request context to autopatch's internal GET/PUT sub-requests. With the chi adapter that also carried chi's matched route state (chi.RouteCtxKey), which chi reuses instead of routing again, so the bodyless internal GET was routed back into the generated PATCH handler, recursing and panicking on io.ReadAll(nil).

Add an optional internalContextSanitizer hook: autopatch asks the adapter to sanitize the context used for internal sub-requests, staying router-agnostic (no chi import). The chi adapter implements it by shadowing chi.RouteCtxKey so internal requests route fresh, while preserving all other context values, deadlines, and cancellation. Other adapters are unaffected.

Includes a chi-backed regression test that panics on io.ReadAll(nil) without the fix.