### PR TITLE
fix: run nested resolvers in fixed arrays

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -397,7 +397,7 @@ func (r *findResult[T]) every(current reflect.Value, path []int, v T, f func(ref
 	switch current.Kind() {
 	case reflect.Struct:
 		r.every(current.Field(path[0]), path[1:], v, f)
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		for j := 0; j < current.Len(); j++ {
 			r.every(current.Index(j), path, v, f)
 		}
@@ -432,7 +432,7 @@ func jsonName(field reflect.StructField) string {
 // PathBuffer, and applying a function to leaf nodes.
 func (r *findResult[T]) everyPB(current reflect.Value, path []int, pb *PathBuffer, v T, f func(reflect.Value, T)) {
 	switch reflect.Indirect(current).Kind() {
-	case reflect.Slice, reflect.Map:
+	case reflect.Slice, reflect.Array, reflect.Map:
 		// Ignore these. We only care about the leaf nodes.
 	default:
 		if len(path) == 0 {
@@ -480,7 +480,7 @@ func (r *findResult[T]) everyPB(current reflect.Value, path []int, pb *PathBuffe
 		for i := 0; i < pops; i++ {
 			pb.Pop()
 		}
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		for j := 0; j < current.Len(); j++ {
 			pb.PushIndex(j)
 			r.everyPB(current.Index(j), path, pb, v, f)
@@ -566,7 +566,7 @@ func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T]
 				delete(visited, t)
 			}
 		}
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		_findInType[T](t.Elem(), path, result, onType, onField, recurseFields, visited, ignore...)
 	case reflect.Map:
 		_findInType[T](t.Elem(), path, result, onType, onField, recurseFields, visited, ignore...)

--- a/huma_test.go
+++ b/huma_test.go
@@ -4041,6 +4041,45 @@ func TestNestedResolverWithPath(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"location":"body.field1.foo[0].field2"`)
 }
 
+type FixedArrayResolverItem struct {
+	Value    string `json:"value,omitempty" default:"default"`
+	Resolved bool   `json:"-"`
+	Path     string `json:"-"`
+}
+
+func (i *FixedArrayResolverItem) Resolve(_ huma.Context, prefix *huma.PathBuffer) []error {
+	i.Resolved = true
+	i.Path = prefix.String()
+	return nil
+}
+
+func TestResolverInFixedArray(t *testing.T) {
+	r, app := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+	var got FixedArrayResolverItem
+	huma.Register(app, huma.Operation{
+		OperationID: "test",
+		Method:      http.MethodPost,
+		Path:        "/test",
+	}, func(ctx context.Context, input *struct {
+		Body struct {
+			Items [1]FixedArrayResolverItem `json:"items"`
+		}
+	}) (*struct{}, error) {
+		got = input.Body.Items[0]
+		return nil, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"items":[{}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code, w.Body.String())
+	assert.Equal(t, "default", got.Value)
+	assert.True(t, got.Resolved)
+	assert.Equal(t, "body.items[0]", got.Path)
+}
+
 type ResolverCustomStatus struct{}
 
 func (r *ResolverCustomStatus) Resolve(ctx huma.Context) []error {


### PR DESCRIPTION
- make the reflection walkers recurse through fixed arrays the same way they already recurse through slices
- preserve array indices in `ResolverWithPath` locations and apply discovered defaults inside array elements
- add a request-level regression test covering resolver mutation, path generation, and defaults

should fix #1075