### PR TITLE
feat(form-data): handle unmarshalling and validation of non-file JSON form data fields

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -181,6 +181,51 @@ type ComplexOutput struct {
 	}
 }
 
+func BenchmarkMultipartJSONField(b *testing.B) {
+	_, api := humatest.New(b, huma.DefaultConfig("Test API", "1.0.0"))
+
+	type Metadata struct {
+		Name   string `json:"name" default:"anon"`
+		Email  string `json:"email" format:"email"`
+		Age    int    `json:"age" default:"18"`
+		Client string `json:"client"`
+	}
+
+	huma.Register(api, huma.Operation{
+		Method: http.MethodPost,
+		Path:   "/upload",
+	}, func(ctx context.Context, input *struct {
+		RawBody huma.MultipartFormFiles[struct {
+			Metadata Metadata      `form:"metadata" contentType:"application/json" required:"true"`
+			File     huma.FormFile `form:"file" contentType:"text/plain"`
+		}]
+	}) (*struct{}, error) {
+		return nil, nil
+	})
+
+	body := "--SimpleBoundary\r\n" +
+		"Content-Disposition: form-data; name=\"metadata\"\r\n" +
+		"Content-Type: application/json\r\n\r\n" +
+		`{"name":"John Doe","email":"john@example.com","age":30,"client":"bench"}` + "\r\n" +
+		"--SimpleBoundary\r\n" +
+		"Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n" +
+		"Content-Type: text/plain\r\n\r\n" +
+		"Hello World\r\n" +
+		"--SimpleBoundary--\r\n"
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		r := httptest.NewRequest(http.MethodPost, "/upload", strings.NewReader(body))
+		r.Header.Set("Content-Type", "multipart/form-data; boundary=SimpleBoundary")
+		w := httptest.NewRecorder()
+		api.Adapter().ServeHTTP(w, r)
+		if w.Code < 200 || w.Code >= 300 {
+			b.Fatalf("unexpected status %d: %s", w.Code, w.Body.String())
+		}
+	}
+}
+
 func BenchmarkFullRequest_Complex(b *testing.B) {
 	_, api := humatest.New(b, huma.DefaultConfig("Test API", "1.0.0"))
 

--- a/docs/docs/features/request-inputs.md
+++ b/docs/docs/features/request-inputs.md
@@ -173,6 +173,9 @@ huma.Register(api, huma.Operation{
 		MyGreeting                string          `form:"greeting", minLength:"6"`
 		SomeNumbers               []int           `form:"numbers"`
 		NonTaggedValuesAreIgnored string  // ignored
+		// Field content is unmarshalled and validated
+		MyStruct 				  SomeStruct      `form:"my_struct" contentType:"application/json"`
+		MyStructSlice 			  []SomeStruct    `form:"my_struct_slice" contentType:"application/json"`
 	}]
 }) (*struct{}, error) {
 	// The raw multipart.Form body is again available under input.RawBody.Form.
@@ -212,6 +215,9 @@ huma.Register(api, huma.Operation{
 ```
 
 The files are decoded according to the specified contentType. If no contentType is provided, it defaults to `application/octet-stream`.
+
+Non-file fields in multipart form data can be unmarshalled from JSON and validated, by setting their content-type to `application/json`. Field content in the request must be valid JSON.
+
 
 ## Request Example
 

--- a/formdata.go
+++ b/formdata.go
@@ -255,10 +255,17 @@ func multiPartContentEncoding(t reflect.Type) map[string]*Encoding {
 		name := formDataFieldName(f)
 
 		contentType := "text/plain"
-		if f.Type == reflect.TypeFor[FormFile]() || f.Type == reflect.TypeFor[[]FormFile]() {
+		switch {
+		case f.Type == reflect.TypeFor[FormFile]() || f.Type == reflect.TypeFor[[]FormFile]():
 			contentType = f.Tag.Get("contentType")
 			if contentType == "" {
 				contentType = "application/octet-stream"
+			}
+		default:
+			// Honor an explicit content type (e.g. application/json) so the
+			// generated encoding matches how the field is actually parsed.
+			if c := f.Tag.Get("contentType"); c != "" {
+				contentType = c
 			}
 		}
 		encoding[name] = &Encoding{

--- a/huma.go
+++ b/huma.go
@@ -100,15 +100,16 @@ type StreamResponse struct {
 const styleDeepObject = "deepObject"
 
 type paramFieldInfo struct {
-	Type       reflect.Type
-	Name       string
-	Loc        string
-	Required   bool
-	Default    string
-	TimeFormat string
-	Explode    bool
-	Style      string
-	Schema     *Schema
+	Type        reflect.Type
+	Name        string
+	Loc         string
+	Required    bool
+	Default     string
+	TimeFormat  string
+	Explode     bool
+	Style       string
+	ContentType string
+	Schema      *Schema
 }
 
 // paramLocation holds the result of parsing a struct field's parameter location tags.
@@ -246,6 +247,10 @@ func findParams(registry Registry, op *Operation, t reflect.Type) *findResult[*p
 		// OpenAPI 3.x spec and are forced back to true below.
 		if _, ok = f.Tag.Lookup("required"); ok {
 			pfi.Required = boolTag(f, "required", false)
+		}
+
+		if _, ok = f.Tag.Lookup("contentType"); ok {
+			pfi.ContentType = f.Tag.Get("contentType")
 		}
 
 		// Per OpenAPI 3.x spec, path parameters MUST always be required.
@@ -925,6 +930,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 			if rbt.isMultipart() {
 				// Read form
 				form, err := readForm(ctx)
+				jsonUnmarshaler := func(data []byte, v any) error { return api.Unmarshal("application/json", data, v) }
 
 				if err != nil {
 					res.Errors = append(res.Errors, err)
@@ -968,6 +974,44 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 									res.Add(pb, value, "expected at most one value, but received multiple values")
 									return
 								}
+
+								// JSON fields
+								if p.ContentType == "application/json" {
+									fieldSchema := op.RequestBody.Content["multipart/form-data"].Schema.Properties[p.Name]
+									jsonValidator := func(data any, res *ValidateResult) {
+										Validate(api.OpenAPI().Components.Schemas, fieldSchema, pb, ModeWriteToServer, data, res)
+									}
+
+									var (
+										parsed                 any
+										errorsBeforeValidation = len(res.Errors)
+									)
+									if err := jsonUnmarshaler([]byte(value[0]), &parsed); err != nil {
+										res.Add(pb, value, "invalid JSON: "+err.Error())
+									} else {
+										jsonValidator(parsed, res)
+									}
+									if errorsBeforeValidation == len(res.Errors) {
+										if err := jsonUnmarshaler([]byte(value[0]), f.Addr().Interface()); err != nil {
+											// Should have been caught by the validator above
+											res.Add(pb, value, "invalid JSON: "+err.Error())
+										}
+										// Set defaults
+										fieldDefaults := findDefaults(api.OpenAPI().Components.Schemas, f.Type())
+										fieldDefaults.Every(f, func(item reflect.Value, def any) {
+											if item.IsZero() {
+												if item.Kind() == reflect.Pointer {
+													item.Set(reflect.New(item.Type().Elem()))
+													item = item.Elem()
+												}
+												item.Set(reflect.Indirect(reflect.ValueOf(def)))
+											}
+										})
+									}
+									return
+								}
+
+								// Regular fields
 								pv, err := parseInto(ctx, f, value[0], value, *p)
 								if err != nil {
 									res.Add(pb, value, err.Error())

--- a/huma.go
+++ b/huma.go
@@ -112,6 +112,37 @@ type paramFieldInfo struct {
 	Schema      *Schema
 }
 
+// jsonFormFieldInfo holds precomputed metadata for a multipart form field that
+// is unmarshalled and validated as JSON (via `contentType:"application/json"`).
+// It is computed once at registration time to keep request handling cheap.
+type jsonFormFieldInfo struct {
+	schema   *Schema
+	defaults *findResult[any]
+}
+
+// multipartFieldNeedsJSONTag reports whether a multipart form field of type t
+// can only be handled by unmarshalling it as JSON, i.e. it cannot be parsed
+// from a plain-text form value by parseInto. Such fields must be tagged
+// `contentType:"application/json"`.
+//
+// It is intentionally conservative: it flags only struct and map types that are
+// not otherwise scalar-parseable, so it never reports a field that parseInto
+// would have handled successfully.
+func multipartFieldNeedsJSONTag(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Struct, reflect.Map:
+		if t == timeType || t == urlType {
+			return false
+		}
+		if reflect.PointerTo(t).Implements(paramWrapperType) ||
+			reflect.PointerTo(t).Implements(textUnmarshalerType) {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
 // paramLocation holds the result of parsing a struct field's parameter location tags.
 // It contains a pointer to the associated paramFieldInfo and, for query parameters,
 // a pointer to the explode flag (nil for all other locations).
@@ -784,8 +815,44 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 
 	a := api.Adapter()
 	var rawBodyInputParams *findResult[*paramFieldInfo]
+	// jsonFormFields holds precomputed metadata for multipart form fields that
+	// carry `contentType:"application/json"`, so the per-request handler avoids
+	// repeating schema lookups and reflection-based default discovery.
+	var jsonFormFields map[*paramFieldInfo]*jsonFormFieldInfo
 	if rawBodyDataT != nil {
 		rawBodyInputParams = findParams(registry, &op, rawBodyDataT)
+		for i := range rawBodyInputParams.Paths {
+			p := rawBodyInputParams.Paths[i].Value
+			if p.Loc != "form" || p.Type == formFileType || p.Type == formFilesType {
+				continue
+			}
+			// Resolve the field's content type the same way body codecs do (via
+			// parseContentType), so `+json` suffixes and `;charset` parameters
+			// are handled consistently.
+			ct := ""
+			if start, end, err := parseContentType(p.ContentType); err == nil {
+				ct = strings.ToLower(p.ContentType[start:end])
+			}
+			if ct != "application/json" && ct != "json" {
+				// Fail fast at registration with actionable guidance rather than
+				// a confusing "unsupported param type" error at request time.
+				if multipartFieldNeedsJSONTag(p.Type) {
+					panic(fmt.Errorf(`multipart form field '%s' of type '%s' requires contentType:"application/json" to be unmarshalled as JSON`, p.Name, p.Type))
+				}
+				continue
+			}
+			if jsonFormFields == nil {
+				jsonFormFields = map[*paramFieldInfo]*jsonFormFieldInfo{}
+			}
+			var schema *Schema
+			if mt := op.RequestBody.Content["multipart/form-data"]; mt != nil && mt.Schema != nil {
+				schema = mt.Schema.Properties[p.Name]
+			}
+			jsonFormFields[p] = &jsonFormFieldInfo{
+				schema:   schema,
+				defaults: findDefaults(registry, p.Type),
+			}
+		}
 	}
 	a.Handle(&op, api.Middlewares().Handler(op.Middlewares.Handler(func(ctx Context) {
 		var input I
@@ -976,37 +1043,23 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 								}
 
 								// JSON fields
-								if p.ContentType == "application/json" {
-									fieldSchema := op.RequestBody.Content["multipart/form-data"].Schema.Properties[p.Name]
-									jsonValidator := func(data any, res *ValidateResult) {
-										Validate(api.OpenAPI().Components.Schemas, fieldSchema, pb, ModeWriteToServer, data, res)
-									}
+								if jf := jsonFormFields[p]; jf != nil {
+									errorsBeforeValidation := len(res.Errors)
 
-									var (
-										parsed                 any
-										errorsBeforeValidation = len(res.Errors)
-									)
+									var parsed any
 									if err := jsonUnmarshaler([]byte(value[0]), &parsed); err != nil {
 										res.Add(pb, value, "invalid JSON: "+err.Error())
-									} else {
-										jsonValidator(parsed, res)
+									} else if !op.SkipValidateParams {
+										Validate(oapi.Components.Schemas, jf.schema, pb, ModeWriteToServer, parsed, res)
 									}
+
 									if errorsBeforeValidation == len(res.Errors) {
 										if err := jsonUnmarshaler([]byte(value[0]), f.Addr().Interface()); err != nil {
-											// Should have been caught by the validator above
+											// Should have been caught by the validation above.
 											res.Add(pb, value, "invalid JSON: "+err.Error())
 										}
-										// Set defaults
-										fieldDefaults := findDefaults(api.OpenAPI().Components.Schemas, f.Type())
-										fieldDefaults.Every(f, func(item reflect.Value, def any) {
-											if item.IsZero() {
-												if item.Kind() == reflect.Pointer {
-													item.Set(reflect.New(item.Type().Elem()))
-													item = item.Elem()
-												}
-												item.Set(reflect.Indirect(reflect.ValueOf(def)))
-											}
-										})
+										// Set defaults on the unmarshalled value.
+										setDefaults(f, jf.defaults)
 									}
 									return
 								}
@@ -2217,6 +2270,14 @@ func parseBodyInto(v reflect.Value, bodyIndex []int, u intoUnmarshaler, body []b
 		}
 	}
 	// Set defaults for any fields that were not in the input.
+	setDefaults(v, defaults)
+	return nil
+}
+
+// setDefaults sets default values on every field reachable from v that was left
+// at its zero value. It is shared by the request body and multipart JSON form
+// field decoding paths.
+func setDefaults(v reflect.Value, defaults *findResult[any]) {
 	defaults.Every(v, func(item reflect.Value, def any) {
 		if item.IsZero() {
 			if item.Kind() == reflect.Pointer {
@@ -2226,7 +2287,6 @@ func parseBodyInto(v reflect.Value, bodyIndex []int, u intoUnmarshaler, body []b
 			item.Set(reflect.Indirect(reflect.ValueOf(def)))
 		}
 	})
-	return nil
 }
 
 // readBody reads the message body from ctx into buf, respecting the

--- a/huma_test.go
+++ b/huma_test.go
@@ -1402,6 +1402,236 @@ func TestFeatures(t *testing.T) {
 			Body:    `some-data`,
 		},
 		{
+			Name: "request-body-multipart-json-struct",
+			Register: func(t *testing.T, api huma.API) {
+				type User struct {
+					Name  string `json:"name"`
+					Email string `json:"email"`
+					Age   int    `json:"age"`
+				}
+
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPost,
+					Path:   "/upload",
+				}, func(ctx context.Context, input *struct {
+					RawBody huma.MultipartFormFiles[struct {
+						UserData User          `form:"user" contentType:"application/json" required:"true"`
+						File     huma.FormFile `form:"file" contentType:"text/plain"`
+					}]
+				}) (*struct{}, error) {
+					data := input.RawBody.Data()
+
+					// Verify the struct was correctly deserialized from JSON
+					assert.Equal(t, "John Doe", data.UserData.Name)
+					assert.Equal(t, "john@example.com", data.UserData.Email)
+					assert.Equal(t, 30, data.UserData.Age)
+
+					// Verify the file was also processed correctly
+					assert.Equal(t, "test.txt", data.File.Filename)
+					content, err := io.ReadAll(data.File)
+					require.NoError(t, err)
+					assert.Equal(t, "Hello World", string(content))
+
+					return nil, nil
+				})
+			},
+			Method:  http.MethodPost,
+			URL:     "/upload",
+			Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=SimpleBoundary"},
+			Body: `--SimpleBoundary
+Content-Disposition: form-data; name="user"
+Content-Type: application/json
+
+{"name": "John Doe", "email": "john@example.com", "age": 30}
+--SimpleBoundary
+Content-Disposition: form-data; name="file"; filename="test.txt"
+Content-Type: text/plain
+
+Hello World
+--SimpleBoundary--`,
+		},
+		{
+			Name: "request-body-multipart-json-struct-invalid-json",
+			Register: func(t *testing.T, api huma.API) {
+				type User struct {
+					Name  string `json:"name"`
+					Email string `json:"email" format:"email"`
+					Age   int    `json:"age"`
+				}
+
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPost,
+					Path:   "/upload",
+				}, func(ctx context.Context, input *struct {
+					RawBody huma.MultipartFormFiles[struct {
+						UserData User          `form:"user" contentType:"application/json" required:"true"`
+						File     huma.FormFile `form:"file" contentType:"text/plain"`
+					}]
+				}) (*struct{}, error) {
+					return nil, nil
+				})
+			},
+			Method:  http.MethodPost,
+			URL:     "/upload",
+			Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=SimpleBoundary"},
+			Body: `--SimpleBoundary
+Content-Disposition: form-data; name="user"
+Content-Type: application/json
+
+this is not valid json
+--SimpleBoundary
+Content-Disposition: form-data; name="file"; filename="test.txt"
+Content-Type: text/plain
+
+Hello World
+--SimpleBoundary--`,
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				if ok := assert.Equal(t, http.StatusUnprocessableEntity, resp.Code); ok {
+					var errors huma.ErrorModel
+					err := json.Unmarshal(resp.Body.Bytes(), &errors)
+					require.NoError(t, err)
+					assert.Equal(t, "form.user", errors.Errors[0].Location)
+				}
+			},
+		},
+		{
+			Name: "request-body-multipart-json-struct-invalid-data",
+			Register: func(t *testing.T, api huma.API) {
+				type User struct {
+					Name  string `json:"name"`
+					Email string `json:"email" format:"email"`
+					Age   int    `json:"age"`
+				}
+
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPost,
+					Path:   "/upload",
+				}, func(ctx context.Context, input *struct {
+					RawBody huma.MultipartFormFiles[struct {
+						UserData User          `form:"user" contentType:"application/json" required:"true"`
+						File     huma.FormFile `form:"file" contentType:"text/plain"`
+					}]
+				}) (*struct{}, error) {
+					return nil, nil
+				})
+			},
+			Method:  http.MethodPost,
+			URL:     "/upload",
+			Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=SimpleBoundary"},
+			Body: `--SimpleBoundary
+Content-Disposition: form-data; name="user"
+Content-Type: application/json
+
+{"name": "John Doe", "email": "SOME INVALID EMAIL", "age": 30}
+--SimpleBoundary
+Content-Disposition: form-data; name="file"; filename="test.txt"
+Content-Type: text/plain
+
+Hello World
+--SimpleBoundary--`,
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				if ok := assert.Equal(t, http.StatusUnprocessableEntity, resp.Code); ok {
+					var errors huma.ErrorModel
+					err := json.Unmarshal(resp.Body.Bytes(), &errors)
+					require.NoError(t, err)
+					assert.Equal(t, "form.user.email", errors.Errors[0].Location)
+				}
+			},
+		},
+		{
+			Name: "request-body-multipart-json-struct-default-set",
+			Register: func(t *testing.T, api huma.API) {
+				type User struct {
+					Name  string `json:"name,omitempty" default:"Default Name"`
+					Email string `json:"email,omitempty" format:"email"`
+					Age   *int   `json:"age,omitempty" default:"25"`
+				}
+
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPost,
+					Path:   "/upload",
+				}, func(ctx context.Context, input *struct {
+					RawBody huma.MultipartFormFiles[struct {
+						UserData User          `form:"user" contentType:"application/json" required:"true"`
+						File     huma.FormFile `form:"file" contentType:"text/plain"`
+					}]
+				}) (*struct{}, error) {
+					data := input.RawBody.Data()
+
+					// Verify the struct was correctly deserialized from JSON
+					assert.Equal(t, "Default Name", data.UserData.Name)
+					assert.Equal(t, 25, *data.UserData.Age)
+					return nil, nil
+				})
+			},
+			Method:  http.MethodPost,
+			URL:     "/upload",
+			Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=SimpleBoundary"},
+			Body: `--SimpleBoundary
+Content-Disposition: form-data; name="user"
+Content-Type: application/json
+
+{}
+--SimpleBoundary
+Content-Disposition: form-data; name="file"; filename="test.txt"
+Content-Type: text/plain
+
+Hello World
+--SimpleBoundary--`,
+		},
+		{
+			Name: "request-body-multipart-json-array",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPost,
+					Path:   "/upload",
+				}, func(ctx context.Context, input *struct {
+					RawBody huma.MultipartFormFiles[struct {
+						Numbers []int    `form:"numbers" contentType:"application/json"`
+						Tags    []string `form:"tags" contentType:"application/json"`
+						Count   int      `form:"count" contentType:"application/json"`
+						Active  bool     `form:"active" contentType:"application/json"`
+					}]
+				}) (*struct{}, error) {
+					data := input.RawBody.Data()
+
+					// Verify arrays were correctly deserialized from JSON
+					assert.Equal(t, []int{1, 2, 3, 4, 5}, data.Numbers)
+					assert.Equal(t, []string{"tag1", "tag2", "tag3"}, data.Tags)
+
+					// Verify scalar types were correctly deserialized from JSON
+					assert.Equal(t, 42, data.Count)
+					assert.True(t, data.Active)
+
+					return nil, nil
+				})
+			},
+			Method:  http.MethodPost,
+			URL:     "/upload",
+			Headers: map[string]string{"Content-Type": "multipart/form-data; boundary=SimpleBoundary"},
+			Body: `--SimpleBoundary
+Content-Disposition: form-data; name="numbers"
+Content-Type: application/json
+
+[1, 2, 3, 4, 5]
+--SimpleBoundary
+Content-Disposition: form-data; name="tags"
+Content-Type: application/json
+
+["tag1", "tag2", "tag3"]
+--SimpleBoundary
+Content-Disposition: form-data; name="count"
+Content-Type: application/json
+
+42
+--SimpleBoundary
+Content-Disposition: form-data; name="active"
+Content-Type: application/json
+
+true
+--SimpleBoundary--`,
+		},
+		{
 			Name: "request-body-multipart-file-decoded",
 			Register: func(t *testing.T, api huma.API) {
 				huma.Register(api, huma.Operation{

--- a/huma_test.go
+++ b/huma_test.go
@@ -1434,6 +1434,12 @@ func TestFeatures(t *testing.T) {
 
 					return nil, nil
 				})
+
+				// The generated encoding must advertise the JSON content type so
+				// the published spec matches how the field is actually parsed.
+				mpContent := api.OpenAPI().Paths["/upload"].Post.RequestBody.Content["multipart/form-data"]
+				assert.Equal(t, "application/json", mpContent.Encoding["user"].ContentType)
+				assert.Equal(t, "text/plain", mpContent.Encoding["file"].ContentType)
 			},
 			Method:  http.MethodPost,
 			URL:     "/upload",
@@ -3558,6 +3564,77 @@ Content-Type: text/plain
 			}
 		})
 	}
+}
+
+// TestMultipartJSONContentTypeMatching ensures the `contentType` tag is matched
+// as a media type: parameters like `charset` and structured `+json` suffixes
+// still select JSON handling.
+func TestMultipartJSONContentTypeMatching(t *testing.T) {
+	_, api := humatest.New(t, huma.DefaultConfig("Test", "1.0.0"))
+
+	type Meta struct {
+		Name string `json:"name"`
+	}
+
+	huma.Register(api, huma.Operation{
+		Method: http.MethodPost,
+		Path:   "/upload",
+	}, func(ctx context.Context, input *struct {
+		RawBody huma.MultipartFormFiles[struct {
+			Charset Meta `form:"charset" contentType:"application/json; charset=utf-8"`
+			Vendor  Meta `form:"vendor" contentType:"application/vnd.api+json"`
+		}]
+	}) (*struct{}, error) {
+		data := input.RawBody.Data()
+		assert.Equal(t, "a", data.Charset.Name)
+		assert.Equal(t, "b", data.Vendor.Name)
+		return nil, nil
+	})
+
+	body := "--B\r\n" +
+		"Content-Disposition: form-data; name=\"charset\"\r\n\r\n" +
+		`{"name":"a"}` + "\r\n" +
+		"--B\r\n" +
+		"Content-Disposition: form-data; name=\"vendor\"\r\n\r\n" +
+		`{"name":"b"}` + "\r\n" +
+		"--B--\r\n"
+
+	r := httptest.NewRequest(http.MethodPost, "/upload", strings.NewReader(body))
+	r.Header.Set("Content-Type", "multipart/form-data; boundary=B")
+	w := httptest.NewRecorder()
+	api.Adapter().ServeHTTP(w, r)
+	assert.Less(t, w.Code, 300, w.Body.String())
+
+	// The generated encoding must reflect the tagged content types.
+	enc := api.OpenAPI().Paths["/upload"].Post.RequestBody.Content["multipart/form-data"].Encoding
+	assert.Equal(t, "application/json; charset=utf-8", enc["charset"].ContentType)
+	assert.Equal(t, "application/vnd.api+json", enc["vendor"].ContentType)
+}
+
+// TestMultipartStructFieldRequiresJSONTag ensures a non-parseable struct form
+// field without a JSON content type fails fast at registration with actionable
+// guidance instead of a confusing request-time error.
+func TestMultipartStructFieldRequiresJSONTag(t *testing.T) {
+	_, api := humatest.New(t, huma.DefaultConfig("Test", "1.0.0"))
+
+	type Meta struct {
+		Name string `json:"name"`
+	}
+
+	assert.PanicsWithError(t,
+		`multipart form field 'meta' of type 'huma_test.Meta' requires contentType:"application/json" to be unmarshalled as JSON`,
+		func() {
+			huma.Register(api, huma.Operation{
+				Method: http.MethodPost,
+				Path:   "/upload",
+			}, func(ctx context.Context, input *struct {
+				RawBody huma.MultipartFormFiles[struct {
+					Meta Meta `form:"meta"`
+				}]
+			}) (*struct{}, error) {
+				return nil, nil
+			})
+		})
 }
 
 func TestOpenAPI(t *testing.T) {


### PR DESCRIPTION
Closes #897.

Makes Huma unmarshal and validate non-file fields in multipart forms that have tag `contentType:"application/json"`.

I am not perfectly happy with this implementation, since it duplicates a bit of logic from regular JSON body unmarshalling. But factorizing this would involve major changes in the API.

To keep the patch minimal, I had to include the parsed `contentType` tag in `fieldParamInfo`. Hope this is acceptable.