### PR TITLE
fix: Ensure autopatch processes properties in the same order every time

### DIFF
--- a/autopatch/autopatch.go
+++ b/autopatch/autopatch.go
@@ -10,14 +10,17 @@ package autopatch
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"iter"
 	"maps"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -496,7 +499,7 @@ func makeOptionalSchema(s *huma.Schema) *huma.Schema {
 
 	if s.Properties != nil {
 		optionalSchema.Properties = make(map[string]*huma.Schema)
-		for k, v := range s.Properties {
+		for k, v := range sortedMapIterator(s.Properties) {
 			optionalSchema.Properties[k] = makeOptionalSchema(v)
 		}
 	}
@@ -559,4 +562,16 @@ func findRelativeResourcePath(requestPath string, putPath string) string {
 		}
 	}
 	return "/" + workingPath
+}
+
+// sortedMapIterator returns a deterministic iterator over m, yielding keys in sorted order.
+func sortedMapIterator[K cmp.Ordered, V any](m map[K]V) iter.Seq2[K, V] {
+	sortedKeys := slices.Sorted(maps.Keys(m))
+	return func(yield func(K, V) bool) {
+		for _, k := range sortedKeys {
+			if !yield(k, m[k]) {
+				return
+			}
+		}
+	}
 }

--- a/autopatch/autopatch_test.go
+++ b/autopatch/autopatch_test.go
@@ -697,3 +697,43 @@ func TestSortedMapIterator(t *testing.T) {
 		})
 	}
 }
+
+func TestSortedMapIterator_EarlyExit(t *testing.T) {
+	inputMap := map[string]int{
+		"5": 5,
+		"4": 4,
+		"3": 3,
+		"2": 2,
+		"1": 1,
+	}
+
+	want := []struct {
+		key   string
+		value int
+	}{
+		{key: "1", value: 1},
+		{key: "2", value: 2},
+		{key: "3", value: 3},
+	}
+
+	elementsToProcess := 3
+	elementsProcessed := 0
+
+	var got []struct {
+		key   string
+		value int
+	}
+
+	for k, v := range sortedMapIterator(inputMap) {
+		got = append(got, struct {
+			key   string
+			value int
+		}{key: k, value: v})
+
+		elementsProcessed++
+		if elementsProcessed == elementsToProcess {
+			break
+		}
+	}
+	assert.Equal(t, want, got)
+}

--- a/autopatch/autopatch_test.go
+++ b/autopatch/autopatch_test.go
@@ -635,3 +635,65 @@ func TestFindRelativeResourcePath(t *testing.T) {
 		assert.Equal(t, test.expected, findRelativeResourcePath(test.requestPath, test.putPath))
 	}
 }
+
+func TestSortedMapIterator(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]int
+		want []struct {
+			key   string
+			value int
+		}
+	}{
+		{
+			name: "empty map",
+			m:    map[string]int{},
+			want: nil,
+		},
+		{
+			name: "nil map",
+			m:    nil,
+			want: nil,
+		},
+		{
+			name: "single entry",
+			m:    map[string]int{"one": 1},
+			want: []struct {
+				key   string
+				value int
+			}{{key: "one", value: 1}},
+		},
+		{
+			name: "sorted key order",
+			m: map[string]int{
+				"zebra": 3,
+				"alpha": 1,
+				"mango": 2,
+			},
+			want: []struct {
+				key   string
+				value int
+			}{
+				{key: "alpha", value: 1},
+				{key: "mango", value: 2},
+				{key: "zebra", value: 3},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got []struct {
+				key   string
+				value int
+			}
+			for k, v := range sortedMapIterator(test.m) {
+				got = append(got, struct {
+					key   string
+					value int
+				}{key: k, value: v})
+			}
+			assert.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Since map iterators return properties in a random order, autopatch schemas can fluctuate when multiple fields use the same type.

This change ensures fields are processed in a deterministic order (sorted by name) to avoid type name fluctuations.