### PR TITLE
fix: support defaults for custom JSON wrappers

### DIFF
--- a/huma_test.go
+++ b/huma_test.go
@@ -1196,6 +1196,27 @@ func TestFeatures(t *testing.T) {
 			Body:   `{"items": [{"id": 1}]}`,
 		},
 		{
+			Name: "request-body-custom-unmarshaler-default",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPut,
+					Path:   "/body",
+				}, func(ctx context.Context, input *struct {
+					Body struct {
+						Name OmittableNullable[string] `json:"name,omitzero" default:"Kari"`
+					}
+				}) (*struct{}, error) {
+					assert.True(t, input.Body.Name.Sent)
+					assert.False(t, input.Body.Name.Null)
+					assert.Equal(t, "Kari", input.Body.Name.Value)
+					return nil, nil
+				})
+			},
+			Method: http.MethodPut,
+			URL:    "/body",
+			Body:   `{}`,
+		},
+		{
 			Name: "request-body-pointer-defaults",
 			Register: func(t *testing.T, api huma.API) {
 				huma.Register(api, huma.Operation{

--- a/schema.go
+++ b/schema.go
@@ -43,6 +43,7 @@ var (
 	ipType                = reflect.TypeFor[net.IP]()
 	ipAddrType            = reflect.TypeFor[netip.Addr]()
 	rawMessageType        = reflect.TypeFor[json.RawMessage]()
+	jsonUnmarshalerType   = reflect.TypeFor[json.Unmarshaler]()
 	schemaProviderType    = reflect.TypeFor[SchemaProvider]()
 	schemaTransformerType = reflect.TypeFor[SchemaTransformer]()
 	textUnmarshalerType   = reflect.TypeFor[encoding.TextUnmarshaler]()
@@ -504,6 +505,24 @@ func convertType(fieldName string, t reflect.Type, v any) any {
 		return tmp.Interface()
 	}
 
+	target := deref(t)
+	targetPtr := reflect.PointerTo(target)
+	if target.Implements(jsonUnmarshalerType) || targetPtr.Implements(jsonUnmarshalerType) {
+		data, err := json.Marshal(v)
+		if err != nil {
+			panic(fmt.Errorf("unable to convert %v to %v for field '%s': %v: %w", tv, t, fieldName, err, ErrSchemaInvalid))
+		}
+
+		converted := reflect.New(target)
+		if err := json.Unmarshal(data, converted.Interface()); err != nil {
+			panic(fmt.Errorf("unable to convert %v to %v for field '%s': %v: %w", tv, t, fieldName, err, ErrSchemaInvalid))
+		}
+		if t.Kind() == reflect.Pointer {
+			return converted.Interface()
+		}
+		return converted.Elem().Interface()
+	}
+
 	if !tv.ConvertibleTo(deref(t)) {
 		panic(fmt.Errorf("unable to convert %v to %v for field '%s': %w", tv, t, fieldName, ErrSchemaInvalid))
 	}
@@ -557,7 +576,12 @@ func jsonTagValue(r Registry, fieldName string, s *Schema, value string) any {
 func jsonTag(r Registry, f reflect.StructField, s *Schema, name string) any {
 	t := f.Type
 	if value := f.Tag.Get(name); value != "" {
-		return convertType(f.Name, t, jsonTagValue(r, f.Name, s, value))
+		parsed := jsonTagValue(r, f.Name, s, value)
+		base := deref(t)
+		if base.Implements(schemaProviderType) || reflect.PointerTo(base).Implements(schemaProviderType) {
+			return parsed
+		}
+		return convertType(f.Name, t, parsed)
 	}
 	return nil
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -572,6 +572,22 @@ func TestSchema(t *testing.T) {
 			}`,
 		},
 		{
+			name: "field-default-custom-unmarshaler",
+			input: struct {
+				Value OmittableNullable[string] `json:"value,omitzero" default:"foo"`
+			}{},
+			expected: `{
+				"type": "object",
+				"properties": {
+					"value": {
+						"type": ["string", "null"],
+						"default": "foo"
+					}
+				},
+				"additionalProperties": false
+			}`,
+		},
+		{
 			name: "field-optional-without-name",
 			input: struct {
 				Value string `json:",omitempty"`
@@ -1063,6 +1079,13 @@ func TestSchema(t *testing.T) {
 			name: "panic-json-int",
 			input: struct {
 				Value int `json:"value" default:"true"`
+			}{},
+			panics: `invalid number tag value 'true' for field 'Value': schema is invalid`,
+		},
+		{
+			name: "panic-json-custom-unmarshaler",
+			input: struct {
+				Value OmittableNullable[int] `json:"value,omitzero" default:"true"`
 			}{},
 			panics: `invalid number tag value 'true' for field 'Value': schema is invalid`,
 		},


### PR DESCRIPTION
## Summary

- keep `SchemaProvider` defaults in their declared JSON Schema wire format
- construct runtime defaults through the wrapper's existing `json.Unmarshaler` contract
- preserve schema validation before conversion, so invalid defaults still fail registration

## Root cause

Default tags were reflect-converted directly from the schema value to the Go field type. A custom schema can expose a primitive wire type while using a struct wrapper in Go, so the primitive value is not directly convertible to the wrapper.

## Tests

- `go test . -run '^(TestSchema|TestFeatures)$' -count=1`
- `go test . -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run`

The full Windows suite was also attempted; unrelated platform-sensitive `TestCLIShutdown` and Fiber adapter tests timed out/failed, while the affected core package and configured lint pass.

Fixes #814