### PR TITLE
fix: preserve wrapped resolver error metadata

### DIFF
--- a/error.go
+++ b/error.go
@@ -176,6 +176,20 @@ func (e *errWithHeaders) GetHeaders() http.Header {
 	return e.headers
 }
 
+// appendErrorHeaders appends any headers carried by err (if it is or wraps a
+// HeadersError) onto the response, preserving multi-value headers such as
+// Set-Cookie.
+func appendErrorHeaders(ctx Context, err error) {
+	var he HeadersError
+	if errors.As(err, &he) {
+		for k, values := range he.GetHeaders() {
+			for _, v := range values {
+				ctx.AppendHeader(k, v)
+			}
+		}
+	}
+}
+
 // ErrorWithHeaders wraps an error with additional headers to be sent to the
 // client. This is useful for e.g. caching, rate limiting, or other metadata.
 func ErrorWithHeaders(err error, headers http.Header) error {

--- a/huma.go
+++ b/huma.go
@@ -1197,14 +1197,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 			// Resolver errors may be wrapped and may each carry response metadata,
 			// so preserve headers from every error, matching the handler path below.
 			for _, err := range res.Errors {
-				var he HeadersError
-				if errors.As(err, &he) {
-					for k, values := range he.GetHeaders() {
-						for _, v := range values {
-							ctx.AppendHeader(k, v)
-						}
-					}
-				}
+				appendErrorHeaders(ctx, err)
 			}
 			WriteErr(api, ctx, errStatus, "validation failed", res.Errors...)
 			return
@@ -1212,14 +1205,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 
 		output, err := handler(ctx.Context(), &input)
 		if err != nil {
-			var he HeadersError
-			if errors.As(err, &he) {
-				for k, values := range he.GetHeaders() {
-					for _, v := range values {
-						ctx.AppendHeader(k, v)
-					}
-				}
-			}
+			appendErrorHeaders(ctx, err)
 
 			status := http.StatusInternalServerError
 

--- a/huma.go
+++ b/huma.go
@@ -1188,9 +1188,22 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 				// If there are errors, and they provide a status, then update the
 				// response status code to match. Otherwise, use the default status
 				// code is used. Since these run in order, the last error code wins.
-				if s, ok := res.Errors[i].(StatusError); ok {
+				var s StatusError
+				if errors.As(res.Errors[i], &s) {
 					errStatus = s.GetStatus()
 					break
+				}
+			}
+			// Resolver errors may be wrapped and may each carry response metadata,
+			// so preserve headers from every error, matching the handler path below.
+			for _, err := range res.Errors {
+				var he HeadersError
+				if errors.As(err, &he) {
+					for k, values := range he.GetHeaders() {
+						for _, v := range values {
+							ctx.AppendHeader(k, v)
+						}
+					}
 				}
 			}
 			WriteErr(api, ctx, errStatus, "validation failed", res.Errors...)

--- a/huma_test.go
+++ b/huma_test.go
@@ -3819,6 +3819,36 @@ func TestExhaustiveErrors(t *testing.T) {
 	}`, w.Body.String())
 }
 
+type WrappedResolverErrorInput struct{}
+
+func (*WrappedResolverErrorInput) Resolve(huma.Context) []error {
+	err := huma.ErrorWithHeaders(
+		huma.Error401Unauthorized("credentials required"),
+		http.Header{
+			"WWW-Authenticate": {"Bearer realm=\"protected\""},
+			"Set-Cookie":       {"session=; Max-Age=0", "refresh=; Max-Age=0"},
+		},
+	)
+	return []error{fmt.Errorf("resolver failed: %w", err)}
+}
+
+func TestWrappedResolverErrorStatusAndHeaders(t *testing.T) {
+	router, api := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+	handlerCalled := false
+	huma.Get(api, "/resolver-error", func(context.Context, *WrappedResolverErrorInput) (*struct{}, error) {
+		handlerCalled = true
+		return nil, nil
+	})
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, httptest.NewRequest(http.MethodGet, "/resolver-error", nil))
+
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+	assert.Equal(t, "Bearer realm=\"protected\"", resp.Header().Get("WWW-Authenticate"))
+	assert.Equal(t, []string{"session=; Max-Age=0", "refresh=; Max-Age=0"}, resp.Header().Values("Set-Cookie"))
+	assert.False(t, handlerCalled)
+}
+
 type MyError struct {
 	status  int
 	Message string   `json:"message"`


### PR DESCRIPTION
resolver errors now use `errors.As` for `StatusError`, matching the normal handler error path. i also propagate `HeadersError` values from every resolver error so auth challenges, cookies, and retry metadata aren't dropped.

- keep the existing behavior where the last resolver status wins
- preserve multi-value headers such as `Set-Cookie`
- add a regression test with a wrapped `401`, `WWW-Authenticate`, and two cookies

this pr is an attempt to fix #1069 -- let me know if i got something wrong!