### PR TITLE
fix: compare numeric enum values numerically

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -1,6 +1,7 @@
 package huma
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -373,6 +374,44 @@ func validateDiscriminator(r Registry, s *Schema, path *PathBuffer, mode Validat
 	Validate(r, r.SchemaFromRef(ref), path, mode, v, res)
 }
 
+// toFloat64 normalizes any supported numeric Go type to a float64. The second
+// return value is false when v is not a numeric type. This lets numeric
+// validation treat values uniformly regardless of whether they came from a
+// JSON body (float64), a query/path parameter (int64), or a custom schema.
+func toFloat64(v any) (float64, bool) {
+	switch v := v.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int8:
+		return float64(v), true
+	case int16:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint:
+		return float64(v), true
+	case uint8:
+		return float64(v), true
+	case uint16:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case json.Number:
+		f, err := v.Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
 // Validate an input value against a schema, collecting errors in the validation
 // result object. If successful, `res.Errors` will be empty. It is suggested
 // to use a `sync.Pool` to reuse the PathBuffer and ValidateResult objects,
@@ -432,34 +471,8 @@ func Validate(r Registry, s *Schema, path *PathBuffer, mode ValidateMode, v any,
 			return
 		}
 	case TypeNumber, TypeInteger:
-		var num float64
-
-		switch v := v.(type) {
-		case float64:
-			num = v
-		case float32:
-			num = float64(v)
-		case int:
-			num = float64(v)
-		case int8:
-			num = float64(v)
-		case int16:
-			num = float64(v)
-		case int32:
-			num = float64(v)
-		case int64:
-			num = float64(v)
-		case uint:
-			num = float64(v)
-		case uint8:
-			num = float64(v)
-		case uint16:
-			num = float64(v)
-		case uint32:
-			num = float64(v)
-		case uint64:
-			num = float64(v)
-		default:
+		num, ok := toFloat64(v)
+		if !ok {
 			if s.Type == TypeInteger {
 				res.Add(path, v, validation.MsgExpectedInteger)
 			} else {
@@ -582,6 +595,20 @@ func Validate(r Registry, s *Schema, path *PathBuffer, mode ValidateMode, v any,
 
 	if len(s.Enum) > 0 {
 		found := slices.Contains(s.Enum, v)
+		if !found && (s.Type == TypeInteger || s.Type == TypeNumber) {
+			// Numeric enums may be stored with a different Go type than the
+			// parsed value (e.g. float64 from JSON bodies vs int64 from query
+			// or path params), so a strict type comparison is not enough.
+			// Compare numerically instead. Note this uses float64 like the rest
+			// of the numeric validation above, so integer values beyond 2^53
+			// are subject to the same precision limits.
+			if num, ok := toFloat64(v); ok {
+				found = slices.ContainsFunc(s.Enum, func(e any) bool {
+					ev, ok := toFloat64(e)
+					return ok && ev == num
+				})
+			}
+		}
 		if !found {
 			res.Add(path, v, s.msgEnum)
 		}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1092,6 +1092,33 @@ var validateTests = []struct {
 		input: map[string]any{"value": []any{1.0}},
 	},
 	{
+		// Regression for #1044: enum tag values are stored as float64 while
+		// query/path params are parsed as int64; the two must compare equal.
+		name: "enum int success int64 value",
+		typ: reflect.TypeFor[struct {
+			Value int "json:\"value\" enum:\"1,5,9\""
+		}](),
+		input: map[string]any{"value": int64(5)},
+	},
+	{
+		name: "enum int int64 value not in enum",
+		typ: reflect.TypeFor[struct {
+			Value int "json:\"value\" enum:\"1,5,9\""
+		}](),
+		input: map[string]any{"value": int64(2)},
+		errs:  []string{"expected value to be one of \"1, 5, 9\""},
+	},
+	{
+		// Custom Schema() emitting float64 enum values, validated against an
+		// int64 value (the query/path parameter path from #1044).
+		name: "enum integer float64 stored int64 value",
+		s: &huma.Schema{
+			Type: huma.TypeInteger,
+			Enum: []any{float64(1), float64(2)},
+		},
+		input: int64(2),
+	},
+	{
 		name: "expected enum",
 		typ: reflect.TypeFor[struct {
 			Value string "json:\"value\" enum:\"one,two\""

--- a/validate_test.go
+++ b/validate_test.go
@@ -1119,6 +1119,26 @@ var validateTests = []struct {
 		input: int64(2),
 	},
 	{
+		// json.Number is produced by decoders configured with UseNumber().
+		name:  "number json.Number success",
+		s:     &huma.Schema{Type: huma.TypeNumber},
+		input: json.Number("5.5"),
+	},
+	{
+		name: "enum integer json.Number value",
+		s: &huma.Schema{
+			Type: huma.TypeInteger,
+			Enum: []any{float64(1), float64(2)},
+		},
+		input: json.Number("2"),
+	},
+	{
+		name:  "number invalid json.Number",
+		s:     &huma.Schema{Type: huma.TypeNumber},
+		input: json.Number("not-a-number"),
+		errs:  []string{"expected number"},
+	},
+	{
 		name: "expected enum",
 		typ: reflect.TypeFor[struct {
 			Value string "json:\"value\" enum:\"one,two\""


### PR DESCRIPTION
Fixes #1044

Integer enums always failed validation for query/path parameters. The enum check used type-strict `slices.Contains`, but the runtime value type depends on its source: JSON bodies decode integers as `float64` while query/path params parse as `int64`. Tag-based enums are stored as `float64` (via `json.Unmarshal`), so a single enum slice could never satisfy both paths.

## Changes
- Extract the numeric normalization already inlined in the type check into a shared `toFloat64` helper (now also handling `json.Number`).
- Compare integer/number enums numerically instead of by Go type. Non-numeric enums keep strict comparison.

## Tests
Added regression cases covering int64 values against float64-stored enums (tag-based and custom `Schema()`), plus a negative guard. Verified they fail without the fix and pass with it. Full suite (789 tests) passes, vet clean.