### PR TITLE
fix: content type validation should be case insensitive

### DIFF
--- a/api.go
+++ b/api.go
@@ -352,7 +352,7 @@ func (a *api) Unmarshal(contentType string, data []byte, v any) error {
 		return err
 	}
 
-	ct := contentType[start:end]
+	ct := strings.ToLower(contentType[start:end])
 	if ct == "" {
 		// Default to assume JSON since this is an API.
 		ct = "application/json"
@@ -396,14 +396,15 @@ func (a *api) Transform(ctx Context, status string, v any) (any, error) {
 }
 
 func (a *api) Marshal(w io.Writer, ct string, v any) error {
-	f, ok := a.formats[ct]
+	lower := strings.ToLower(ct)
+	f, ok := a.formats[lower]
 	if !ok {
-		start, end, err := parseContentType(ct)
+		start, end, err := parseContentType(lower)
 		if err != nil {
 			return err
 		}
 
-		f, ok = a.formats[ct[start:end]]
+		f, ok = a.formats[lower[start:end]]
 	}
 	if !ok {
 		return fmt.Errorf("%w: %s", ErrUnknownContentType, ct)

--- a/huma_test.go
+++ b/huma_test.go
@@ -924,6 +924,32 @@ func TestFeatures(t *testing.T) {
 			Body: `{"name":"foo"}`,
 		},
 		{
+			// Media types are case-insensitive (RFC 9110 §8.3.1). A client sending
+			// e.g. `Application/Json` must still be matched to the registered
+			// `application/json` format rather than rejected with 415.
+			Name: "request-body-content-type-case-insensitive",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPut,
+					Path:   "/body",
+				}, func(ctx context.Context, input *struct {
+					Body struct {
+						Name string `json:"name"`
+					}
+				}) (*struct{}, error) {
+					assert.Equal(t, "foo", input.Body.Name)
+					return nil, nil
+				})
+			},
+			Method:  http.MethodPut,
+			URL:     "/body",
+			Headers: map[string]string{"Content-Type": "Application/Json; charset=UTF-8"},
+			Body:    `{"name":"foo"}`,
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusNoContent, resp.Code, resp.Body.String())
+			},
+		},
+		{
 			Name: "request-body-embed",
 			Register: func(t *testing.T, api huma.API) {
 				type Input struct {


### PR DESCRIPTION
I ran into this in production: an old .NET app couldn't call our Huma-based service because it sends Content-Type: Application/Json (capitalized), and Huma responded with 415 Unsupported Media Type.

Media types are case-insensitive per RFC 9110 §8.3.1, but the format lookup (a.formats[ct]) is a case-sensitive map access, so Application/Json doesn't match the registered application/json.

Fixed by lowercasing the media-type token. Added a test as well 