### PR TITLE
fix: require absolute URI for format:uri/iri

### DIFF
--- a/docs/docs/features/request-validation.md
+++ b/docs/docs/features/request-validation.md
@@ -152,7 +152,7 @@ Built-in string formats include:
 | `ip`                              | IPv4 or IPv6 address            | `127.0.0.1` or `::1`                   |
 | `ipv4`                            | IPv4 address                    | `127.0.0.1`                            |
 | `ipv6`                            | IPv6 address                    | `::1`                                  |
-| `uri` / `iri`                     | URI                             | `https://example.com`                  |
+| `uri` / `iri`                     | Absolute URI (must have scheme) | `https://example.com`                  |
 | `uri-reference` / `iri-reference` | URI reference                   | `/path/to/resource`                    |
 | `uri-template`                    | URI template                    | `/path/{id}`                           |
 | `json-pointer`                    | JSON Pointer                    | `/path/to/field`                       |

--- a/validate.go
+++ b/validate.go
@@ -268,11 +268,19 @@ func validateFormat(path *PathBuffer, str string, s *Schema, res *ValidateResult
 	// 	if _, err := idnaProfile.ToASCII(str); err != nil {
 	// 		res.Add(path, str, validation.MsgExpectedRFC5890Hostname)
 	// 	}
-	case "uri", "uri-reference", "iri", "iri-reference":
+	case "uri", "iri":
+		// A URI (unlike a URI reference) must be absolute, i.e. include a
+		// scheme. Bare url.Parse accepts relative paths and the empty string,
+		// which the docs list only under uri-reference.
+		if u, err := url.Parse(str); err != nil {
+			res.Add(path, str, ErrorFormatter(validation.MsgExpectedRFC3986URI, err))
+		} else if !u.IsAbs() {
+			res.Add(path, str, ErrorFormatter(validation.MsgExpectedRFC3986URI, fmt.Errorf("missing protocol scheme")))
+		}
+	case "uri-reference", "iri-reference":
 		if _, err := url.Parse(str); err != nil {
 			res.Add(path, str, ErrorFormatter(validation.MsgExpectedRFC3986URI, err))
 		}
-		// TODO: check if it's actually a reference?
 	case "uri-template":
 		u, err := url.Parse(str)
 		if err != nil {

--- a/validate_test.go
+++ b/validate_test.go
@@ -478,6 +478,51 @@ var validateTests = []struct {
 		errs:  []string{"expected string to be RFC 3986 uri: parse \":\": missing protocol scheme"},
 	},
 	{
+		name: "uri success non-http scheme",
+		typ: reflect.TypeFor[struct {
+			Value string "json:\"value\" format:\"uri\""
+		}](),
+		input: map[string]any{"value": "mailto:someone@example.com"},
+	},
+	{
+		name: "expected uri not absolute",
+		typ: reflect.TypeFor[struct {
+			Value string "json:\"value\" format:\"uri\""
+		}](),
+		input: map[string]any{"value": "/relative/path"},
+		errs:  []string{"expected string to be RFC 3986 uri: missing protocol scheme"},
+	},
+	{
+		name: "expected uri empty",
+		typ: reflect.TypeFor[struct {
+			Value string "json:\"value\" format:\"uri\""
+		}](),
+		input: map[string]any{"value": ""},
+		errs:  []string{"expected string to be RFC 3986 uri: missing protocol scheme"},
+	},
+	{
+		name: "expected iri not absolute",
+		typ: reflect.TypeFor[struct {
+			Value string "json:\"value\" format:\"iri\""
+		}](),
+		input: map[string]any{"value": "/relative/path"},
+		errs:  []string{"expected string to be RFC 3986 uri: missing protocol scheme"},
+	},
+	{
+		name: "uri-reference success relative",
+		typ: reflect.TypeFor[struct {
+			Value string "json:\"value\" format:\"uri-reference\""
+		}](),
+		input: map[string]any{"value": "/path/to/resource"},
+	},
+	{
+		name: "iri-reference success relative",
+		typ: reflect.TypeFor[struct {
+			Value string "json:\"value\" format:\"iri-reference\""
+		}](),
+		input: map[string]any{"value": "/path/to/resource"},
+	},
+	{
 		name: "uuid success",
 		typ: reflect.TypeFor[struct {
 			Value string "json:\"value\" format:\"uuid\""


### PR DESCRIPTION
Fixes #1064

## Problem

`format:"uri"`, `"iri"`, `"uri-reference"` and `"iri-reference"` all used a bare `url.Parse`, which succeeds for the empty string and relative paths (`/relative`, `foo`, etc.). Per JSON Schema a `uri` must be *absolute* (include a scheme) while a `uri-reference` may be relative, a distinction the validation docs table already drew but the code did not enforce.

## Change

Split the format switch so `uri`/`iri` additionally reject non-absolute values via `url.URL.IsAbs()`, keeping `uri-reference`/`iri-reference` permissive. Non-http schemes (`mailto:`, `urn:`, etc.) still pass, as they are valid absolute URIs.

Added table tests covering absolute/relative/empty for both `uri` and `iri`, plus a non-http scheme success case, and updated the docs table to say "Absolute URI (must have scheme)".

## Compatibility note

This tightens validation: fields using `format:"uri"` that previously accepted `""` or relative paths will now fail. Callers needing relative values should use `format:"uri-reference"`.