### PR TITLE
fix(humafiber): correct Fiber v2 EachHeader iteration and body decompression

### DIFF
--- a/adapters/humafiber/humafiber_v2.go
+++ b/adapters/humafiber/humafiber_v2.go
@@ -95,10 +95,8 @@ func (c *fiberV2Wrapper) Header(name string) string {
 }
 
 func (c *fiberV2Wrapper) EachHeader(cb func(name, value string)) {
-	for name, values := range c.orig.Request().Header.All() {
-		for _, value := range values {
-			cb(string(name), string(value))
-		}
+	for name, value := range c.orig.Request().Header.All() {
+		cb(string(name), string(value))
 	}
 }
 
@@ -108,7 +106,7 @@ func (c *fiberV2Wrapper) BodyReader() io.Reader {
 		// Streaming is enabled, so send the reader.
 		return orig.Request().BodyStream()
 	}
-	return bytes.NewReader(orig.BodyRaw())
+	return bytes.NewReader(orig.Body())
 }
 
 func (c *fiberV2Wrapper) GetMultipartForm() (*multipart.Form, error) {

--- a/adapters/humafiber/humafiber_v2_test.go
+++ b/adapters/humafiber/humafiber_v2_test.go
@@ -1,13 +1,100 @@
 package humafiber
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"io"
 	"net/http"
 	"testing"
 
 	"github.com/danielgtaylor/huma/v2"
 	fiberV2 "github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/require"
 )
+
+// TestFiberV2EachHeaderAndCookie ensures EachHeader yields one callback per
+// header value (not one per byte) so header-based helpers like huma.ReadCookie
+// continue to work under the Fiber v2 adapter. Regression test for #1055.
+func TestFiberV2EachHeaderAndCookie(t *testing.T) {
+	r := fiberV2.New()
+	api := NewV2(r, huma.DefaultConfig("Test API", "1.0.0"))
+
+	var authValue string
+	var authCallbacks int
+	var cookieValue string
+	var cookieErr error
+	api.UseMiddleware(func(ctx huma.Context, next func(huma.Context)) {
+		ctx.EachHeader(func(name, value string) {
+			if name == "Authorization" {
+				authCallbacks++
+				authValue = value
+			}
+		})
+		cookie, err := huma.ReadCookie(ctx, "session")
+		cookieErr = err
+		if cookie != nil {
+			cookieValue = cookie.Value
+		}
+		next(ctx)
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-root",
+		Method:      http.MethodGet,
+		Path:        "/",
+	}, func(ctx context.Context, _ *struct{}) (*struct{}, error) {
+		return &struct{}{}, nil
+	})
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/", nil)
+	req.Header.Set("Authorization", "Bearer abc")
+	req.Header.Set("Cookie", "session=xyz")
+	_, err := r.Test(req)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, authCallbacks, "EachHeader should fire once per header value, not once per byte")
+	require.Equal(t, "Bearer abc", authValue)
+	require.NoError(t, cookieErr)
+	require.Equal(t, "xyz", cookieValue)
+}
+
+// TestFiberV2BodyReaderDecompresses ensures BodyReader returns the decompressed
+// request body (Body) rather than the raw compressed bytes (BodyRaw), so
+// handlers receive usable payloads when Content-Encoding is set. Regression
+// test for #1055.
+func TestFiberV2BodyReaderDecompresses(t *testing.T) {
+	r := fiberV2.New()
+	api := NewV2(r, huma.DefaultConfig("Test API", "1.0.0"))
+
+	type Body struct {
+		Name string `json:"name"`
+	}
+	huma.Register(api, huma.Operation{
+		OperationID: "echo",
+		Method:      http.MethodPost,
+		Path:        "/echo",
+	}, func(ctx context.Context, in *struct{ Body Body }) (*struct{ Body Body }, error) {
+		return &struct{ Body Body }{Body: in.Body}, nil
+	})
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write([]byte(`{"name":"gzipped"}`))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	req, _ := http.NewRequest(http.MethodPost, "http://example.com/echo", &buf)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	resp, err := r.Test(req)
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "compressed body should decompress and parse: %s", body)
+	require.Contains(t, string(body), `"name":"gzipped"`)
+}
 
 func BenchmarkHumaFiberV2(b *testing.B) {
 	type GreetingInput struct {


### PR DESCRIPTION
Fixes #1055

## Problem

The Fiber v2 adapter (`humafiber.NewV2`, added in #962) has two bugs in its `huma.Context` implementation:

1. **`EachHeader` iterates bytes, not headers.** `(*fasthttp.RequestHeader).All()` returns `iter.Seq2[[]byte, []byte]` yielding `(name, value)` pairs, but the code treated the value as a slice of values and ranged over it, invoking the callback once per byte. A request with `Authorization: Bearer abc` produced ten single-character callbacks. This broke `huma.ReadCookie`/`huma.ReadCookies`, which collect the `Cookie` header via `EachHeader`, so cookies were no longer found.

2. **`BodyReader` used `BodyRaw()` instead of `Body()`.** `BodyRaw()` returns the raw bytes without decompressing, so compressed request bodies reached handlers still compressed. The Fiber v3 adapter and v2.37.3 both use `Body()`, which decompresses per `Content-Encoding`.

## Fix

- `EachHeader`: range both values of the `Seq2`, one callback per header value.
- `BodyReader`: use `orig.Body()`, matching the v3 adapter and v2.37.3.

## Tests

- `TestFiberV2EachHeaderAndCookie` — asserts one callback per header value and a readable cookie.
- `TestFiberV2BodyReaderDecompresses` — sends a gzip body with `Content-Encoding: gzip` and asserts the handler receives decompressed, parseable JSON.

Both tests fail against the unfixed source and pass with the fix.