### PR TITLE
fix: handle nil interface response bodies

### DIFF
--- a/huma_test.go
+++ b/huma_test.go
@@ -2851,6 +2851,26 @@ Content-Type: text/plain
 			},
 		},
 		{
+			Name: "response-transform-nil-interface-body",
+			Transformers: []huma.Transformer{
+				huma.NewSchemaLinkTransformer("/", "/").Transform,
+			},
+			Register: func(t *testing.T, api huma.API) {
+				huma.Get(api, "/transform", func(ctx context.Context, i *struct{}) (*struct {
+					Body any
+				}, error) {
+					return &struct {
+						Body any
+					}{Body: nil}, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/transform",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code)
+			},
+		},
+		{
 			Name: "schema-url-from-x-forwarded-host",
 			Transformers: []huma.Transformer{
 				huma.NewSchemaLinkTransformer("/", "/").Transform,

--- a/huma_test.go
+++ b/huma_test.go
@@ -2866,9 +2866,10 @@ Content-Type: text/plain
 			},
 			Method: http.MethodGet,
 			URL:    "/transform",
-			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
-				assert.Equal(t, http.StatusOK, resp.Code)
-			},
+Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.JSONEq(t, `null`, resp.Body.String())
+},
 		},
 		{
 			Name: "schema-url-from-x-forwarded-host",

--- a/transforms.go
+++ b/transforms.go
@@ -155,6 +155,10 @@ func (t *SchemaLinkTransformer) OnAddOperation(oapi *OpenAPI, op *Operation) {
 // Transform is called for every response to add the `$schema` field and/or
 // the Link header pointing to the JSON Schema.
 func (t *SchemaLinkTransformer) Transform(ctx Context, _ string, v any) (any, error) {
+	if v == nil {
+		return v, nil
+	}
+
 	vv := reflect.ValueOf(v)
 	if vv.Kind() == reflect.Pointer && vv.IsNil() {
 		return v, nil


### PR DESCRIPTION
`SchemaLinkTransformer` now returns early for a nil interface before calling `reflect.TypeOf` and `deref`. The existing typed nil pointer behavior stays unchanged.

- added a  regression case with `Body any` set to nil
- keep the normal `200` response and serialize the body as JSON `null`

should fix #1071