### PR TITLE
feat: native support for stdlib UUIDs introduced in Go 1.27

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -792,6 +792,10 @@ func schemaFromType(r Registry, t reflect.Type) *Schema {
 		return custom
 	}
 
+	if s := stdlibUUIDSchema(t, isPointer); s != nil {
+		return s
+	}
+
 	// Handle special cases for known stdlib types.
 	switch t {
 	case timeType:

--- a/schema_uuid_go127.go
+++ b/schema_uuid_go127.go
@@ -1,0 +1,17 @@
+//go:build go1.27
+
+package huma
+
+import (
+	"reflect"
+	"uuid"
+)
+
+var uuidType = reflect.TypeFor[uuid.UUID]()
+
+func stdlibUUIDSchema(t reflect.Type, isPointer bool) *Schema {
+	if t == uuidType {
+		return &Schema{Type: TypeString, Nullable: isPointer, Format: "uuid"}
+	}
+	return nil
+}

--- a/schema_uuid_go127_test.go
+++ b/schema_uuid_go127_test.go
@@ -1,0 +1,32 @@
+//go:build go1.27
+
+package huma_test
+
+import (
+	"reflect"
+	"testing"
+	"uuid"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+func TestSchemaStdlibUUID(t *testing.T) {
+	type Input struct {
+		ID   uuid.UUID   `json:"id"`
+		IDs  []uuid.UUID `json:"ids"`
+	}
+
+	r := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
+	s := r.Schema(reflect.TypeFor[Input](), false, "")
+
+	id := s.Properties["id"]
+	assert.Equal(t, huma.TypeString, id.Type)
+	assert.Equal(t, "uuid", id.Format)
+
+	ids := s.Properties["ids"]
+	assert.Equal(t, huma.TypeArray, ids.Type)
+	assert.Equal(t, huma.TypeString, ids.Items.Type)
+	assert.Equal(t, "uuid", ids.Items.Format)
+}

--- a/schema_uuid_pre_go127.go
+++ b/schema_uuid_pre_go127.go
@@ -1,0 +1,7 @@
+//go:build !go1.27
+
+package huma
+
+import "reflect"
+
+func stdlibUUIDSchema(reflect.Type, bool) *Schema { return nil }


### PR DESCRIPTION
Go 1.27 introduces a new `uuid` package in the standard library[^0]. Until now, Huma users wanting UUID fields had to depend on `github.com/google/uuid` et al., and even with that dependency a field of type `uuid.UUID` does not get `format: "uuid"` set on its OpenAPI schema, the user must manually  add a `format:"uuid"` struct tag.

This change automatically recognizes the new stdlib `uuid.UUID` type on Go 1.27+ and emits a schema with `type: string` and `format: "uuid"`, with no struct-tag annotation required.

Closes https://github.com/danielgtaylor/huma/issues/868.

[^0]: https://pkg.go.dev/uuid