### PR TITLE
feat: Add trace-aware structured logging middleware

### DIFF
--- a/middleware/accesslog.go
+++ b/middleware/accesslog.go
@@ -61,13 +61,13 @@ func AccessLogger(config AccessLoggerConfig) func(huma.Context, func(huma.Contex
 
 		defer func() {
 			if recovered := recover(); recovered != nil {
-				writeAccessLog(ctx, logger, config, start, httpStatusInternalServerError)
+				writeAccessLog(ctx, config.Logger, config, start, httpStatusInternalServerError)
 				panic(recovered)
 			}
 		}()
 
 		next(ctx)
-		writeAccessLog(ctx, logger, config, start, statusOrDefault(ctx.Status(), httpStatusOK))
+		writeAccessLog(ctx, config.Logger, config, start, statusOrDefault(ctx.Status(), httpStatusOK))
 	}
 }
 

--- a/middleware/accesslog.go
+++ b/middleware/accesslog.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"log/slog"
+	"strconv"
 	"strings"
 	"time"
 
@@ -159,6 +160,7 @@ func gcpAccessAttrs(ctx huma.Context, config AccessLoggerConfig, info RequestInf
 			slog.Int("status", status),
 			slog.String("userAgent", ctx.Header("User-Agent")),
 			slog.String("remoteIp", ctx.RemoteAddr()),
+			slog.String("latency", durationSeconds(duration)),
 		),
 		slog.Float64("duration_ms", durationMilliseconds(duration)),
 	}
@@ -247,11 +249,11 @@ func gcpRequestAttrs(ctx huma.Context, config AccessLoggerConfig, info RequestIn
 	if traceID == "" {
 		return attrs
 	}
-	if config.GCP.ProjectID == "" {
-		attrs = append(attrs, slog.String("traceId", traceID))
-	} else {
-		attrs = append(attrs, slog.String("logging.googleapis.com/trace", "projects/"+config.GCP.ProjectID+"/traces/"+traceID))
+	trace := traceID
+	if config.GCP.ProjectID != "" {
+		trace = "projects/" + config.GCP.ProjectID + "/traces/" + traceID
 	}
+	attrs = append(attrs, slog.String("logging.googleapis.com/trace", trace))
 	if parentID != "" {
 		attrs = append(attrs, slog.String("parentId", parentID))
 	}
@@ -344,6 +346,19 @@ func statusOrDefault(status, defaultStatus int) int {
 
 func durationMilliseconds(duration time.Duration) float64 {
 	return float64(duration) / float64(time.Millisecond)
+}
+
+func durationSeconds(duration time.Duration) string {
+	if duration <= 0 {
+		return "0s"
+	}
+	seconds := duration / time.Second
+	nanos := duration % time.Second
+	if nanos == 0 {
+		return strconv.FormatInt(int64(seconds), 10) + "s"
+	}
+	fraction := strings.TrimRight(strconv.FormatInt(int64(nanos)+int64(time.Second), 10)[1:], "0")
+	return strconv.FormatInt(int64(seconds), 10) + "." + fraction + "s"
 }
 
 const (

--- a/middleware/accesslog.go
+++ b/middleware/accesslog.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"log/slog"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -101,7 +102,7 @@ func requestLogger(ctx huma.Context, config AccessLoggerConfig) *slog.Logger {
 }
 
 func loggerRequestAttrs(ctx huma.Context, config AccessLoggerConfig) []slog.Attr {
-	info := requestInfo(ctx.Context())
+	info := requestContextInfo(ctx.Context())
 	switch config.Preset {
 	case LogPresetGCP:
 		return gcpRequestAttrs(ctx, config, info)
@@ -115,12 +116,12 @@ func loggerRequestAttrs(ctx huma.Context, config AccessLoggerConfig) []slog.Attr
 }
 
 func writeAccessLog(ctx huma.Context, logger *slog.Logger, config AccessLoggerConfig, start time.Time, status int) {
-	attrs := accessAttrs(ctx, config, status, config.Now().Sub(start))
+	attrs := accessAttrs(ctx, config, status, elapsed(start, config.Now()))
 	logger.LogAttrs(ctx.Context(), config.StatusLevel(status), "request completed", attrs...)
 }
 
 func accessAttrs(ctx huma.Context, config AccessLoggerConfig, status int, duration time.Duration) []slog.Attr {
-	info := requestInfo(ctx.Context())
+	info := requestContextInfo(ctx.Context())
 	switch config.Preset {
 	case LogPresetGCP:
 		return gcpAccessAttrs(ctx, config, info, status, duration)
@@ -133,7 +134,7 @@ func accessAttrs(ctx huma.Context, config AccessLoggerConfig, status int, durati
 	}
 }
 
-func genericAccessAttrs(ctx huma.Context, info RequestInfo, status int, duration time.Duration, extra func(huma.Context) []slog.Attr) []slog.Attr {
+func genericAccessAttrs(ctx huma.Context, info requestInfo, status int, duration time.Duration, extra func(huma.Context) []slog.Attr) []slog.Attr {
 	attrs := []slog.Attr{
 		slog.String("method", ctx.Method()),
 		slog.Int("status", status),
@@ -152,14 +153,14 @@ func genericAccessAttrs(ctx huma.Context, info RequestInfo, status int, duration
 	return attrs
 }
 
-func gcpAccessAttrs(ctx huma.Context, config AccessLoggerConfig, info RequestInfo, status int, duration time.Duration) []slog.Attr {
+func gcpAccessAttrs(ctx huma.Context, config AccessLoggerConfig, info requestInfo, status int, duration time.Duration) []slog.Attr {
 	attrs := []slog.Attr{
 		slog.Group("httpRequest",
 			slog.String("requestMethod", ctx.Method()),
 			slog.String("requestUrl", ctx.URL().Path),
 			slog.Int("status", status),
 			slog.String("userAgent", ctx.Header("User-Agent")),
-			slog.String("remoteIp", ctx.RemoteAddr()),
+			slog.String("remoteIp", remoteIP(ctx.RemoteAddr())),
 			slog.String("latency", durationSeconds(duration)),
 		),
 		slog.Float64("duration_ms", durationMilliseconds(duration)),
@@ -177,7 +178,7 @@ func gcpAccessAttrs(ctx huma.Context, config AccessLoggerConfig, info RequestInf
 	return attrs
 }
 
-func awsAccessAttrs(ctx huma.Context, info RequestInfo, status int, duration time.Duration, extra func(huma.Context) []slog.Attr) []slog.Attr {
+func awsAccessAttrs(ctx huma.Context, info requestInfo, status int, duration time.Duration, extra func(huma.Context) []slog.Attr) []slog.Attr {
 	route := ""
 	if op := ctx.Operation(); op != nil {
 		route = op.Path
@@ -201,7 +202,7 @@ func awsAccessAttrs(ctx huma.Context, info RequestInfo, status int, duration tim
 	return attrs
 }
 
-func genericRequestAttrs(info RequestInfo) []slog.Attr {
+func genericRequestAttrs(info requestInfo) []slog.Attr {
 	var attrs []slog.Attr
 	if info.RequestID != "" {
 		attrs = append(attrs, slog.String("request_id", info.RequestID))
@@ -220,7 +221,7 @@ func genericRequestAttrs(info RequestInfo) []slog.Attr {
 	return attrs
 }
 
-func gcpRequestAttrs(ctx huma.Context, config AccessLoggerConfig, info RequestInfo) []slog.Attr {
+func gcpRequestAttrs(ctx huma.Context, config AccessLoggerConfig, info requestInfo) []slog.Attr {
 	var attrs []slog.Attr
 	if info.RequestID != "" {
 		attrs = append(attrs, slog.String("requestId", info.RequestID))
@@ -263,7 +264,7 @@ func gcpRequestAttrs(ctx huma.Context, config AccessLoggerConfig, info RequestIn
 	return append(attrs, slog.Bool("logging.googleapis.com/trace_sampled", sampled))
 }
 
-func awsRequestAttrs(info RequestInfo) []slog.Attr {
+func awsRequestAttrs(info requestInfo) []slog.Attr {
 	var attrs []slog.Attr
 	if info.RequestID != "" {
 		attrs = append(attrs, slog.String("requestId", info.RequestID))
@@ -282,7 +283,7 @@ func awsRequestAttrs(info RequestInfo) []slog.Attr {
 	return attrs
 }
 
-func azureAccessAttrs(ctx huma.Context, info RequestInfo, status int, duration time.Duration, extra func(huma.Context) []slog.Attr) []slog.Attr {
+func azureAccessAttrs(ctx huma.Context, info requestInfo, status int, duration time.Duration, extra func(huma.Context) []slog.Attr) []slog.Attr {
 	route := ""
 	if op := ctx.Operation(); op != nil {
 		route = op.Path
@@ -306,7 +307,7 @@ func azureAccessAttrs(ctx huma.Context, info RequestInfo, status int, duration t
 	return attrs
 }
 
-func azureRequestAttrs(info RequestInfo) []slog.Attr {
+func azureRequestAttrs(info requestInfo) []slog.Attr {
 	var attrs []slog.Attr
 	if info.RequestID != "" {
 		attrs = append(attrs, slog.String("requestId", info.RequestID))
@@ -344,6 +345,14 @@ func statusOrDefault(status, defaultStatus int) int {
 	return status
 }
 
+func elapsed(start, end time.Time) time.Duration {
+	duration := end.Sub(start)
+	if duration < 0 {
+		return 0
+	}
+	return duration
+}
+
 func durationMilliseconds(duration time.Duration) float64 {
 	return float64(duration) / float64(time.Millisecond)
 }
@@ -359,6 +368,16 @@ func durationSeconds(duration time.Duration) string {
 	}
 	fraction := strings.TrimRight(strconv.FormatInt(int64(nanos)+int64(time.Second), 10)[1:], "0")
 	return strconv.FormatInt(int64(seconds), 10) + "." + fraction + "s"
+}
+
+func remoteIP(addr string) string {
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	if strings.HasPrefix(addr, "[") && strings.HasSuffix(addr, "]") {
+		return strings.TrimPrefix(strings.TrimSuffix(addr, "]"), "[")
+	}
+	return addr
 }
 
 const (

--- a/middleware/accesslog.go
+++ b/middleware/accesslog.go
@@ -19,9 +19,8 @@ type AccessLoggerConfig struct {
 	// slog.Default().
 	Logger *slog.Logger
 
-	// Preset configures request and access-log field names for a log aggregation
-	// target. When Logger is created by NewJSONLogger, set both configs to the
-	// same preset.
+	// Preset configures request and access-log field names. When Logger is
+	// created by NewJSONLogger, use the same preset in both configs.
 	Preset LogPreset
 
 	// GCP configures Google Cloud Logging fields.
@@ -40,12 +39,13 @@ type AccessLoggerConfig struct {
 
 // GCPConfig configures Google Cloud Logging fields.
 type GCPConfig struct {
-	// ProjectID is the Google Cloud project ID used to format Cloud Trace links.
+	// ProjectID is the Google Cloud project ID. When set, trace IDs are formatted
+	// as full Cloud Trace resource names.
 	ProjectID string
 
-	// CloudTraceContextHeader is the optional provider-specific request header
-	// used by Cloud Run for request-log nesting. The default is
-	// "X-Cloud-Trace-Context" when LogPresetGCP is selected.
+	// CloudTraceContextHeader is the fallback request header used for Google
+	// Cloud trace correlation when traceparent is absent or invalid. The default
+	// is "X-Cloud-Trace-Context" when LogPresetGCP is selected.
 	CloudTraceContextHeader string
 }
 

--- a/middleware/accesslog.go
+++ b/middleware/accesslog.go
@@ -17,7 +17,9 @@ type AccessLoggerConfig struct {
 	// slog.Default().
 	Logger *slog.Logger
 
-	// Preset configures built-in field names for a log aggregation target.
+	// Preset configures request and access-log field names for a log aggregation
+	// target. When Logger is created by NewJSONLogger, set both configs to the
+	// same preset.
 	Preset LogPreset
 
 	// GCP configures Google Cloud Logging fields.
@@ -46,7 +48,9 @@ type GCPConfig struct {
 }
 
 // AccessLogger returns middleware that stores a request-scoped logger and emits
-// one structured access log after the operation completes.
+// one structured access log after the operation completes. Register
+// RequestContext before AccessLogger to include request ID and trace correlation
+// fields.
 func AccessLogger(config AccessLoggerConfig) func(huma.Context, func(huma.Context)) {
 	config = withAccessLoggerDefaults(config)
 
@@ -102,6 +106,8 @@ func loggerRequestAttrs(ctx huma.Context, config AccessLoggerConfig) []slog.Attr
 		return gcpRequestAttrs(ctx, config, info)
 	case LogPresetAWS:
 		return awsRequestAttrs(info)
+	case LogPresetAzure:
+		return azureRequestAttrs(info)
 	default:
 		return genericRequestAttrs(info)
 	}
@@ -119,6 +125,8 @@ func accessAttrs(ctx huma.Context, config AccessLoggerConfig, status int, durati
 		return gcpAccessAttrs(ctx, config, info, status, duration)
 	case LogPresetAWS:
 		return awsAccessAttrs(ctx, info, status, duration, config.ExtraAttrs)
+	case LogPresetAzure:
+		return azureAccessAttrs(ctx, info, status, duration, config.ExtraAttrs)
 	default:
 		return genericAccessAttrs(ctx, info, status, duration, config.ExtraAttrs)
 	}
@@ -202,7 +210,8 @@ func genericRequestAttrs(info RequestInfo) []slog.Attr {
 	if info.Trace.Valid {
 		attrs = append(attrs,
 			slog.String("trace_id", info.Trace.TraceID),
-			slog.String("span_id", info.Trace.ParentID),
+			slog.String("parent_id", info.Trace.ParentID),
+			slog.String("trace_flags", traceFlagsText(info.Trace.Flags)),
 			slog.Bool("sampled", info.Trace.Sampled),
 		)
 	}
@@ -219,17 +228,18 @@ func gcpRequestAttrs(ctx huma.Context, config AccessLoggerConfig, info RequestIn
 	}
 
 	traceID := ""
-	spanID := ""
+	parentID := ""
+	traceFlags := byte(0)
 	sampled := false
 	if info.Trace.Valid {
 		traceID = info.Trace.TraceID
-		spanID = info.Trace.ParentID
+		parentID = info.Trace.ParentID
+		traceFlags = info.Trace.Flags
 		sampled = info.Trace.Sampled
 	} else if config.GCP.CloudTraceContextHeader != "" {
 		trace := parseCloudTraceContext(ctx.Header(config.GCP.CloudTraceContextHeader))
 		if trace.Valid {
 			traceID = trace.TraceID
-			spanID = trace.SpanID
 			sampled = trace.Sampled
 		}
 	}
@@ -238,11 +248,15 @@ func gcpRequestAttrs(ctx huma.Context, config AccessLoggerConfig, info RequestIn
 		return attrs
 	}
 	if config.GCP.ProjectID == "" {
-		return append(attrs, slog.String("traceId", traceID))
+		attrs = append(attrs, slog.String("traceId", traceID))
+	} else {
+		attrs = append(attrs, slog.String("logging.googleapis.com/trace", "projects/"+config.GCP.ProjectID+"/traces/"+traceID))
 	}
-	attrs = append(attrs, slog.String("logging.googleapis.com/trace", "projects/"+config.GCP.ProjectID+"/traces/"+traceID))
-	if spanID != "" {
-		attrs = append(attrs, slog.String("logging.googleapis.com/spanId", spanID))
+	if parentID != "" {
+		attrs = append(attrs, slog.String("parentId", parentID))
+	}
+	if info.Trace.Valid {
+		attrs = append(attrs, slog.String("traceFlags", traceFlagsText(traceFlags)))
 	}
 	return append(attrs, slog.Bool("logging.googleapis.com/trace_sampled", sampled))
 }
@@ -258,7 +272,52 @@ func awsRequestAttrs(info RequestInfo) []slog.Attr {
 	if info.Trace.Valid {
 		attrs = append(attrs,
 			slog.String("traceId", info.Trace.TraceID),
-			slog.String("spanId", info.Trace.ParentID),
+			slog.String("parentId", info.Trace.ParentID),
+			slog.String("traceFlags", traceFlagsText(info.Trace.Flags)),
+			slog.Bool("sampled", info.Trace.Sampled),
+		)
+	}
+	return attrs
+}
+
+func azureAccessAttrs(ctx huma.Context, info RequestInfo, status int, duration time.Duration, extra func(huma.Context) []slog.Attr) []slog.Attr {
+	route := ""
+	if op := ctx.Operation(); op != nil {
+		route = op.Path
+	}
+	attrs := []slog.Attr{
+		slog.Group("http",
+			slog.Group("request",
+				slog.String("method", ctx.Method()),
+			),
+			slog.String("route", route),
+			slog.Group("response",
+				slog.Int("status_code", status),
+			),
+		),
+		slog.Float64("duration_ms", durationMilliseconds(duration)),
+	}
+	attrs = append(attrs, azureRequestAttrs(info)...)
+	if extra != nil {
+		attrs = append(attrs, extra(ctx)...)
+	}
+	return attrs
+}
+
+func azureRequestAttrs(info RequestInfo) []slog.Attr {
+	var attrs []slog.Attr
+	if info.RequestID != "" {
+		attrs = append(attrs, slog.String("requestId", info.RequestID))
+	}
+	if info.CorrelationID != "" {
+		attrs = append(attrs, slog.String("correlationId", info.CorrelationID))
+	}
+	if info.Trace.Valid {
+		attrs = append(attrs,
+			slog.String("operationId", info.Trace.TraceID),
+			slog.String("traceId", info.Trace.TraceID),
+			slog.String("parentId", info.Trace.ParentID),
+			slog.String("traceFlags", traceFlagsText(info.Trace.Flags)),
 			slog.Bool("sampled", info.Trace.Sampled),
 		)
 	}
@@ -295,7 +354,6 @@ const (
 
 type cloudTraceContext struct {
 	TraceID string
-	SpanID  string
 	Sampled bool
 	Valid   bool
 }
@@ -317,10 +375,18 @@ func parseCloudTraceContext(header string) cloudTraceContext {
 	}
 	return cloudTraceContext{
 		TraceID: traceID,
-		SpanID:  spanID,
-		Sampled: strings.Contains(options, "o=1"),
+		Sampled: cloudTraceSampled(options),
 		Valid:   true,
 	}
+}
+
+func cloudTraceSampled(options string) bool {
+	for _, option := range strings.Split(options, ";") {
+		if strings.TrimSpace(option) == "o=1" {
+			return true
+		}
+	}
+	return false
 }
 
 func allDigits(value string) bool {
@@ -330,4 +396,9 @@ func allDigits(value string) bool {
 		}
 	}
 	return true
+}
+
+func traceFlagsText(flags byte) string {
+	const hex = "0123456789abcdef"
+	return string([]byte{hex[flags>>4], hex[flags&0x0f]})
 }

--- a/middleware/accesslog.go
+++ b/middleware/accesslog.go
@@ -1,0 +1,333 @@
+package middleware
+
+import (
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// StatusLeveler maps HTTP response statuses to log levels.
+type StatusLeveler func(status int) slog.Level
+
+// AccessLoggerConfig configures AccessLogger.
+type AccessLoggerConfig struct {
+	// Logger is the base logger used for request and access logs. The default is
+	// slog.Default().
+	Logger *slog.Logger
+
+	// Preset configures built-in field names for a log aggregation target.
+	Preset LogPreset
+
+	// GCP configures Google Cloud Logging fields.
+	GCP GCPConfig
+
+	// Now returns the current time. The default is time.Now.
+	Now func() time.Time
+
+	// StatusLevel maps response statuses to log levels. The default maps 5xx to
+	// error, 4xx to warn, and all others to info.
+	StatusLevel StatusLeveler
+
+	// ExtraAttrs returns additional access-log attributes.
+	ExtraAttrs func(huma.Context) []slog.Attr
+}
+
+// GCPConfig configures Google Cloud Logging fields.
+type GCPConfig struct {
+	// ProjectID is the Google Cloud project ID used to format Cloud Trace links.
+	ProjectID string
+
+	// CloudTraceContextHeader is the optional provider-specific request header
+	// used by Cloud Run for request-log nesting. The default is
+	// "X-Cloud-Trace-Context" when LogPresetGCP is selected.
+	CloudTraceContextHeader string
+}
+
+// AccessLogger returns middleware that stores a request-scoped logger and emits
+// one structured access log after the operation completes.
+func AccessLogger(config AccessLoggerConfig) func(huma.Context, func(huma.Context)) {
+	config = withAccessLoggerDefaults(config)
+
+	return func(ctx huma.Context, next func(huma.Context)) {
+		start := config.Now()
+		logger := requestLogger(ctx, config)
+		ctx = withLogger(ctx, logger)
+
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				writeAccessLog(ctx, logger, config, start, httpStatusInternalServerError)
+				panic(recovered)
+			}
+		}()
+
+		next(ctx)
+		writeAccessLog(ctx, logger, config, start, statusOrDefault(ctx.Status(), httpStatusOK))
+	}
+}
+
+func withAccessLoggerDefaults(config AccessLoggerConfig) AccessLoggerConfig {
+	if config.Logger == nil {
+		config.Logger = slog.Default()
+	}
+	if config.Now == nil {
+		config.Now = time.Now
+	}
+	if config.StatusLevel == nil {
+		config.StatusLevel = defaultStatusLevel
+	}
+	if config.Preset == LogPresetGCP && config.GCP.CloudTraceContextHeader == "" {
+		config.GCP.CloudTraceContextHeader = "X-Cloud-Trace-Context"
+	}
+	return config
+}
+
+func requestLogger(ctx huma.Context, config AccessLoggerConfig) *slog.Logger {
+	attrs := loggerRequestAttrs(ctx, config)
+	if len(attrs) == 0 {
+		return config.Logger
+	}
+	args := make([]any, len(attrs))
+	for i := range attrs {
+		args[i] = attrs[i]
+	}
+	return config.Logger.With(args...)
+}
+
+func loggerRequestAttrs(ctx huma.Context, config AccessLoggerConfig) []slog.Attr {
+	info := requestInfo(ctx.Context())
+	switch config.Preset {
+	case LogPresetGCP:
+		return gcpRequestAttrs(ctx, config, info)
+	case LogPresetAWS:
+		return awsRequestAttrs(info)
+	default:
+		return genericRequestAttrs(info)
+	}
+}
+
+func writeAccessLog(ctx huma.Context, logger *slog.Logger, config AccessLoggerConfig, start time.Time, status int) {
+	attrs := accessAttrs(ctx, config, status, config.Now().Sub(start))
+	logger.LogAttrs(ctx.Context(), config.StatusLevel(status), "request completed", attrs...)
+}
+
+func accessAttrs(ctx huma.Context, config AccessLoggerConfig, status int, duration time.Duration) []slog.Attr {
+	info := requestInfo(ctx.Context())
+	switch config.Preset {
+	case LogPresetGCP:
+		return gcpAccessAttrs(ctx, config, info, status, duration)
+	case LogPresetAWS:
+		return awsAccessAttrs(ctx, info, status, duration, config.ExtraAttrs)
+	default:
+		return genericAccessAttrs(ctx, info, status, duration, config.ExtraAttrs)
+	}
+}
+
+func genericAccessAttrs(ctx huma.Context, info RequestInfo, status int, duration time.Duration, extra func(huma.Context) []slog.Attr) []slog.Attr {
+	attrs := []slog.Attr{
+		slog.String("method", ctx.Method()),
+		slog.Int("status", status),
+		slog.Float64("duration_ms", durationMilliseconds(duration)),
+	}
+	if op := ctx.Operation(); op != nil {
+		attrs = append(attrs, slog.String("path_template", op.Path))
+		if op.OperationID != "" {
+			attrs = append(attrs, slog.String("operation_id", op.OperationID))
+		}
+	}
+	attrs = append(attrs, genericRequestAttrs(info)...)
+	if extra != nil {
+		attrs = append(attrs, extra(ctx)...)
+	}
+	return attrs
+}
+
+func gcpAccessAttrs(ctx huma.Context, config AccessLoggerConfig, info RequestInfo, status int, duration time.Duration) []slog.Attr {
+	attrs := []slog.Attr{
+		slog.Group("httpRequest",
+			slog.String("requestMethod", ctx.Method()),
+			slog.String("requestUrl", ctx.URL().Path),
+			slog.Int("status", status),
+			slog.String("userAgent", ctx.Header("User-Agent")),
+			slog.String("remoteIp", ctx.RemoteAddr()),
+		),
+		slog.Float64("duration_ms", durationMilliseconds(duration)),
+	}
+	if op := ctx.Operation(); op != nil {
+		attrs = append(attrs, slog.String("pathTemplate", op.Path))
+		if op.OperationID != "" {
+			attrs = append(attrs, slog.String("operationId", op.OperationID))
+		}
+	}
+	attrs = append(attrs, gcpRequestAttrs(ctx, config, info)...)
+	if config.ExtraAttrs != nil {
+		attrs = append(attrs, config.ExtraAttrs(ctx)...)
+	}
+	return attrs
+}
+
+func awsAccessAttrs(ctx huma.Context, info RequestInfo, status int, duration time.Duration, extra func(huma.Context) []slog.Attr) []slog.Attr {
+	route := ""
+	if op := ctx.Operation(); op != nil {
+		route = op.Path
+	}
+	attrs := []slog.Attr{
+		slog.Group("http",
+			slog.Group("request",
+				slog.String("method", ctx.Method()),
+			),
+			slog.String("route", route),
+			slog.Group("response",
+				slog.Int("status_code", status),
+			),
+		),
+		slog.Float64("duration_ms", durationMilliseconds(duration)),
+	}
+	attrs = append(attrs, awsRequestAttrs(info)...)
+	if extra != nil {
+		attrs = append(attrs, extra(ctx)...)
+	}
+	return attrs
+}
+
+func genericRequestAttrs(info RequestInfo) []slog.Attr {
+	var attrs []slog.Attr
+	if info.RequestID != "" {
+		attrs = append(attrs, slog.String("request_id", info.RequestID))
+	}
+	if info.CorrelationID != "" {
+		attrs = append(attrs, slog.String("correlation_id", info.CorrelationID))
+	}
+	if info.Trace.Valid {
+		attrs = append(attrs,
+			slog.String("trace_id", info.Trace.TraceID),
+			slog.String("span_id", info.Trace.ParentID),
+			slog.Bool("sampled", info.Trace.Sampled),
+		)
+	}
+	return attrs
+}
+
+func gcpRequestAttrs(ctx huma.Context, config AccessLoggerConfig, info RequestInfo) []slog.Attr {
+	var attrs []slog.Attr
+	if info.RequestID != "" {
+		attrs = append(attrs, slog.String("requestId", info.RequestID))
+	}
+	if info.CorrelationID != "" {
+		attrs = append(attrs, slog.String("correlationId", info.CorrelationID))
+	}
+
+	traceID := ""
+	spanID := ""
+	sampled := false
+	if info.Trace.Valid {
+		traceID = info.Trace.TraceID
+		spanID = info.Trace.ParentID
+		sampled = info.Trace.Sampled
+	} else if config.GCP.CloudTraceContextHeader != "" {
+		trace := parseCloudTraceContext(ctx.Header(config.GCP.CloudTraceContextHeader))
+		if trace.Valid {
+			traceID = trace.TraceID
+			spanID = trace.SpanID
+			sampled = trace.Sampled
+		}
+	}
+
+	if traceID == "" {
+		return attrs
+	}
+	if config.GCP.ProjectID == "" {
+		return append(attrs, slog.String("traceId", traceID))
+	}
+	attrs = append(attrs, slog.String("logging.googleapis.com/trace", "projects/"+config.GCP.ProjectID+"/traces/"+traceID))
+	if spanID != "" {
+		attrs = append(attrs, slog.String("logging.googleapis.com/spanId", spanID))
+	}
+	return append(attrs, slog.Bool("logging.googleapis.com/trace_sampled", sampled))
+}
+
+func awsRequestAttrs(info RequestInfo) []slog.Attr {
+	var attrs []slog.Attr
+	if info.RequestID != "" {
+		attrs = append(attrs, slog.String("requestId", info.RequestID))
+	}
+	if info.CorrelationID != "" {
+		attrs = append(attrs, slog.String("correlationId", info.CorrelationID))
+	}
+	if info.Trace.Valid {
+		attrs = append(attrs,
+			slog.String("traceId", info.Trace.TraceID),
+			slog.String("spanId", info.Trace.ParentID),
+			slog.Bool("sampled", info.Trace.Sampled),
+		)
+	}
+	return attrs
+}
+
+func defaultStatusLevel(status int) slog.Level {
+	switch {
+	case status >= httpStatusInternalServerError:
+		return slog.LevelError
+	case status >= httpStatusBadRequest:
+		return slog.LevelWarn
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func statusOrDefault(status, defaultStatus int) int {
+	if status == 0 {
+		return defaultStatus
+	}
+	return status
+}
+
+func durationMilliseconds(duration time.Duration) float64 {
+	return float64(duration) / float64(time.Millisecond)
+}
+
+const (
+	httpStatusOK                  = 200
+	httpStatusBadRequest          = 400
+	httpStatusInternalServerError = 500
+)
+
+type cloudTraceContext struct {
+	TraceID string
+	SpanID  string
+	Sampled bool
+	Valid   bool
+}
+
+func parseCloudTraceContext(header string) cloudTraceContext {
+	if header == "" {
+		return cloudTraceContext{}
+	}
+	tracePart, options, _ := strings.Cut(header, ";")
+	traceID, spanID, ok := strings.Cut(tracePart, "/")
+	if !ok {
+		traceID = tracePart
+	}
+	if len(traceID) != traceIDSize || !isLowerHex(traceID) || allZero(traceID) {
+		return cloudTraceContext{}
+	}
+	if spanID != "" && !allDigits(spanID) {
+		return cloudTraceContext{}
+	}
+	return cloudTraceContext{
+		TraceID: traceID,
+		SpanID:  spanID,
+		Sampled: strings.Contains(options, "o=1"),
+		Valid:   true,
+	}
+}
+
+func allDigits(value string) bool {
+	for i := range len(value) {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -1,0 +1,171 @@
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"strconv"
+	"sync/atomic"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+const (
+	defaultRequestIDHeader  = "X-Request-Id"
+	defaultTraceparent      = "traceparent"
+	defaultTracestate       = "tracestate"
+	defaultRequestIDMaxSize = 128
+)
+
+type requestInfoKey struct{}
+
+var fallbackRequestID atomic.Uint64
+
+// RequestContextConfig configures the request context middleware.
+type RequestContextConfig struct {
+	// RequestIDHeader is the request header used to accept an existing request
+	// ID. The default is "X-Request-Id".
+	RequestIDHeader string
+
+	// TraceparentHeader is the request header used for W3C Trace Context. The
+	// default is "traceparent".
+	TraceparentHeader string
+
+	// TracestateHeader is the request header used for W3C Trace Context state.
+	// The default is "tracestate".
+	TracestateHeader string
+
+	// ResponseRequestIDHeader is the response header used to echo the request ID.
+	// The default is the configured RequestIDHeader.
+	ResponseRequestIDHeader string
+
+	// DisableResponseRequestIDHeader disables echoing the request ID in the
+	// response.
+	DisableResponseRequestIDHeader bool
+
+	// NewRequestID creates a request ID when the incoming request ID is missing
+	// or invalid. The default uses crypto/rand and returns 16 lowercase hex
+	// encoded random bytes.
+	NewRequestID func() string
+}
+
+// RequestInfo contains request-scoped correlation data.
+type RequestInfo struct {
+	// RequestID is the accepted or generated request ID.
+	RequestID string
+
+	// CorrelationID is the valid W3C trace ID when present, otherwise the
+	// request ID.
+	CorrelationID string
+
+	// Trace is the parsed W3C Trace Context data.
+	Trace TraceContext
+}
+
+// RequestContext returns middleware that parses request correlation data and
+// stores it on the underlying context.Context.
+func RequestContext(config RequestContextConfig) func(huma.Context, func(huma.Context)) {
+	config = withRequestContextDefaults(config)
+
+	return func(ctx huma.Context, next func(huma.Context)) {
+		requestID := ctx.Header(config.RequestIDHeader)
+		if !validRequestID(requestID) {
+			requestID = newRequestID(config.NewRequestID)
+		}
+
+		trace := ParseTraceparent(ctx.Header(config.TraceparentHeader))
+		if trace.Valid {
+			trace.Tracestate = ctx.Header(config.TracestateHeader)
+		}
+
+		correlationID := requestID
+		if trace.Valid {
+			correlationID = trace.TraceID
+		}
+
+		info := RequestInfo{
+			RequestID:     requestID,
+			CorrelationID: correlationID,
+			Trace:         trace,
+		}
+
+		if !config.DisableResponseRequestIDHeader {
+			ctx.SetHeader(config.ResponseRequestIDHeader, requestID)
+		}
+
+		next(huma.WithContext(ctx, context.WithValue(ctx.Context(), requestInfoKey{}, info)))
+	}
+}
+
+// RequestID returns the request ID stored in ctx, if any.
+func RequestID(ctx context.Context) string {
+	return requestInfo(ctx).RequestID
+}
+
+// CorrelationID returns the correlation ID stored in ctx, if any.
+func CorrelationID(ctx context.Context) string {
+	return requestInfo(ctx).CorrelationID
+}
+
+// Trace returns the W3C Trace Context stored in ctx, if any.
+func Trace(ctx context.Context) TraceContext {
+	return requestInfo(ctx).Trace
+}
+
+func requestInfo(ctx context.Context) RequestInfo {
+	if ctx == nil {
+		return RequestInfo{}
+	}
+	info, _ := ctx.Value(requestInfoKey{}).(RequestInfo)
+	return info
+}
+
+func withRequestContextDefaults(config RequestContextConfig) RequestContextConfig {
+	if config.RequestIDHeader == "" {
+		config.RequestIDHeader = defaultRequestIDHeader
+	}
+	if config.TraceparentHeader == "" {
+		config.TraceparentHeader = defaultTraceparent
+	}
+	if config.TracestateHeader == "" {
+		config.TracestateHeader = defaultTracestate
+	}
+	if config.ResponseRequestIDHeader == "" {
+		config.ResponseRequestIDHeader = config.RequestIDHeader
+	}
+	return config
+}
+
+func newRequestID(fn func() string) string {
+	if fn != nil {
+		if id := fn(); validRequestID(id) {
+			return id
+		}
+	}
+	return randomRequestID()
+}
+
+func randomRequestID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err == nil {
+		return hex.EncodeToString(b[:])
+	}
+	return "fallback-" + strconv.FormatUint(fallbackRequestID.Add(1), 16)
+}
+
+func validRequestID(id string) bool {
+	if len(id) == 0 || len(id) > defaultRequestIDMaxSize {
+		return false
+	}
+	for i := range len(id) {
+		switch c := id[i]; {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '-' || c == '_' || c == '.' || c == ':' || c == '/' || c == '=' || c == '+':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -21,18 +21,18 @@ type requestInfoKey struct{}
 
 var fallbackRequestID atomic.Uint64
 
-// RequestContextConfig configures the request context middleware.
+// RequestContextConfig configures RequestContext.
 type RequestContextConfig struct {
-	// RequestIDHeader is the request header used to accept an existing request
-	// ID. The default is "X-Request-Id".
+	// RequestIDHeader is the request header used to accept an existing request ID.
+	// The default is "X-Request-Id".
 	RequestIDHeader string
 
-	// TraceparentHeader is the request header used for W3C Trace Context. The
-	// default is "traceparent".
+	// TraceparentHeader is the W3C Trace Context traceparent header. The default
+	// is "traceparent".
 	TraceparentHeader string
 
-	// TracestateHeader is the request header used for W3C Trace Context state.
-	// The default is "tracestate".
+	// TracestateHeader is the W3C Trace Context tracestate header. The default is
+	// "tracestate".
 	TracestateHeader string
 
 	// ResponseRequestIDHeader is the response header used to echo the request ID.
@@ -43,9 +43,8 @@ type RequestContextConfig struct {
 	// response.
 	DisableResponseRequestIDHeader bool
 
-	// NewRequestID creates a request ID when the incoming request ID is missing
-	// or invalid. The default uses crypto/rand and returns 16 lowercase hex
-	// encoded random bytes.
+	// NewRequestID creates a request ID when the incoming request ID is missing or
+	// invalid. The default returns 16 random bytes encoded as lowercase hex.
 	NewRequestID func() string
 }
 
@@ -55,8 +54,8 @@ type requestInfo struct {
 	Trace         TraceContext
 }
 
-// RequestContext returns middleware that parses request correlation data and
-// stores it on the underlying context.Context.
+// RequestContext returns middleware that stores request ID and trace correlation
+// data on the underlying context.Context.
 func RequestContext(config RequestContextConfig) func(huma.Context, func(huma.Context)) {
 	config = withRequestContextDefaults(config)
 

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -49,17 +49,10 @@ type RequestContextConfig struct {
 	NewRequestID func() string
 }
 
-// RequestInfo contains request-scoped correlation data.
-type RequestInfo struct {
-	// RequestID is the accepted or generated request ID.
-	RequestID string
-
-	// CorrelationID is the valid W3C trace ID when present, otherwise the
-	// request ID.
+type requestInfo struct {
+	RequestID     string
 	CorrelationID string
-
-	// Trace is the parsed W3C Trace Context data.
-	Trace TraceContext
+	Trace         TraceContext
 }
 
 // RequestContext returns middleware that parses request correlation data and
@@ -83,7 +76,7 @@ func RequestContext(config RequestContextConfig) func(huma.Context, func(huma.Co
 			correlationID = trace.TraceID
 		}
 
-		info := RequestInfo{
+		info := requestInfo{
 			RequestID:     requestID,
 			CorrelationID: correlationID,
 			Trace:         trace,
@@ -99,24 +92,24 @@ func RequestContext(config RequestContextConfig) func(huma.Context, func(huma.Co
 
 // RequestID returns the request ID stored in ctx, if any.
 func RequestID(ctx context.Context) string {
-	return requestInfo(ctx).RequestID
+	return requestContextInfo(ctx).RequestID
 }
 
 // CorrelationID returns the correlation ID stored in ctx, if any.
 func CorrelationID(ctx context.Context) string {
-	return requestInfo(ctx).CorrelationID
+	return requestContextInfo(ctx).CorrelationID
 }
 
 // Trace returns the W3C Trace Context stored in ctx, if any.
 func Trace(ctx context.Context) TraceContext {
-	return requestInfo(ctx).Trace
+	return requestContextInfo(ctx).Trace
 }
 
-func requestInfo(ctx context.Context) RequestInfo {
+func requestContextInfo(ctx context.Context) requestInfo {
 	if ctx == nil {
-		return RequestInfo{}
+		return requestInfo{}
 	}
-	info, _ := ctx.Value(requestInfoKey{}).(RequestInfo)
+	info, _ := ctx.Value(requestInfoKey{}).(requestInfo)
 	return info
 }
 

--- a/middleware/context_test.go
+++ b/middleware/context_test.go
@@ -104,6 +104,27 @@ func TestRequestContextRejectsUnsafeRequestID(t *testing.T) {
 	}
 }
 
+func TestRequestContextAcceptsSafeRequestID(t *testing.T) {
+	_, api := humatest.New(t)
+	api.UseMiddleware(middleware.RequestContext(middleware.RequestContextConfig{
+		NewRequestID: func() string { return "generated-id" },
+	}))
+
+	var gotRequestID string
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		gotRequestID = middleware.RequestID(ctx)
+		return &struct{}{}, nil
+	})
+
+	resp := api.Get("/test", "X-Request-Id: client-id_123")
+	if gotRequestID != "client-id_123" {
+		t.Fatalf("RequestID = %q, want client-id_123", gotRequestID)
+	}
+	if header := resp.Header().Get("X-Request-Id"); header != "client-id_123" {
+		t.Fatalf("response request ID header = %q, want client-id_123", header)
+	}
+}
+
 func TestRequestContextCanDisableResponseHeader(t *testing.T) {
 	_, api := humatest.New(t)
 	api.UseMiddleware(middleware.RequestContext(middleware.RequestContextConfig{

--- a/middleware/context_test.go
+++ b/middleware/context_test.go
@@ -83,6 +83,50 @@ func TestRequestContextTraceparent(t *testing.T) {
 	}
 }
 
+func TestRequestContextCustomHeaders(t *testing.T) {
+	const traceparent = "00-3d23d071b5bfd6579171efce907685cb-08f067aa0ba902b7-01"
+
+	_, api := humatest.New(t)
+	api.UseMiddleware(middleware.RequestContext(middleware.RequestContextConfig{
+		RequestIDHeader:         "X-Correlation-Id",
+		TraceparentHeader:       "X-Traceparent",
+		TracestateHeader:        "X-Tracestate",
+		ResponseRequestIDHeader: "X-Response-Request-Id",
+		NewRequestID:            func() string { return "generated-id" },
+	}))
+
+	var gotRequestID string
+	var gotCorrelationID string
+	var gotTrace middleware.TraceContext
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		gotRequestID = middleware.RequestID(ctx)
+		gotCorrelationID = middleware.CorrelationID(ctx)
+		gotTrace = middleware.Trace(ctx)
+		return &struct{}{}, nil
+	})
+
+	resp := api.Get("/test",
+		"X-Correlation-Id: client-id",
+		"X-Traceparent: "+traceparent,
+		"X-Tracestate: congo=t61rcWkgMzE",
+	)
+	if header := resp.Header().Get("X-Response-Request-Id"); header != "client-id" {
+		t.Fatalf("response request ID header = %q, want client-id", header)
+	}
+	if gotRequestID != "client-id" {
+		t.Fatalf("RequestID = %q, want client-id", gotRequestID)
+	}
+	if gotCorrelationID != "3d23d071b5bfd6579171efce907685cb" {
+		t.Fatalf("CorrelationID = %q, want trace ID", gotCorrelationID)
+	}
+	if !gotTrace.Valid {
+		t.Fatal("Trace.Valid = false, want true")
+	}
+	if gotTrace.Tracestate != "congo=t61rcWkgMzE" {
+		t.Fatalf("Trace.Tracestate = %q, want custom tracestate", gotTrace.Tracestate)
+	}
+}
+
 func TestRequestContextRejectsUnsafeRequestID(t *testing.T) {
 	_, api := humatest.New(t)
 	api.UseMiddleware(middleware.RequestContext(middleware.RequestContextConfig{

--- a/middleware/context_test.go
+++ b/middleware/context_test.go
@@ -1,0 +1,152 @@
+package middleware_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/danielgtaylor/huma/v2/middleware"
+)
+
+func TestRequestContextDefaults(t *testing.T) {
+	_, api := humatest.New(t)
+	api.UseMiddleware(middleware.RequestContext(middleware.RequestContextConfig{
+		NewRequestID: func() string { return "req-123" },
+	}))
+
+	var gotRequestID string
+	var gotCorrelationID string
+	var gotTrace middleware.TraceContext
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		gotRequestID = middleware.RequestID(ctx)
+		gotCorrelationID = middleware.CorrelationID(ctx)
+		gotTrace = middleware.Trace(ctx)
+		return &struct{}{}, nil
+	})
+
+	resp := api.Get("/test")
+	if header := resp.Header().Get("X-Request-Id"); header != "req-123" {
+		t.Fatalf("response request ID header = %q, want req-123", header)
+	}
+	if gotRequestID != "req-123" {
+		t.Fatalf("RequestID = %q, want req-123", gotRequestID)
+	}
+	if gotCorrelationID != "req-123" {
+		t.Fatalf("CorrelationID = %q, want req-123", gotCorrelationID)
+	}
+	if gotTrace.Valid {
+		t.Fatal("Trace.Valid = true, want false")
+	}
+}
+
+func TestRequestContextTraceparent(t *testing.T) {
+	const traceparent = "00-3d23d071b5bfd6579171efce907685cb-08f067aa0ba902b7-03"
+	const tracestate = "congo=t61rcWkgMzE"
+
+	_, api := humatest.New(t)
+	api.UseMiddleware(middleware.RequestContext(middleware.RequestContextConfig{
+		NewRequestID: func() string { return "req-123" },
+	}))
+
+	var gotRequestID string
+	var gotCorrelationID string
+	var gotTrace middleware.TraceContext
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		gotRequestID = middleware.RequestID(ctx)
+		gotCorrelationID = middleware.CorrelationID(ctx)
+		gotTrace = middleware.Trace(ctx)
+		return &struct{}{}, nil
+	})
+
+	resp := api.Get("/test", "traceparent: "+traceparent, "tracestate: "+tracestate)
+	if header := resp.Header().Get("X-Request-Id"); header != "req-123" {
+		t.Fatalf("response request ID header = %q, want req-123", header)
+	}
+	if gotRequestID != "req-123" {
+		t.Fatalf("RequestID = %q, want req-123", gotRequestID)
+	}
+	if gotCorrelationID != "3d23d071b5bfd6579171efce907685cb" {
+		t.Fatalf("CorrelationID = %q, want trace ID", gotCorrelationID)
+	}
+	if !gotTrace.Valid {
+		t.Fatal("Trace.Valid = false, want true")
+	}
+	if !gotTrace.Sampled {
+		t.Fatal("Trace.Sampled = false, want true")
+	}
+	if gotTrace.Tracestate != tracestate {
+		t.Fatalf("Trace.Tracestate = %q, want %q", gotTrace.Tracestate, tracestate)
+	}
+}
+
+func TestRequestContextRejectsUnsafeRequestID(t *testing.T) {
+	_, api := humatest.New(t)
+	api.UseMiddleware(middleware.RequestContext(middleware.RequestContextConfig{
+		NewRequestID: func() string { return "safe-id" },
+	}))
+
+	var gotRequestID string
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		gotRequestID = middleware.RequestID(ctx)
+		return &struct{}{}, nil
+	})
+
+	resp := api.Get("/test", "X-Request-Id: bad id")
+	if gotRequestID != "safe-id" {
+		t.Fatalf("RequestID = %q, want safe-id", gotRequestID)
+	}
+	if header := resp.Header().Get("X-Request-Id"); header != "safe-id" {
+		t.Fatalf("response request ID header = %q, want safe-id", header)
+	}
+}
+
+func TestRequestContextCanDisableResponseHeader(t *testing.T) {
+	_, api := humatest.New(t)
+	api.UseMiddleware(middleware.RequestContext(middleware.RequestContextConfig{
+		NewRequestID:                   func() string { return "req-123" },
+		DisableResponseRequestIDHeader: true,
+	}))
+
+	var gotRequestID string
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		gotRequestID = middleware.RequestID(ctx)
+		return &struct{}{}, nil
+	})
+
+	resp := api.Get("/test")
+	if gotRequestID != "req-123" {
+		t.Fatalf("RequestID = %q, want req-123", gotRequestID)
+	}
+	if header := resp.Header().Get("X-Request-Id"); header != "" {
+		t.Fatalf("response request ID header = %q, want empty", header)
+	}
+}
+
+func TestRequestContextHumagoAdapter(t *testing.T) {
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	api.UseMiddleware(middleware.RequestContext(middleware.RequestContextConfig{
+		NewRequestID: func() string { return "humago-id" },
+	}))
+
+	var gotRequestID string
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		gotRequestID = middleware.RequestID(ctx)
+		return &struct{}{}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	resp := httptest.NewRecorder()
+	mux.ServeHTTP(resp, req)
+
+	if gotRequestID != "humago-id" {
+		t.Fatalf("RequestID = %q, want humago-id", gotRequestID)
+	}
+	if header := resp.Header().Get("X-Request-Id"); header != "humago-id" {
+		t.Fatalf("response request ID header = %q, want humago-id", header)
+	}
+}

--- a/middleware/doc.go
+++ b/middleware/doc.go
@@ -1,2 +1,0 @@
-// Package middleware provides router-agnostic Huma middleware helpers.
-package middleware

--- a/middleware/doc.go
+++ b/middleware/doc.go
@@ -1,0 +1,2 @@
+// Package middleware provides router-agnostic Huma middleware helpers.
+package middleware

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -11,8 +11,7 @@ import (
 
 type loggerKey struct{}
 
-// LogPreset configures JSON and access-log field names for common log
-// aggregation targets.
+// LogPreset configures JSON and access-log field names for common targets.
 type LogPreset string
 
 const (
@@ -22,7 +21,7 @@ const (
 	// LogPresetGCP uses Google Cloud Logging field names.
 	LogPresetGCP LogPreset = "gcp"
 
-	// LogPresetAWS uses AWS CloudWatch-friendly field names.
+	// LogPresetAWS uses AWS CloudWatch Logs-friendly field names.
 	LogPresetAWS LogPreset = "aws"
 
 	// LogPresetAzure uses Azure Monitor-friendly field names.
@@ -37,9 +36,8 @@ type JSONLoggerConfig struct {
 	// Level is the minimum enabled log level.
 	Level slog.Leveler
 
-	// Preset configures built-in JSON field names for a log aggregation target.
-	// Use the same value for AccessLoggerConfig.Preset when composing
-	// NewJSONLogger with AccessLogger.
+	// Preset configures built-in JSON field names. Use the same value for
+	// AccessLoggerConfig.Preset when composing NewJSONLogger with AccessLogger.
 	Preset LogPreset
 
 	// ReplaceAttr optionally rewrites attributes after the preset mapping has

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -11,7 +11,8 @@ import (
 
 type loggerKey struct{}
 
-// LogPreset configures JSON field names for common log aggregation targets.
+// LogPreset configures JSON and access-log field names for common log
+// aggregation targets.
 type LogPreset string
 
 const (
@@ -23,6 +24,9 @@ const (
 
 	// LogPresetAWS uses AWS CloudWatch-friendly field names.
 	LogPresetAWS LogPreset = "aws"
+
+	// LogPresetAzure uses Azure Monitor-friendly field names.
+	LogPresetAzure LogPreset = "azure"
 )
 
 // JSONLoggerConfig configures NewJSONLogger.
@@ -33,7 +37,9 @@ type JSONLoggerConfig struct {
 	// Level is the minimum enabled log level.
 	Level slog.Leveler
 
-	// Preset configures built-in field names for a log aggregation target.
+	// Preset configures built-in JSON field names for a log aggregation target.
+	// Use the same value for AccessLoggerConfig.Preset when composing
+	// NewJSONLogger with AccessLogger.
 	Preset LogPreset
 
 	// ReplaceAttr optionally rewrites attributes after the preset mapping has
@@ -64,8 +70,9 @@ func NewJSONLogger(config JSONLoggerConfig) *slog.Logger {
 	return slog.New(slog.NewJSONHandler(writer, opts))
 }
 
-// Logger returns the request-scoped logger stored in ctx, or slog.Default().
-func Logger(ctx context.Context) *slog.Logger {
+// RequestLogger returns the request-scoped logger stored in ctx, or
+// slog.Default().
+func RequestLogger(ctx context.Context) *slog.Logger {
 	if ctx == nil {
 		return slog.Default()
 	}
@@ -107,6 +114,15 @@ func replacePresetAttr(preset LogPreset, groups []string, attr slog.Attr) slog.A
 		case slog.TimeKey:
 			attr.Key = "timestamp"
 		}
+	case LogPresetAzure:
+		switch attr.Key {
+		case slog.LevelKey:
+			attr.Value = slog.StringValue(azureLevel(attr.Value))
+		case slog.MessageKey:
+			attr.Key = "message"
+		case slog.TimeKey:
+			attr.Key = "timestamp"
+		}
 	}
 
 	return attr
@@ -137,4 +153,25 @@ func levelString(value slog.Value) string {
 		return value.String()
 	}
 	return level.String()
+}
+
+func azureLevel(value slog.Value) string {
+	level, ok := value.Any().(slog.Level)
+	if !ok {
+		return value.String()
+	}
+	switch {
+	case level >= slog.LevelError+4:
+		return "CRITICAL"
+	case level >= slog.LevelError:
+		return "ERROR"
+	case level >= slog.LevelWarn:
+		return "WARNING"
+	case level >= slog.LevelInfo:
+		return "INFO"
+	case level >= slog.LevelDebug:
+		return "DEBUG"
+	default:
+		return "TRACE"
+	}
 }

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -1,0 +1,140 @@
+package middleware
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type loggerKey struct{}
+
+// LogPreset configures JSON field names for common log aggregation targets.
+type LogPreset string
+
+const (
+	// LogPresetDefault uses slog's standard JSON field names.
+	LogPresetDefault LogPreset = ""
+
+	// LogPresetGCP uses Google Cloud Logging field names.
+	LogPresetGCP LogPreset = "gcp"
+
+	// LogPresetAWS uses AWS CloudWatch-friendly field names.
+	LogPresetAWS LogPreset = "aws"
+)
+
+// JSONLoggerConfig configures NewJSONLogger.
+type JSONLoggerConfig struct {
+	// Writer receives JSON log lines. The default is os.Stdout.
+	Writer io.Writer
+
+	// Level is the minimum enabled log level.
+	Level slog.Leveler
+
+	// Preset configures built-in field names for a log aggregation target.
+	Preset LogPreset
+
+	// ReplaceAttr optionally rewrites attributes after the preset mapping has
+	// been applied.
+	ReplaceAttr func(groups []string, attr slog.Attr) slog.Attr
+}
+
+// NewJSONLogger creates a slog JSON logger with optional field-name presets.
+func NewJSONLogger(config JSONLoggerConfig) *slog.Logger {
+	writer := config.Writer
+	if writer == nil {
+		writer = os.Stdout
+	}
+
+	opts := &slog.HandlerOptions{
+		Level: config.Level,
+	}
+	if config.Preset != LogPresetDefault || config.ReplaceAttr != nil {
+		opts.ReplaceAttr = func(groups []string, attr slog.Attr) slog.Attr {
+			attr = replacePresetAttr(config.Preset, groups, attr)
+			if config.ReplaceAttr != nil {
+				attr = config.ReplaceAttr(groups, attr)
+			}
+			return attr
+		}
+	}
+
+	return slog.New(slog.NewJSONHandler(writer, opts))
+}
+
+// Logger returns the request-scoped logger stored in ctx, or slog.Default().
+func Logger(ctx context.Context) *slog.Logger {
+	if ctx == nil {
+		return slog.Default()
+	}
+	if logger, ok := ctx.Value(loggerKey{}).(*slog.Logger); ok && logger != nil {
+		return logger
+	}
+	return slog.Default()
+}
+
+func withLogger(ctx huma.Context, logger *slog.Logger) huma.Context {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return huma.WithContext(ctx, context.WithValue(ctx.Context(), loggerKey{}, logger))
+}
+
+func replacePresetAttr(preset LogPreset, groups []string, attr slog.Attr) slog.Attr {
+	if len(groups) != 0 {
+		return attr
+	}
+
+	switch preset {
+	case LogPresetGCP:
+		switch attr.Key {
+		case slog.LevelKey:
+			attr.Key = "severity"
+			attr.Value = slog.StringValue(gcpSeverity(attr.Value))
+		case slog.MessageKey:
+			attr.Key = "message"
+		case slog.TimeKey:
+			attr.Key = "timestamp"
+		}
+	case LogPresetAWS:
+		switch attr.Key {
+		case slog.LevelKey:
+			attr.Value = slog.StringValue(levelString(attr.Value))
+		case slog.MessageKey:
+			attr.Key = "message"
+		case slog.TimeKey:
+			attr.Key = "timestamp"
+		}
+	}
+
+	return attr
+}
+
+func gcpSeverity(value slog.Value) string {
+	level, ok := value.Any().(slog.Level)
+	if !ok {
+		return value.String()
+	}
+	switch {
+	case level >= slog.LevelError:
+		return "ERROR"
+	case level >= slog.LevelWarn:
+		return "WARNING"
+	case level >= slog.LevelInfo:
+		return "INFO"
+	case level >= slog.LevelDebug:
+		return "DEBUG"
+	default:
+		return "DEFAULT"
+	}
+}
+
+func levelString(value slog.Value) string {
+	level, ok := value.Any().(slog.Level)
+	if !ok {
+		return value.String()
+	}
+	return level.String()
+}

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -189,6 +189,46 @@ func TestAccessLoggerGCPPreset(t *testing.T) {
 	if httpRequest["requestMethod"] != http.MethodGet {
 		t.Fatalf("httpRequest.requestMethod = %v, want GET", httpRequest["requestMethod"])
 	}
+	if httpRequest["latency"] != "0.001s" {
+		t.Fatalf("httpRequest.latency = %v, want 0.001s", httpRequest["latency"])
+	}
+}
+
+func TestAccessLoggerGCPTraceWithoutProjectID(t *testing.T) {
+	const traceparent = "00-3d23d071b5bfd6579171efce907685cb-08f067aa0ba902b7-01"
+
+	var buf bytes.Buffer
+	_, api := humatest.New(t)
+	api.UseMiddleware(
+		middleware.RequestContext(middleware.RequestContextConfig{
+			NewRequestID: func() string { return "req-123" },
+		}),
+		middleware.AccessLogger(middleware.AccessLoggerConfig{
+			Logger: middleware.NewJSONLogger(middleware.JSONLoggerConfig{
+				Writer: &buf,
+				Preset: middleware.LogPresetGCP,
+			}),
+			Preset: middleware.LogPresetGCP,
+			Now:    sequenceNow(time.Unix(100, 0), time.Unix(100, int64(time.Millisecond))),
+		}),
+	)
+
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		return &struct{}{}, nil
+	})
+
+	api.Get("/test", "traceparent: "+traceparent)
+
+	entry := decodeLogEntries(t, &buf)[0]
+	if entry["logging.googleapis.com/trace"] != "3d23d071b5bfd6579171efce907685cb" {
+		t.Fatalf("trace field = %v", entry["logging.googleapis.com/trace"])
+	}
+	if _, ok := entry["traceId"]; ok {
+		t.Fatalf("GCP log should use Cloud Logging trace field, not plain traceId: %#v", entry)
+	}
+	if entry["logging.googleapis.com/trace_sampled"] != true {
+		t.Fatalf("trace_sampled = %v, want true", entry["logging.googleapis.com/trace_sampled"])
+	}
 }
 
 func TestAccessLoggerAWSCloudWatchShape(t *testing.T) {

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -55,6 +55,27 @@ func TestNewJSONLoggerPresets(t *testing.T) {
 			t.Fatalf("GCP log should not include msg: %#v", entry)
 		}
 	})
+
+	t.Run("azure", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := middleware.NewJSONLogger(middleware.JSONLoggerConfig{
+			Writer: &buf,
+			Preset: middleware.LogPresetAzure,
+		})
+
+		logger.Warn("slow")
+
+		entry := decodeLogEntries(t, &buf)[0]
+		if entry["message"] != "slow" {
+			t.Fatalf("message = %v, want slow", entry["message"])
+		}
+		if entry["level"] != "WARNING" {
+			t.Fatalf("level = %v, want WARNING", entry["level"])
+		}
+		if _, ok := entry["msg"]; ok {
+			t.Fatalf("Azure log should not include msg: %#v", entry)
+		}
+	})
 }
 
 func TestAccessLoggerGeneric(t *testing.T) {
@@ -71,7 +92,7 @@ func TestAccessLoggerGeneric(t *testing.T) {
 	)
 
 	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{ Status int }, error) {
-		middleware.Logger(ctx).InfoContext(ctx, "handler")
+		middleware.RequestLogger(ctx).InfoContext(ctx, "handler")
 		return &struct{ Status int }{Status: http.StatusCreated}, nil
 	})
 
@@ -141,8 +162,14 @@ func TestAccessLoggerGCPPreset(t *testing.T) {
 	if entry["logging.googleapis.com/trace"] != "projects/test-project/traces/3d23d071b5bfd6579171efce907685cb" {
 		t.Fatalf("trace field = %v", entry["logging.googleapis.com/trace"])
 	}
-	if entry["logging.googleapis.com/spanId"] != "08f067aa0ba902b7" {
-		t.Fatalf("span field = %v", entry["logging.googleapis.com/spanId"])
+	if entry["parentId"] != "08f067aa0ba902b7" {
+		t.Fatalf("parentId = %v, want 08f067aa0ba902b7", entry["parentId"])
+	}
+	if entry["traceFlags"] != "01" {
+		t.Fatalf("traceFlags = %v, want 01", entry["traceFlags"])
+	}
+	if _, ok := entry["logging.googleapis.com/spanId"]; ok {
+		t.Fatalf("GCP log should not emit spanId without an active span: %#v", entry)
 	}
 	if entry["logging.googleapis.com/trace_sampled"] != true {
 		t.Fatalf("trace_sampled = %v, want true", entry["logging.googleapis.com/trace_sampled"])
@@ -154,6 +181,8 @@ func TestAccessLoggerGCPPreset(t *testing.T) {
 }
 
 func TestAccessLoggerAWSCloudWatchShape(t *testing.T) {
+	const traceparent = "00-3d23d071b5bfd6579171efce907685cb-08f067aa0ba902b7-01"
+
 	var buf bytes.Buffer
 	_, api := humatest.New(t)
 	api.UseMiddleware(
@@ -177,7 +206,7 @@ func TestAccessLoggerAWSCloudWatchShape(t *testing.T) {
 		return &struct{ Status int }{Status: http.StatusNoContent}, nil
 	})
 
-	api.Get("/test")
+	api.Get("/test", "traceparent: "+traceparent)
 
 	entry := decodeLogEntries(t, &buf)[0]
 	if entry["message"] != "request completed" {
@@ -186,6 +215,18 @@ func TestAccessLoggerAWSCloudWatchShape(t *testing.T) {
 	if entry["requestId"] != "req-123" {
 		t.Fatalf("requestId = %v, want req-123", entry["requestId"])
 	}
+	if entry["traceId"] != "3d23d071b5bfd6579171efce907685cb" {
+		t.Fatalf("traceId = %v, want trace ID", entry["traceId"])
+	}
+	if entry["parentId"] != "08f067aa0ba902b7" {
+		t.Fatalf("parentId = %v, want parent ID", entry["parentId"])
+	}
+	if entry["traceFlags"] != "01" {
+		t.Fatalf("traceFlags = %v, want 01", entry["traceFlags"])
+	}
+	if _, ok := entry["spanId"]; ok {
+		t.Fatalf("AWS log should not emit spanId without an active span: %#v", entry)
+	}
 	if entry["service"] != "billing" {
 		t.Fatalf("service = %v, want billing", entry["service"])
 	}
@@ -193,6 +234,112 @@ func TestAccessLoggerAWSCloudWatchShape(t *testing.T) {
 	response := httpGroup["response"].(map[string]any)
 	if response["status_code"] != float64(http.StatusNoContent) {
 		t.Fatalf("http.response.status_code = %v, want 204", response["status_code"])
+	}
+}
+
+func TestAccessLoggerAzureMonitorShape(t *testing.T) {
+	const traceparent = "00-3d23d071b5bfd6579171efce907685cb-08f067aa0ba902b7-01"
+
+	var buf bytes.Buffer
+	_, api := humatest.New(t)
+	api.UseMiddleware(
+		middleware.RequestContext(middleware.RequestContextConfig{
+			NewRequestID: func() string { return "req-123" },
+		}),
+		middleware.AccessLogger(middleware.AccessLoggerConfig{
+			Logger: middleware.NewJSONLogger(middleware.JSONLoggerConfig{
+				Writer: &buf,
+				Preset: middleware.LogPresetAzure,
+			}),
+			Preset: middleware.LogPresetAzure,
+			Now:    sequenceNow(time.Unix(100, 0), time.Unix(100, int64(time.Millisecond))),
+		}),
+	)
+
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{ Status int }, error) {
+		return &struct{ Status int }{Status: http.StatusAccepted}, nil
+	})
+
+	api.Get("/test", "traceparent: "+traceparent)
+
+	entry := decodeLogEntries(t, &buf)[0]
+	if entry["message"] != "request completed" {
+		t.Fatalf("message = %v, want request completed", entry["message"])
+	}
+	if entry["level"] != "INFO" {
+		t.Fatalf("level = %v, want INFO", entry["level"])
+	}
+	if entry["operationId"] != "3d23d071b5bfd6579171efce907685cb" {
+		t.Fatalf("operationId = %v, want trace ID", entry["operationId"])
+	}
+	if entry["traceId"] != "3d23d071b5bfd6579171efce907685cb" {
+		t.Fatalf("traceId = %v, want trace ID", entry["traceId"])
+	}
+	if entry["parentId"] != "08f067aa0ba902b7" {
+		t.Fatalf("parentId = %v, want parent ID", entry["parentId"])
+	}
+	if entry["traceFlags"] != "01" {
+		t.Fatalf("traceFlags = %v, want 01", entry["traceFlags"])
+	}
+	httpGroup := entry["http"].(map[string]any)
+	response := httpGroup["response"].(map[string]any)
+	if response["status_code"] != float64(http.StatusAccepted) {
+		t.Fatalf("http.response.status_code = %v, want 202", response["status_code"])
+	}
+}
+
+func TestAccessLoggerGCPCloudTraceContextSampleOption(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+		sampled bool
+	}{
+		{
+			name:    "sampled",
+			header:  "3d23d071b5bfd6579171efce907685cb/123;o=1",
+			sampled: true,
+		},
+		{
+			name:   "not substring matched",
+			header: "3d23d071b5bfd6579171efce907685cb/123;o=10",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			_, api := humatest.New(t)
+			api.UseMiddleware(
+				middleware.RequestContext(middleware.RequestContextConfig{
+					NewRequestID: func() string { return "req-123" },
+				}),
+				middleware.AccessLogger(middleware.AccessLoggerConfig{
+					Logger: middleware.NewJSONLogger(middleware.JSONLoggerConfig{
+						Writer: &buf,
+						Preset: middleware.LogPresetGCP,
+					}),
+					Preset: middleware.LogPresetGCP,
+					GCP: middleware.GCPConfig{
+						ProjectID: "test-project",
+					},
+					Now: sequenceNow(time.Unix(100, 0), time.Unix(100, int64(time.Millisecond))),
+				}),
+			)
+
+			huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+				return &struct{}{}, nil
+			})
+
+			api.Get("/test", "X-Cloud-Trace-Context: "+tc.header)
+
+			entry := decodeLogEntries(t, &buf)[0]
+			if entry["logging.googleapis.com/trace"] != "projects/test-project/traces/3d23d071b5bfd6579171efce907685cb" {
+				t.Fatalf("trace field = %v", entry["logging.googleapis.com/trace"])
+			}
+			if entry["logging.googleapis.com/trace_sampled"] != tc.sampled {
+				t.Fatalf("trace_sampled = %v, want %v", entry["logging.googleapis.com/trace_sampled"], tc.sampled)
+			}
+		})
 	}
 }
 
@@ -263,8 +410,8 @@ func sequenceNow(times ...time.Time) func() time.Time {
 	}
 }
 
-func TestLoggerFallback(t *testing.T) {
-	if middleware.Logger(nil) == nil {
-		t.Fatal("Logger(nil) returned nil")
+func TestRequestLoggerFallback(t *testing.T) {
+	if middleware.RequestLogger(nil) == nil {
+		t.Fatal("RequestLogger(nil) returned nil")
 	}
 }

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -137,6 +137,37 @@ func TestAccessLoggerGeneric(t *testing.T) {
 	}
 }
 
+func TestAccessLoggerUsesHandlerErrorStatus(t *testing.T) {
+	var buf bytes.Buffer
+	_, api := humatest.New(t)
+	api.UseMiddleware(
+		middleware.RequestContext(middleware.RequestContextConfig{
+			NewRequestID: func() string { return "req-123" },
+		}),
+		middleware.AccessLogger(middleware.AccessLoggerConfig{
+			Logger: middleware.NewJSONLogger(middleware.JSONLoggerConfig{Writer: &buf}),
+			Now:    sequenceNow(time.Unix(100, 0), time.Unix(100, int64(time.Millisecond))),
+		}),
+	)
+
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		return nil, huma.Error403Forbidden("denied")
+	})
+
+	resp := api.Get("/test")
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("response status = %d, want 403", resp.Code)
+	}
+
+	entry := decodeLogEntries(t, &buf)[0]
+	if entry["level"] != "WARN" {
+		t.Fatalf("level = %v, want WARN", entry["level"])
+	}
+	if entry["status"] != float64(http.StatusForbidden) {
+		t.Fatalf("status = %v, want 403", entry["status"])
+	}
+}
+
 func TestAccessLoggerGCPPreset(t *testing.T) {
 	const traceparent = "00-3d23d071b5bfd6579171efce907685cb-08f067aa0ba902b7-01"
 

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -1,0 +1,270 @@
+package middleware_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/danielgtaylor/huma/v2/middleware"
+)
+
+func TestNewJSONLoggerPresets(t *testing.T) {
+	t.Run("generic", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := middleware.NewJSONLogger(middleware.JSONLoggerConfig{Writer: &buf})
+
+		logger.Info("hello")
+
+		entry := decodeLogEntries(t, &buf)[0]
+		if entry["msg"] != "hello" {
+			t.Fatalf("msg = %v, want hello", entry["msg"])
+		}
+		if entry["level"] != "INFO" {
+			t.Fatalf("level = %v, want INFO", entry["level"])
+		}
+		if _, ok := entry["severity"]; ok {
+			t.Fatalf("generic log should not include severity: %#v", entry)
+		}
+	})
+
+	t.Run("gcp", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := middleware.NewJSONLogger(middleware.JSONLoggerConfig{
+			Writer: &buf,
+			Preset: middleware.LogPresetGCP,
+		})
+
+		logger.Warn("slow")
+
+		entry := decodeLogEntries(t, &buf)[0]
+		if entry["message"] != "slow" {
+			t.Fatalf("message = %v, want slow", entry["message"])
+		}
+		if entry["severity"] != "WARNING" {
+			t.Fatalf("severity = %v, want WARNING", entry["severity"])
+		}
+		if _, ok := entry["msg"]; ok {
+			t.Fatalf("GCP log should not include msg: %#v", entry)
+		}
+	})
+}
+
+func TestAccessLoggerGeneric(t *testing.T) {
+	var buf bytes.Buffer
+	_, api := humatest.New(t)
+	api.UseMiddleware(
+		middleware.RequestContext(middleware.RequestContextConfig{
+			NewRequestID: func() string { return "req-123" },
+		}),
+		middleware.AccessLogger(middleware.AccessLoggerConfig{
+			Logger: middleware.NewJSONLogger(middleware.JSONLoggerConfig{Writer: &buf}),
+			Now:    sequenceNow(time.Unix(100, 0), time.Unix(100, int64(1500*time.Millisecond))),
+		}),
+	)
+
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{ Status int }, error) {
+		middleware.Logger(ctx).InfoContext(ctx, "handler")
+		return &struct{ Status int }{Status: http.StatusCreated}, nil
+	})
+
+	api.Get("/test")
+
+	entries := decodeLogEntries(t, &buf)
+	if len(entries) != 2 {
+		t.Fatalf("log entries = %d, want 2", len(entries))
+	}
+	if entries[0]["request_id"] != "req-123" {
+		t.Fatalf("handler request_id = %v, want req-123", entries[0]["request_id"])
+	}
+
+	access := entries[1]
+	if access["msg"] != "request completed" {
+		t.Fatalf("access msg = %v, want request completed", access["msg"])
+	}
+	if access["method"] != http.MethodGet {
+		t.Fatalf("method = %v, want GET", access["method"])
+	}
+	if access["path_template"] != "/test" {
+		t.Fatalf("path_template = %v, want /test", access["path_template"])
+	}
+	if access["status"] != float64(http.StatusCreated) {
+		t.Fatalf("status = %v, want 201", access["status"])
+	}
+	if access["duration_ms"] != float64(1500) {
+		t.Fatalf("duration_ms = %v, want 1500", access["duration_ms"])
+	}
+}
+
+func TestAccessLoggerGCPPreset(t *testing.T) {
+	const traceparent = "00-3d23d071b5bfd6579171efce907685cb-08f067aa0ba902b7-01"
+
+	var buf bytes.Buffer
+	_, api := humatest.New(t)
+	api.UseMiddleware(
+		middleware.RequestContext(middleware.RequestContextConfig{
+			NewRequestID: func() string { return "req-123" },
+		}),
+		middleware.AccessLogger(middleware.AccessLoggerConfig{
+			Logger: middleware.NewJSONLogger(middleware.JSONLoggerConfig{
+				Writer: &buf,
+				Preset: middleware.LogPresetGCP,
+			}),
+			Preset: middleware.LogPresetGCP,
+			GCP: middleware.GCPConfig{
+				ProjectID: "test-project",
+			},
+			Now: sequenceNow(time.Unix(100, 0), time.Unix(100, int64(time.Millisecond))),
+		}),
+	)
+
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{ Status int }, error) {
+		return &struct{ Status int }{Status: http.StatusOK}, nil
+	})
+
+	api.Get("/test", "traceparent: "+traceparent)
+
+	entry := decodeLogEntries(t, &buf)[0]
+	if entry["message"] != "request completed" {
+		t.Fatalf("message = %v, want request completed", entry["message"])
+	}
+	if entry["severity"] != "INFO" {
+		t.Fatalf("severity = %v, want INFO", entry["severity"])
+	}
+	if entry["logging.googleapis.com/trace"] != "projects/test-project/traces/3d23d071b5bfd6579171efce907685cb" {
+		t.Fatalf("trace field = %v", entry["logging.googleapis.com/trace"])
+	}
+	if entry["logging.googleapis.com/spanId"] != "08f067aa0ba902b7" {
+		t.Fatalf("span field = %v", entry["logging.googleapis.com/spanId"])
+	}
+	if entry["logging.googleapis.com/trace_sampled"] != true {
+		t.Fatalf("trace_sampled = %v, want true", entry["logging.googleapis.com/trace_sampled"])
+	}
+	httpRequest := entry["httpRequest"].(map[string]any)
+	if httpRequest["requestMethod"] != http.MethodGet {
+		t.Fatalf("httpRequest.requestMethod = %v, want GET", httpRequest["requestMethod"])
+	}
+}
+
+func TestAccessLoggerAWSCloudWatchShape(t *testing.T) {
+	var buf bytes.Buffer
+	_, api := humatest.New(t)
+	api.UseMiddleware(
+		middleware.RequestContext(middleware.RequestContextConfig{
+			NewRequestID: func() string { return "req-123" },
+		}),
+		middleware.AccessLogger(middleware.AccessLoggerConfig{
+			Logger: middleware.NewJSONLogger(middleware.JSONLoggerConfig{
+				Writer: &buf,
+				Preset: middleware.LogPresetAWS,
+			}),
+			Preset: middleware.LogPresetAWS,
+			Now:    sequenceNow(time.Unix(100, 0), time.Unix(100, int64(time.Millisecond))),
+			ExtraAttrs: func(huma.Context) []slog.Attr {
+				return []slog.Attr{slog.String("service", "billing")}
+			},
+		}),
+	)
+
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{ Status int }, error) {
+		return &struct{ Status int }{Status: http.StatusNoContent}, nil
+	})
+
+	api.Get("/test")
+
+	entry := decodeLogEntries(t, &buf)[0]
+	if entry["message"] != "request completed" {
+		t.Fatalf("message = %v, want request completed", entry["message"])
+	}
+	if entry["requestId"] != "req-123" {
+		t.Fatalf("requestId = %v, want req-123", entry["requestId"])
+	}
+	if entry["service"] != "billing" {
+		t.Fatalf("service = %v, want billing", entry["service"])
+	}
+	httpGroup := entry["http"].(map[string]any)
+	response := httpGroup["response"].(map[string]any)
+	if response["status_code"] != float64(http.StatusNoContent) {
+		t.Fatalf("http.response.status_code = %v, want 204", response["status_code"])
+	}
+}
+
+func TestAccessLoggerLogsPanicAndRepanics(t *testing.T) {
+	var buf bytes.Buffer
+	_, api := humatest.New(t)
+	api.UseMiddleware(
+		middleware.RequestContext(middleware.RequestContextConfig{
+			NewRequestID: func() string { return "req-123" },
+		}),
+		middleware.AccessLogger(middleware.AccessLoggerConfig{
+			Logger: middleware.NewJSONLogger(middleware.JSONLoggerConfig{Writer: &buf}),
+			Now:    sequenceNow(time.Unix(100, 0), time.Unix(100, int64(time.Millisecond))),
+		}),
+	)
+
+	huma.Get(api, "/panic", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		panic("boom")
+	})
+
+	defer func() {
+		if recovered := recover(); recovered != "boom" {
+			t.Fatalf("recover = %v, want boom", recovered)
+		}
+		entry := decodeLogEntries(t, &buf)[0]
+		if entry["level"] != "ERROR" {
+			t.Fatalf("level = %v, want ERROR", entry["level"])
+		}
+		if entry["status"] != float64(http.StatusInternalServerError) {
+			t.Fatalf("status = %v, want 500", entry["status"])
+		}
+	}()
+
+	api.Get("/panic")
+}
+
+func decodeLogEntries(t *testing.T, reader io.Reader) []map[string]any {
+	t.Helper()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read logs: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	entries := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("decode log %q: %v", line, err)
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func sequenceNow(times ...time.Time) func() time.Time {
+	i := 0
+	return func() time.Time {
+		if i >= len(times) {
+			return times[len(times)-1]
+		}
+		now := times[i]
+		i++
+		return now
+	}
+}
+
+func TestLoggerFallback(t *testing.T) {
+	if middleware.Logger(nil) == nil {
+		t.Fatal("Logger(nil) returned nil")
+	}
+}

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -98,12 +98,23 @@ func TestAccessLoggerGeneric(t *testing.T) {
 
 	api.Get("/test")
 
-	entries := decodeLogEntries(t, &buf)
+	raw := strings.TrimSpace(buf.String())
+	lines := strings.Split(raw, "\n")
+	entries := decodeLogEntries(t, strings.NewReader(raw))
 	if len(entries) != 2 {
 		t.Fatalf("log entries = %d, want 2", len(entries))
 	}
+	if len(lines) != 2 {
+		t.Fatalf("raw log lines = %d, want 2: %q", len(lines), raw)
+	}
 	if entries[0]["request_id"] != "req-123" {
 		t.Fatalf("handler request_id = %v, want req-123", entries[0]["request_id"])
+	}
+	if count := strings.Count(lines[1], `"request_id":`); count != 1 {
+		t.Fatalf("access log request_id count = %d, want 1: %s", count, lines[1])
+	}
+	if count := strings.Count(lines[1], `"correlation_id":`); count != 1 {
+		t.Fatalf("access log correlation_id count = %d, want 1: %s", count, lines[1])
 	}
 
 	access := entries[1]

--- a/middleware/logger_test.go
+++ b/middleware/logger_test.go
@@ -7,11 +7,13 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/danielgtaylor/huma/v2/humatest"
 	"github.com/danielgtaylor/huma/v2/middleware"
 )
@@ -231,6 +233,66 @@ func TestAccessLoggerGCPTraceWithoutProjectID(t *testing.T) {
 	}
 }
 
+func TestAccessLoggerGCPRemoteIPStripsPort(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		remoteIP   string
+	}{
+		{
+			name:       "ipv4 with port",
+			remoteAddr: "203.0.113.10:4321",
+			remoteIP:   "203.0.113.10",
+		},
+		{
+			name:       "ipv6 with port",
+			remoteAddr: "[2001:db8::1]:4321",
+			remoteIP:   "2001:db8::1",
+		},
+		{
+			name:       "ipv6 without port",
+			remoteAddr: "2001:db8::2",
+			remoteIP:   "2001:db8::2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			mux := http.NewServeMux()
+			api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+			api.UseMiddleware(
+				middleware.RequestContext(middleware.RequestContextConfig{
+					NewRequestID: func() string { return "req-123" },
+				}),
+				middleware.AccessLogger(middleware.AccessLoggerConfig{
+					Logger: middleware.NewJSONLogger(middleware.JSONLoggerConfig{
+						Writer: &buf,
+						Preset: middleware.LogPresetGCP,
+					}),
+					Preset: middleware.LogPresetGCP,
+					Now:    sequenceNow(time.Unix(100, 0), time.Unix(100, int64(time.Millisecond))),
+				}),
+			)
+
+			huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+				return &struct{}{}, nil
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.RemoteAddr = tc.remoteAddr
+			resp := httptest.NewRecorder()
+			mux.ServeHTTP(resp, req)
+
+			entry := decodeLogEntries(t, &buf)[0]
+			httpRequest := entry["httpRequest"].(map[string]any)
+			if httpRequest["remoteIp"] != tc.remoteIP {
+				t.Fatalf("httpRequest.remoteIp = %v, want %s", httpRequest["remoteIp"], tc.remoteIP)
+			}
+		})
+	}
+}
+
 func TestAccessLoggerAWSCloudWatchShape(t *testing.T) {
 	const traceparent = "00-3d23d071b5bfd6579171efce907685cb-08f067aa0ba902b7-01"
 
@@ -391,6 +453,39 @@ func TestAccessLoggerGCPCloudTraceContextSampleOption(t *testing.T) {
 				t.Fatalf("trace_sampled = %v, want %v", entry["logging.googleapis.com/trace_sampled"], tc.sampled)
 			}
 		})
+	}
+}
+
+func TestAccessLoggerClampsNegativeDuration(t *testing.T) {
+	var buf bytes.Buffer
+	_, api := humatest.New(t)
+	api.UseMiddleware(
+		middleware.RequestContext(middleware.RequestContextConfig{
+			NewRequestID: func() string { return "req-123" },
+		}),
+		middleware.AccessLogger(middleware.AccessLoggerConfig{
+			Logger: middleware.NewJSONLogger(middleware.JSONLoggerConfig{
+				Writer: &buf,
+				Preset: middleware.LogPresetGCP,
+			}),
+			Preset: middleware.LogPresetGCP,
+			Now:    sequenceNow(time.Unix(100, 0), time.Unix(99, 0)),
+		}),
+	)
+
+	huma.Get(api, "/test", func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		return &struct{}{}, nil
+	})
+
+	api.Get("/test")
+
+	entry := decodeLogEntries(t, &buf)[0]
+	if entry["duration_ms"] != float64(0) {
+		t.Fatalf("duration_ms = %v, want 0", entry["duration_ms"])
+	}
+	httpRequest := entry["httpRequest"].(map[string]any)
+	if httpRequest["latency"] != "0s" {
+		t.Fatalf("httpRequest.latency = %v, want 0s", httpRequest["latency"])
 	}
 }
 

--- a/middleware/trace.go
+++ b/middleware/trace.go
@@ -52,6 +52,9 @@ func ParseTraceparent(header string) TraceContext {
 	if version == "00" && len(header) != traceparentSize {
 		return TraceContext{}
 	}
+	if version != "00" && len(header) > traceparentSize && header[traceparentSize] != '-' {
+		return TraceContext{}
+	}
 
 	traceID := header[3:35]
 	parentID := header[36:52]

--- a/middleware/trace.go
+++ b/middleware/trace.go
@@ -1,0 +1,102 @@
+package middleware
+
+import "strconv"
+
+const (
+	traceparentVersionSize = 2
+	traceIDSize            = 32
+	parentIDSize           = 16
+	traceFlagsSize         = 2
+	traceparentSize        = traceparentVersionSize + 1 + traceIDSize + 1 + parentIDSize + 1 + traceFlagsSize
+	traceparentMaxSize     = 512
+)
+
+// TraceContext contains parsed W3C Trace Context data.
+type TraceContext struct {
+	// TraceID is the 16-byte trace ID as lowercase hex.
+	TraceID string
+
+	// ParentID is the parent span ID as lowercase hex.
+	ParentID string
+
+	// Flags is the parsed trace-flags byte.
+	Flags byte
+
+	// Sampled reports whether the sampled bit is set in Flags.
+	Sampled bool
+
+	// Traceparent is the raw traceparent header value.
+	Traceparent string
+
+	// Tracestate is the raw tracestate header value. It is only populated when
+	// Traceparent is valid.
+	Tracestate string
+
+	// Valid reports whether Traceparent parsed successfully.
+	Valid bool
+}
+
+// ParseTraceparent parses a W3C Trace Context traceparent header value.
+func ParseTraceparent(header string) TraceContext {
+	if len(header) < traceparentSize || len(header) > traceparentMaxSize {
+		return TraceContext{}
+	}
+	if header[2] != '-' || header[35] != '-' || header[52] != '-' {
+		return TraceContext{}
+	}
+
+	version := header[:2]
+	if !isLowerHex(version) || version == "ff" {
+		return TraceContext{}
+	}
+	if version == "00" && len(header) != traceparentSize {
+		return TraceContext{}
+	}
+
+	traceID := header[3:35]
+	parentID := header[36:52]
+	flagsText := header[53:55]
+	if !isLowerHex(traceID) || allZero(traceID) {
+		return TraceContext{}
+	}
+	if !isLowerHex(parentID) || allZero(parentID) {
+		return TraceContext{}
+	}
+	if !isLowerHex(flagsText) {
+		return TraceContext{}
+	}
+
+	flags64, err := strconv.ParseUint(flagsText, 16, 8)
+	if err != nil {
+		return TraceContext{}
+	}
+	flags := byte(flags64)
+
+	return TraceContext{
+		TraceID:     traceID,
+		ParentID:    parentID,
+		Flags:       flags,
+		Sampled:     flags&0x01 == 0x01,
+		Traceparent: header,
+		Valid:       true,
+	}
+}
+
+func isLowerHex(value string) bool {
+	for i := range len(value) {
+		c := value[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func allZero(value string) bool {
+	for i := range len(value) {
+		if value[i] != '0' {
+			return false
+		}
+	}
+	return true
+}

--- a/middleware/trace.go
+++ b/middleware/trace.go
@@ -16,13 +16,13 @@ type TraceContext struct {
 	// TraceID is the 16-byte trace ID as lowercase hex.
 	TraceID string
 
-	// ParentID is the parent span ID as lowercase hex.
+	// ParentID is the traceparent parent-id as lowercase hex.
 	ParentID string
 
 	// Flags is the parsed trace-flags byte.
 	Flags byte
 
-	// Sampled reports whether the sampled bit is set in Flags.
+	// Sampled reports whether the sampled flag is set.
 	Sampled bool
 
 	// Traceparent is the raw traceparent header value.
@@ -36,7 +36,8 @@ type TraceContext struct {
 	Valid bool
 }
 
-// ParseTraceparent parses a W3C Trace Context traceparent header value.
+// ParseTraceparent parses a W3C Trace Context traceparent header value. It
+// returns a zero TraceContext when the header is invalid.
 func ParseTraceparent(header string) TraceContext {
 	if len(header) < traceparentSize || len(header) > traceparentMaxSize {
 		return TraceContext{}

--- a/middleware/trace_test.go
+++ b/middleware/trace_test.go
@@ -35,6 +35,10 @@ func TestParseTraceparent(t *testing.T) {
 			valid:  true,
 		},
 		{
+			name:   "future version extra data requires delimiter",
+			header: "01-" + validTraceID + "-" + validParentID + "-00extra",
+		},
+		{
 			name:   "all-zero trace ID",
 			header: "00-00000000000000000000000000000000-" + validParentID + "-01",
 		},

--- a/middleware/trace_test.go
+++ b/middleware/trace_test.go
@@ -1,0 +1,90 @@
+package middleware_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2/middleware"
+)
+
+func TestParseTraceparent(t *testing.T) {
+	const validTraceID = "3d23d071b5bfd6579171efce907685cb"
+	const validParentID = "08f067aa0ba902b7"
+
+	tests := []struct {
+		name    string
+		header  string
+		valid   bool
+		sampled bool
+	}{
+		{
+			name:    "valid sampled",
+			header:  "00-" + validTraceID + "-" + validParentID + "-01",
+			valid:   true,
+			sampled: true,
+		},
+		{
+			name:    "sampled bit mask",
+			header:  "00-" + validTraceID + "-" + validParentID + "-03",
+			valid:   true,
+			sampled: true,
+		},
+		{
+			name:   "future version with extra data",
+			header: "01-" + validTraceID + "-" + validParentID + "-00-extra",
+			valid:  true,
+		},
+		{
+			name:   "all-zero trace ID",
+			header: "00-00000000000000000000000000000000-" + validParentID + "-01",
+		},
+		{
+			name:   "all-zero parent ID",
+			header: "00-" + validTraceID + "-0000000000000000-01",
+		},
+		{
+			name:   "invalid version ff",
+			header: "ff-" + validTraceID + "-" + validParentID + "-01",
+		},
+		{
+			name:   "uppercase rejected",
+			header: "00-3D23d071b5bfd6579171efce907685cb-" + validParentID + "-01",
+		},
+		{
+			name:   "version 00 must not have extra data",
+			header: "00-" + validTraceID + "-" + validParentID + "-01-extra",
+		},
+		{
+			name:   "bad delimiter",
+			header: "00_" + validTraceID + "-" + validParentID + "-01",
+		},
+		{
+			name:   "too long",
+			header: strings.Repeat("a", 513),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			trace := middleware.ParseTraceparent(tc.header)
+			if trace.Valid != tc.valid {
+				t.Fatalf("Valid = %v, want %v", trace.Valid, tc.valid)
+			}
+			if !tc.valid {
+				return
+			}
+			if trace.TraceID != validTraceID {
+				t.Fatalf("TraceID = %q, want %q", trace.TraceID, validTraceID)
+			}
+			if trace.ParentID != validParentID {
+				t.Fatalf("ParentID = %q, want %q", trace.ParentID, validParentID)
+			}
+			if trace.Sampled != tc.sampled {
+				t.Fatalf("Sampled = %v, want %v", trace.Sampled, tc.sampled)
+			}
+			if trace.Traceparent != tc.header {
+				t.Fatalf("Traceparent = %q, want original header", trace.Traceparent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds optional middleware for request IDs, W3C trace context correlation,
request-scoped `slog` loggers, and structured access logs. Includes generic,
GCP, AWS, and Azure JSON presets without adding non-stdlib dependencies.

Implementation:

- `RequestContext` parses request IDs and W3C `traceparent`.
- `AccessLogger` stores a request-scoped logger and writes one access log.
- `NewJSONLogger` provides stdout JSON presets for common cloud log collectors.

Usage:

```go
logger := middleware.NewJSONLogger(middleware.JSONLoggerConfig{
    Preset: middleware.LogPresetGCP,
})

api.UseMiddleware(
    middleware.RequestContext(middleware.RequestContextConfig{}),
    middleware.AccessLogger(middleware.AccessLoggerConfig{
        Logger: logger,
        Preset: middleware.LogPresetGCP,
        GCP: middleware.GCPConfig{
            ProjectID: os.Getenv("GOOGLE_CLOUD_PROJECT"),
        },
    }),
)

middleware.RequestLogger(ctx).WarnContext(ctx, "github api access denied",
    slog.Int("status", status),
)
```

Close https://github.com/danielgtaylor/huma/issues/1017