### PR TITLE
Support sending comments with SSE

### DIFF
--- a/sse/sse.go
+++ b/sse/sse.go
@@ -41,6 +41,8 @@ type Message struct {
 	ID    int
 	Data  any
 	Retry int
+	// Comment is sent with a message that has only a comment set (nil `Data`).
+	Comment string
 }
 
 // Sender is a send function for sending SSE messages to the client. It is
@@ -52,6 +54,13 @@ type Sender func(Message) error
 // to calling `sender(Message{Data: data})`.
 func (s Sender) Data(data any) error {
 	return s(Message{Data: data})
+}
+
+// Comment sends an SSE comment to the client. Comments are ignored by clients
+// and are commonly used as heartbeats to keep the connection alive. This is
+// equivalent to calling `sender(Message{Comment: comment})`.
+func (s Sender) Comment(comment string) error {
+	return s(Message{Comment: comment})
 }
 
 // Register a new SSE operation. The `eventTypeMap` maps from event name to
@@ -170,6 +179,15 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 					}
 				}
 
+				flush := func() error {
+					if flusher == nil {
+						fmt.Fprintln(os.Stderr, "error: unable to flush")
+						return fmt.Errorf("unable to flush: %w", http.ErrNotSupported)
+					}
+					flusher.Flush()
+					return nil
+				}
+
 				send := func(msg Message) error {
 					if deadliner != nil {
 						if err := deadliner.SetWriteDeadline(time.Now().Add(WriteTimeout)); err != nil {
@@ -185,6 +203,17 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 					}
 					if msg.Retry > 0 {
 						bw.Write(fmt.Appendf(nil, "retry: %d\n", msg.Retry))
+					}
+
+					if msg.Comment != "" {
+						for line := range strings.SplitSeq(msg.Comment, "\n") {
+							bw.Write(fmt.Appendf(nil, ": %s\n", line))
+						}
+					}
+
+					if msg.Data == nil {
+						bw.Write([]byte("\n"))
+						return flush()
 					}
 
 					event, ok := typeToEvent[deref(reflect.TypeOf(msg.Data))]
@@ -208,13 +237,7 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 						return err
 					}
 					bw.Write([]byte("\n"))
-					if flusher != nil {
-						flusher.Flush()
-					} else {
-						fmt.Fprintln(os.Stderr, "error: unable to flush")
-						return fmt.Errorf("unable to flush: %w", http.ErrNotSupported)
-					}
-					return nil
+					return flush()
 				}
 
 				// Call the user-provided SSE handler.

--- a/sse/sse.go
+++ b/sse/sse.go
@@ -41,7 +41,10 @@ type Message struct {
 	ID    int
 	Data  any
 	Retry int
-	// Comment is sent with a message that has only a comment set (nil `Data`).
+	// Comment, if set, is written as one or more SSE comment lines (each line
+	// prefixed with a colon and ignored by clients). It may accompany an event
+	// or, when `Data` is nil, form a comment-only message such as a heartbeat
+	// used to keep the connection alive.
 	Comment string
 }
 
@@ -206,7 +209,12 @@ func Register[I any](api huma.API, op huma.Operation, eventTypeMap map[string]an
 					}
 
 					if msg.Comment != "" {
-						for line := range strings.SplitSeq(msg.Comment, "\n") {
+						// CR, LF, and CRLF are all SSE line terminators. Normalize
+						// them to LF so every line of the comment is re-emitted as
+						// its own ": " comment line and can't inject other fields.
+						comment := strings.ReplaceAll(msg.Comment, "\r\n", "\n")
+						comment = strings.ReplaceAll(comment, "\r", "\n")
+						for line := range strings.SplitSeq(comment, "\n") {
 							bw.Write(fmt.Appendf(nil, ": %s\n", line))
 						}
 					}

--- a/sse/sse_test.go
+++ b/sse/sse_test.go
@@ -192,6 +192,34 @@ data: {"message":"Hello, world!"}
 		},
 	},
 	{
+		Title: "sse comment normalizes line breaks",
+		TestFunc: func(t *testing.T) {
+			_, api := humatest.New(t)
+			sse.Register(api, huma.Operation{
+				OperationID: "sse",
+				Method:      http.MethodGet,
+				Path:        "/sse",
+			}, map[string]any{
+				"message": &DefaultMessage{},
+			}, func(ctx context.Context, input *struct{}, send sse.Sender) {
+				// CR, CRLF, and LF are all SSE line terminators. Each line must
+				// be re-prefixed with a colon so an embedded line break can't
+				// inject another SSE field (here a stray "data:" line).
+				send.Comment("a\rb\r\nc\ndata: not-injected")
+			})
+
+			resp := api.Get("/sse")
+
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, `: a
+: b
+: c
+: data: not-injected
+
+`, resp.Body.String())
+		},
+	},
+	{
 		Title: "sse flushes headers before first event",
 		TestFunc: func(t *testing.T) {
 			_, api := humatest.New(t)

--- a/sse/sse_test.go
+++ b/sse/sse_test.go
@@ -162,6 +162,36 @@ data: {"error": "encode error: json: unsupported type: chan int"}
 		},
 	},
 	{
+		Title: "sse comment heartbeat",
+		TestFunc: func(t *testing.T) {
+			_, api := humatest.New(t)
+			sse.Register(api, huma.Operation{
+				OperationID: "sse",
+				Method:      http.MethodGet,
+				Path:        "/sse",
+			}, map[string]any{
+				"message": &DefaultMessage{},
+			}, func(ctx context.Context, input *struct{}, send sse.Sender) {
+				send.Comment("heartbeat")
+				send(sse.Message{ID: 5, Comment: "keep\nalive"})
+				send.Data(DefaultMessage{Message: "Hello, world!"})
+			})
+
+			resp := api.Get("/sse")
+
+			assert.Equal(t, http.StatusOK, resp.Code)
+			assert.Equal(t, `: heartbeat
+
+id: 5
+: keep
+: alive
+
+data: {"message":"Hello, world!"}
+
+`, resp.Body.String())
+		},
+	},
+	{
 		Title: "sse flushes headers before first event",
 		TestFunc: func(t *testing.T) {
 			_, api := humatest.New(t)


### PR DESCRIPTION
Sending comments is a common way to keep the connection alive for SSE. This PR adds the feature and refactor to reuse `flush` util function.

This potentially address the questions in https://github.com/danielgtaylor/huma/issues/286.