### PR TITLE
fix: parse named numeric slice parameters

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -681,20 +681,6 @@ func transformAndWrite(api API, ctx Context, status int, ct string, body any) er
 	return nil
 }
 
-func parseArrElement[T any](values []string, parse func(string) (T, error)) ([]T, error) {
-	result := make([]T, 0, len(values))
-
-	for i := range values {
-		v, err := parse(values[i])
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, v)
-	}
-
-	return result, nil
-}
-
 // writeHeader is a utility function to write a header value to the response.
 // the `write` function should be either `ctx.SetHeader` or `ctx.AppendHeader`.
 func writeHeader(write func(string, string), info *headerInfo, f reflect.Value) {
@@ -1896,7 +1882,8 @@ func parseInto(ctx Context, f reflect.Value, value string, preSplit []string, p 
 // parseSliceInto converts a slice of string values into the expected type of f
 // and sets the result on f.
 func parseSliceInto(f reflect.Value, values []string) (any, error) {
-	switch f.Type().Elem().Kind() {
+	elemType := f.Type().Elem()
+	switch elemType.Kind() {
 	case reflect.String:
 		if f.Type() == stringSliceType {
 			f.Set(reflect.ValueOf(values))
@@ -1913,198 +1900,45 @@ func parseSliceInto(f reflect.Value, values []string) (any, error) {
 		}
 
 		return values, nil
-	case reflect.Int:
-		vs, err := parseArrElement(values, func(s string) (int, error) {
-			val, err := strconv.ParseInt(s, 10, strconv.IntSize)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		vs := reflect.MakeSlice(reflect.SliceOf(elemType), len(values), len(values))
+		for i, s := range values {
+			v, err := strconv.ParseInt(s, 10, elemType.Bits())
 			if err != nil {
-				return 0, err
+				return nil, errors.New("invalid integer")
 			}
-
-			return int(val), nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid integer")
+			vs.Index(i).SetInt(v)
 		}
 
-		f.Set(reflect.ValueOf(vs))
+		f.Set(vs)
 
-		return vs, nil
-	case reflect.Int8:
-		vs, err := parseArrElement(values, func(s string) (int8, error) {
-			val, err := strconv.ParseInt(s, 10, 8)
+		return vs.Interface(), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		vs := reflect.MakeSlice(reflect.SliceOf(elemType), len(values), len(values))
+		for i, s := range values {
+			v, err := strconv.ParseUint(s, 10, elemType.Bits())
 			if err != nil {
-				return 0, err
+				return nil, errors.New("invalid integer")
 			}
-
-			return int8(val), nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid integer")
+			vs.Index(i).SetUint(v)
 		}
 
-		f.Set(reflect.ValueOf(vs))
+		f.Set(vs)
 
-		return vs, nil
-	case reflect.Int16:
-		vs, err := parseArrElement(values, func(s string) (int16, error) {
-			val, err := strconv.ParseInt(s, 10, 16)
+		return vs.Interface(), nil
+	case reflect.Float32, reflect.Float64:
+		vs := reflect.MakeSlice(reflect.SliceOf(elemType), len(values), len(values))
+		for i, s := range values {
+			v, err := strconv.ParseFloat(s, elemType.Bits())
 			if err != nil {
-				return 0, err
+				return nil, errors.New("invalid floating value")
 			}
-
-			return int16(val), nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid integer")
+			vs.Index(i).SetFloat(v)
 		}
 
-		f.Set(reflect.ValueOf(vs))
+		f.Set(vs)
 
-		return vs, nil
-	case reflect.Int32:
-		vs, err := parseArrElement(values, func(s string) (int32, error) {
-			val, err := strconv.ParseInt(s, 10, 32)
-			if err != nil {
-				return 0, err
-			}
-
-			return int32(val), nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid integer")
-		}
-
-		f.Set(reflect.ValueOf(vs))
-
-		return vs, nil
-	case reflect.Int64:
-		vs, err := parseArrElement(values, func(s string) (int64, error) {
-			val, err := strconv.ParseInt(s, 10, 64)
-			if err != nil {
-				return 0, err
-			}
-
-			return val, nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid integer")
-		}
-
-		f.Set(reflect.ValueOf(vs))
-
-		return vs, nil
-	case reflect.Uint:
-		vs, err := parseArrElement(values, func(s string) (uint, error) {
-			val, err := strconv.ParseUint(s, 10, strconv.IntSize)
-			if err != nil {
-				return 0, err
-			}
-
-			return uint(val), nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid integer")
-		}
-
-		f.Set(reflect.ValueOf(vs))
-
-		return vs, nil
-	case reflect.Uint8:
-		vs, err := parseArrElement(values, func(s string) (uint8, error) {
-			val, err := strconv.ParseUint(s, 10, 8)
-			if err != nil {
-				return 0, err
-			}
-
-			return uint8(val), nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid integer")
-		}
-
-		f.Set(reflect.ValueOf(vs))
-
-		return vs, nil
-	case reflect.Uint16:
-		vs, err := parseArrElement(values, func(s string) (uint16, error) {
-			val, err := strconv.ParseUint(s, 10, 16)
-			if err != nil {
-				return 0, err
-			}
-
-			return uint16(val), nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid integer")
-		}
-
-		f.Set(reflect.ValueOf(vs))
-
-		return vs, nil
-	case reflect.Uint32:
-		vs, err := parseArrElement(values, func(s string) (uint32, error) {
-			val, err := strconv.ParseUint(s, 10, 32)
-			if err != nil {
-				return 0, err
-			}
-
-			return uint32(val), nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid integer")
-		}
-
-		f.Set(reflect.ValueOf(vs))
-
-		return vs, nil
-	case reflect.Uint64:
-		vs, err := parseArrElement(values, func(s string) (uint64, error) {
-			val, err := strconv.ParseUint(s, 10, 64)
-			if err != nil {
-				return 0, err
-			}
-
-			return val, nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid integer")
-		}
-
-		f.Set(reflect.ValueOf(vs))
-
-		return vs, nil
-	case reflect.Float32:
-		vs, err := parseArrElement(values, func(s string) (float32, error) {
-			val, err := strconv.ParseFloat(s, 32)
-			if err != nil {
-				return 0, err
-			}
-
-			return float32(val), nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid floating value")
-		}
-
-		f.Set(reflect.ValueOf(vs))
-
-		return vs, nil
-	case reflect.Float64:
-		vs, err := parseArrElement(values, func(s string) (float64, error) {
-			val, err := strconv.ParseFloat(s, 64)
-			if err != nil {
-				return 0, err
-			}
-
-			return val, nil
-		})
-		if err != nil {
-			return nil, errors.New("invalid floating value")
-		}
-
-		f.Set(reflect.ValueOf(vs))
-
-		return vs, nil
+		return vs.Interface(), nil
 	}
 
 	// Last resort: use the `encoding.TextUnmarshaler` interface.

--- a/huma_test.go
+++ b/huma_test.go
@@ -529,6 +529,59 @@ func TestFeatures(t *testing.T) {
 			},
 		},
 		{
+			Name: "params-named-numeric-slices",
+			Register: func(t *testing.T, api huma.API) {
+				type ID int
+				type IDs []ID
+				type Numbers []int
+				type Count uint16
+				type Counts []Count
+				type Ratio float32
+				type Ratios []Ratio
+
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/named-numeric-slices",
+				}, func(ctx context.Context, input *struct {
+					IDs     IDs     `query:"ids"`
+					Numbers Numbers `query:"numbers"`
+					Counts  Counts  `query:"counts"`
+					Ratios  Ratios  `query:"ratios"`
+				}) (*struct{}, error) {
+					assert.Equal(t, IDs{1, 2}, input.IDs)
+					assert.Equal(t, Numbers{5, 6}, input.Numbers)
+					assert.Equal(t, Counts{3, 4}, input.Counts)
+					assert.Equal(t, Ratios{1.5, 2.5}, input.Ratios)
+					return nil, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/named-numeric-slices?ids=1,2&numbers=5,6&counts=3,4&ratios=1.5,2.5",
+		},
+		{
+			Name: "params-named-numeric-slices-validation",
+			Register: func(t *testing.T, api huma.API) {
+				type ID int
+				type IDs []ID
+
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/named-numeric-slices",
+				}, func(ctx context.Context, input *struct {
+					IDs IDs `query:"ids" minimum:"1" uniqueItems:"true"`
+				}) (*struct{}, error) {
+					return nil, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/named-numeric-slices?ids=0,0",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+				assert.Contains(t, resp.Body.String(), "expected number >= 1")
+				assert.Contains(t, resp.Body.String(), "expected array items to be unique")
+			},
+		},
+		{
 			Name: "params-error",
 			Register: func(t *testing.T, api huma.API) {
 				huma.Register(api, huma.Operation{

--- a/validate.go
+++ b/validate.go
@@ -430,7 +430,17 @@ func toFloat64(v any) (float64, bool) {
 		f, err := v.Float64()
 		return f, err == nil
 	default:
-		return 0, false
+		value := reflect.ValueOf(v)
+		switch value.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return float64(value.Int()), true
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return float64(value.Uint()), true
+		case reflect.Float32, reflect.Float64:
+			return value.Float(), true
+		default:
+			return 0, false
+		}
 	}
 }
 
@@ -610,8 +620,25 @@ func Validate(r Registry, s *Schema, path *PathBuffer, mode ValidateMode, v any,
 		case []float64:
 			handleArray(r, s, path, mode, res, arr)
 		default:
-			res.Add(path, v, validation.MsgExpectedArray)
-			return
+			value := reflect.ValueOf(v)
+			if value.Kind() != reflect.Slice {
+				res.Add(path, v, validation.MsgExpectedArray)
+				return
+			}
+			switch value.Type().Elem().Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+				reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+				reflect.Float32, reflect.Float64:
+			default:
+				res.Add(path, v, validation.MsgExpectedArray)
+				return
+			}
+
+			items := make([]any, value.Len())
+			for i := range items {
+				items[i] = value.Index(i).Interface()
+			}
+			handleArray(r, s, path, mode, res, items)
 		}
 	case TypeObject:
 		switch vv := v.(type) {


### PR DESCRIPTION
- build numeric parameter slices with their declared element type instead of assigning built-in slices such as `[]int`
- validate named numeric slices without dropping item, length, or uniqueness constraints
- cover named signed integer, unsigned integer, and float elements, plus named slice containers

fixes #1073 (let me know if the small refactor isn't satisfying!)