### PR TITLE
fix: Allow autopatch to resolve refs, when making the put schema optional

### DIFF
--- a/autopatch/autopatch.go
+++ b/autopatch/autopatch.go
@@ -236,7 +236,7 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 	putSchema := put.RequestBody.Content["application/json"].Schema
 
 	// Create an optional version of the PUT schema
-	optionalPutSchema := makeOptionalSchema(api.OpenAPI().Components.Schemas, putSchema)
+	optionalPutSchema := makeOptionalSchema(api.OpenAPI().Components.Schemas, putSchema, map[string]struct{}{})
 
 	// Manually register the operation so it shows up in the generated OpenAPI.
 	op := &huma.Operation{
@@ -450,13 +450,22 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 	})
 }
 
-func makeOptionalSchema(registry huma.Registry, s *huma.Schema) *huma.Schema {
+func makeOptionalSchema(registry huma.Registry, s *huma.Schema, visited map[string]struct{}) *huma.Schema {
 	if s == nil {
 		return nil
 	}
 
+	// If this schema has a ref, try to resolve it and leverage the referenced schema
 	if s.Ref != "" {
-		s = registry.SchemaFromRef(s.Ref)
+		resolved := registry.SchemaFromRef(s.Ref)
+		if _, cycle := visited[s.Ref]; cycle || resolved == nil {
+			// Unresolvable or self-referential: leave the ref in place.
+			return &huma.Schema{Ref: s.Ref}
+		}
+
+		visited[s.Ref] = struct{}{}
+		defer delete(visited, s.Ref)
+		s = resolved
 	}
 
 	optionalSchema := &huma.Schema{
@@ -492,39 +501,39 @@ func makeOptionalSchema(registry huma.Registry, s *huma.Schema) *huma.Schema {
 	}
 
 	if s.Items != nil {
-		optionalSchema.Items = makeOptionalSchema(registry, s.Items)
+		optionalSchema.Items = makeOptionalSchema(registry, s.Items, visited)
 	}
 
 	if s.Properties != nil {
 		optionalSchema.Properties = make(map[string]*huma.Schema)
 		for k, v := range s.Properties {
-			optionalSchema.Properties[k] = makeOptionalSchema(registry, v)
+			optionalSchema.Properties[k] = makeOptionalSchema(registry, v, visited)
 		}
 	}
 
 	if s.OneOf != nil {
 		optionalSchema.OneOf = make([]*huma.Schema, len(s.OneOf))
 		for i, schema := range s.OneOf {
-			optionalSchema.OneOf[i] = makeOptionalSchema(registry, schema)
+			optionalSchema.OneOf[i] = makeOptionalSchema(registry, schema, visited)
 		}
 	}
 
 	if s.AnyOf != nil {
 		optionalSchema.AnyOf = make([]*huma.Schema, len(s.AnyOf))
 		for i, schema := range s.AnyOf {
-			optionalSchema.AnyOf[i] = makeOptionalSchema(registry, schema)
+			optionalSchema.AnyOf[i] = makeOptionalSchema(registry, schema, visited)
 		}
 	}
 
 	if s.AllOf != nil {
 		optionalSchema.AllOf = make([]*huma.Schema, len(s.AllOf))
 		for i, schema := range s.AllOf {
-			optionalSchema.AllOf[i] = makeOptionalSchema(registry, schema)
+			optionalSchema.AllOf[i] = makeOptionalSchema(registry, schema, visited)
 		}
 	}
 
 	if s.Not != nil {
-		optionalSchema.Not = makeOptionalSchema(registry, s.Not)
+		optionalSchema.Not = makeOptionalSchema(registry, s.Not, visited)
 	}
 
 	// Make all properties optional

--- a/autopatch/autopatch.go
+++ b/autopatch/autopatch.go
@@ -450,7 +450,7 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 	})
 }
 
-func makeOptionalSchema(registry huma.Registry, s *huma.Schema, visited map[string]struct{}) *huma.Schema {
+func makeOptionalSchema(registry huma.Registry, s *huma.Schema, visitedRefs map[string]struct{}) *huma.Schema {
 	if s == nil {
 		return nil
 	}
@@ -458,13 +458,13 @@ func makeOptionalSchema(registry huma.Registry, s *huma.Schema, visited map[stri
 	// If this schema has a ref, try to resolve it and leverage the referenced schema
 	if s.Ref != "" {
 		resolved := registry.SchemaFromRef(s.Ref)
-		if _, cycle := visited[s.Ref]; cycle || resolved == nil {
+		if _, cycle := visitedRefs[s.Ref]; cycle || resolved == nil {
 			// Unresolvable or self-referential: leave the ref in place.
 			return &huma.Schema{Ref: s.Ref}
 		}
 
-		visited[s.Ref] = struct{}{}
-		defer delete(visited, s.Ref)
+		visitedRefs[s.Ref] = struct{}{}
+		defer delete(visitedRefs, s.Ref)
 		s = resolved
 	}
 
@@ -500,19 +500,19 @@ func makeOptionalSchema(registry huma.Registry, s *huma.Schema, visited map[stri
 	}
 
 	if s.Items != nil {
-		optionalSchema.Items = makeOptionalSchema(registry, s.Items, visited)
+		optionalSchema.Items = makeOptionalSchema(registry, s.Items, visitedRefs)
 	}
 
 	if s.Properties != nil {
 		optionalSchema.Properties = make(map[string]*huma.Schema)
 		for k, v := range s.Properties {
-			optionalSchema.Properties[k] = makeOptionalSchema(registry, v, visited)
+			optionalSchema.Properties[k] = makeOptionalSchema(registry, v, visitedRefs)
 		}
 	}
 
 	if s.AdditionalProperties != nil {
 		if additionalPropertiesSchema, ok := s.AdditionalProperties.(*huma.Schema); ok {
-			optionalSchema.AdditionalProperties = makeOptionalSchema(registry, additionalPropertiesSchema, visited)
+			optionalSchema.AdditionalProperties = makeOptionalSchema(registry, additionalPropertiesSchema, visitedRefs)
 		} else {
 			optionalSchema.AdditionalProperties = s.AdditionalProperties
 		}
@@ -521,26 +521,26 @@ func makeOptionalSchema(registry huma.Registry, s *huma.Schema, visited map[stri
 	if s.OneOf != nil {
 		optionalSchema.OneOf = make([]*huma.Schema, len(s.OneOf))
 		for i, schema := range s.OneOf {
-			optionalSchema.OneOf[i] = makeOptionalSchema(registry, schema, visited)
+			optionalSchema.OneOf[i] = makeOptionalSchema(registry, schema, visitedRefs)
 		}
 	}
 
 	if s.AnyOf != nil {
 		optionalSchema.AnyOf = make([]*huma.Schema, len(s.AnyOf))
 		for i, schema := range s.AnyOf {
-			optionalSchema.AnyOf[i] = makeOptionalSchema(registry, schema, visited)
+			optionalSchema.AnyOf[i] = makeOptionalSchema(registry, schema, visitedRefs)
 		}
 	}
 
 	if s.AllOf != nil {
 		optionalSchema.AllOf = make([]*huma.Schema, len(s.AllOf))
 		for i, schema := range s.AllOf {
-			optionalSchema.AllOf[i] = makeOptionalSchema(registry, schema, visited)
+			optionalSchema.AllOf[i] = makeOptionalSchema(registry, schema, visitedRefs)
 		}
 	}
 
 	if s.Not != nil {
-		optionalSchema.Not = makeOptionalSchema(registry, s.Not, visited)
+		optionalSchema.Not = makeOptionalSchema(registry, s.Not, visitedRefs)
 	}
 
 	// Make all properties optional

--- a/autopatch/autopatch.go
+++ b/autopatch/autopatch.go
@@ -236,7 +236,7 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 	putSchema := put.RequestBody.Content["application/json"].Schema
 
 	// Create an optional version of the PUT schema
-	optionalPutSchema := makeOptionalSchema(api.OpenAPI().Components.Schemas, putSchema, map[string]struct{}{})
+	optionalPutSchema := makeOptionalSchema(oapi.Components.Schemas, putSchema, map[string]struct{}{})
 
 	// Manually register the operation so it shows up in the generated OpenAPI.
 	op := &huma.Operation{

--- a/autopatch/autopatch.go
+++ b/autopatch/autopatch.go
@@ -234,12 +234,9 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 
 	// Get the schema from the PUT operation
 	putSchema := put.RequestBody.Content["application/json"].Schema
-	if putSchema.Ref != "" {
-		putSchema = oapi.Components.Schemas.SchemaFromRef(putSchema.Ref)
-	}
 
 	// Create an optional version of the PUT schema
-	optionalPutSchema := makeOptionalSchema(putSchema)
+	optionalPutSchema := makeOptionalSchema(api.OpenAPI().Components.Schemas, putSchema)
 
 	// Manually register the operation so it shows up in the generated OpenAPI.
 	op := &huma.Operation{
@@ -453,9 +450,13 @@ func PatchResource(api huma.API, path *huma.PathItem) {
 	})
 }
 
-func makeOptionalSchema(s *huma.Schema) *huma.Schema {
+func makeOptionalSchema(registry huma.Registry, s *huma.Schema) *huma.Schema {
 	if s == nil {
 		return nil
+	}
+
+	if s.Ref != "" {
+		s = registry.SchemaFromRef(s.Ref)
 	}
 
 	optionalSchema := &huma.Schema{
@@ -491,39 +492,39 @@ func makeOptionalSchema(s *huma.Schema) *huma.Schema {
 	}
 
 	if s.Items != nil {
-		optionalSchema.Items = makeOptionalSchema(s.Items)
+		optionalSchema.Items = makeOptionalSchema(registry, s.Items)
 	}
 
 	if s.Properties != nil {
 		optionalSchema.Properties = make(map[string]*huma.Schema)
 		for k, v := range s.Properties {
-			optionalSchema.Properties[k] = makeOptionalSchema(v)
+			optionalSchema.Properties[k] = makeOptionalSchema(registry, v)
 		}
 	}
 
 	if s.OneOf != nil {
 		optionalSchema.OneOf = make([]*huma.Schema, len(s.OneOf))
 		for i, schema := range s.OneOf {
-			optionalSchema.OneOf[i] = makeOptionalSchema(schema)
+			optionalSchema.OneOf[i] = makeOptionalSchema(registry, schema)
 		}
 	}
 
 	if s.AnyOf != nil {
 		optionalSchema.AnyOf = make([]*huma.Schema, len(s.AnyOf))
 		for i, schema := range s.AnyOf {
-			optionalSchema.AnyOf[i] = makeOptionalSchema(schema)
+			optionalSchema.AnyOf[i] = makeOptionalSchema(registry, schema)
 		}
 	}
 
 	if s.AllOf != nil {
 		optionalSchema.AllOf = make([]*huma.Schema, len(s.AllOf))
 		for i, schema := range s.AllOf {
-			optionalSchema.AllOf[i] = makeOptionalSchema(schema)
+			optionalSchema.AllOf[i] = makeOptionalSchema(registry, schema)
 		}
 	}
 
 	if s.Not != nil {
-		optionalSchema.Not = makeOptionalSchema(s.Not)
+		optionalSchema.Not = makeOptionalSchema(registry, s.Not)
 	}
 
 	// Make all properties optional

--- a/autopatch/autopatch.go
+++ b/autopatch/autopatch.go
@@ -469,35 +469,34 @@ func makeOptionalSchema(registry huma.Registry, s *huma.Schema, visited map[stri
 	}
 
 	optionalSchema := &huma.Schema{
-		Type:                 s.Type,
-		Title:                s.Title,
-		Description:          s.Description,
-		Format:               s.Format,
-		ContentEncoding:      s.ContentEncoding,
-		Default:              s.Default,
-		Examples:             s.Examples,
-		AdditionalProperties: s.AdditionalProperties,
-		Enum:                 s.Enum,
-		Minimum:              s.Minimum,
-		ExclusiveMinimum:     s.ExclusiveMinimum,
-		Maximum:              s.Maximum,
-		ExclusiveMaximum:     s.ExclusiveMaximum,
-		MultipleOf:           s.MultipleOf,
-		MinLength:            s.MinLength,
-		MaxLength:            s.MaxLength,
-		Pattern:              s.Pattern,
-		PatternDescription:   s.PatternDescription,
-		MinItems:             s.MinItems,
-		MaxItems:             s.MaxItems,
-		UniqueItems:          s.UniqueItems,
-		MinProperties:        s.MinProperties,
-		MaxProperties:        s.MaxProperties,
-		ReadOnly:             s.ReadOnly,
-		WriteOnly:            s.WriteOnly,
-		Deprecated:           s.Deprecated,
-		Extensions:           s.Extensions,
-		DependentRequired:    s.DependentRequired,
-		Discriminator:        s.Discriminator,
+		Type:               s.Type,
+		Title:              s.Title,
+		Description:        s.Description,
+		Format:             s.Format,
+		ContentEncoding:    s.ContentEncoding,
+		Default:            s.Default,
+		Examples:           s.Examples,
+		Enum:               s.Enum,
+		Minimum:            s.Minimum,
+		ExclusiveMinimum:   s.ExclusiveMinimum,
+		Maximum:            s.Maximum,
+		ExclusiveMaximum:   s.ExclusiveMaximum,
+		MultipleOf:         s.MultipleOf,
+		MinLength:          s.MinLength,
+		MaxLength:          s.MaxLength,
+		Pattern:            s.Pattern,
+		PatternDescription: s.PatternDescription,
+		MinItems:           s.MinItems,
+		MaxItems:           s.MaxItems,
+		UniqueItems:        s.UniqueItems,
+		MinProperties:      s.MinProperties,
+		MaxProperties:      s.MaxProperties,
+		ReadOnly:           s.ReadOnly,
+		WriteOnly:          s.WriteOnly,
+		Deprecated:         s.Deprecated,
+		Extensions:         s.Extensions,
+		DependentRequired:  s.DependentRequired,
+		Discriminator:      s.Discriminator,
 	}
 
 	if s.Items != nil {
@@ -508,6 +507,14 @@ func makeOptionalSchema(registry huma.Registry, s *huma.Schema, visited map[stri
 		optionalSchema.Properties = make(map[string]*huma.Schema)
 		for k, v := range s.Properties {
 			optionalSchema.Properties[k] = makeOptionalSchema(registry, v, visited)
+		}
+	}
+
+	if s.AdditionalProperties != nil {
+		if additionalPropertiesSchema, ok := s.AdditionalProperties.(*huma.Schema); ok {
+			optionalSchema.AdditionalProperties = makeOptionalSchema(registry, additionalPropertiesSchema, visited)
+		} else {
+			optionalSchema.AdditionalProperties = s.AdditionalProperties
 		}
 	}
 

--- a/autopatch/autopatch_test.go
+++ b/autopatch/autopatch_test.go
@@ -416,6 +416,10 @@ func TestNullabilityExtension(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, w.Code)
 }
 
+func testRegistry() huma.Registry {
+	return huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
+}
+
 func TestMakeOptionalSchemaBasicProperties(t *testing.T) {
 	originalSchema := &huma.Schema{
 		Type: "object",
@@ -426,7 +430,7 @@ func TestMakeOptionalSchemaBasicProperties(t *testing.T) {
 		Required: []string{"id", "name"},
 	}
 
-	optionalSchema := makeOptionalSchema(originalSchema)
+	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
 
 	assert.Equal(t, "object", optionalSchema.Type)
 	assert.Contains(t, optionalSchema.Properties, "id")
@@ -442,7 +446,7 @@ func TestMakeOptionalSchemaAnyOf(t *testing.T) {
 		},
 	}
 
-	optionalSchema := makeOptionalSchema(originalSchema)
+	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
 
 	assert.Len(t, optionalSchema.AnyOf, 2)
 	assert.Equal(t, "string", optionalSchema.AnyOf[0].Type)
@@ -459,7 +463,7 @@ func TestMakeOptionalSchemaAllOf(t *testing.T) {
 		},
 	}
 
-	optionalSchema := makeOptionalSchema(originalSchema)
+	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
 
 	assert.Len(t, optionalSchema.AllOf, 2)
 	assert.Equal(t, 1, *optionalSchema.AllOf[0].MinLength)
@@ -473,14 +477,14 @@ func TestMakeOptionalSchemaNot(t *testing.T) {
 		},
 	}
 
-	optionalSchema := makeOptionalSchema(originalSchema)
+	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
 
 	assert.NotNil(t, optionalSchema.Not)
 	assert.Equal(t, "null", optionalSchema.Not.Type)
 }
 
 func TestMakeOptionalSchemaNilInput(t *testing.T) {
-	assert.Nil(t, makeOptionalSchema(nil))
+	assert.Nil(t, makeOptionalSchema(testRegistry(), nil))
 }
 
 func TestReplaceNulls(t *testing.T) {
@@ -590,10 +594,69 @@ func TestMakeOptionalSchemaNestedSchemas(t *testing.T) {
 		Required: []string{"nested"},
 	}
 
-	optionalNestedSchema := makeOptionalSchema(nestedSchema)
+	optionalNestedSchema := makeOptionalSchema(testRegistry(), nestedSchema)
 
 	assert.Empty(t, optionalNestedSchema.Required)
 	assert.Empty(t, optionalNestedSchema.Properties["nested"].Required)
+}
+
+func TestMakeOptionalSchemaRefs(t *testing.T) {
+	const addressRef = "#/components/schemas/Address"
+	const tagRef = "#/components/schemas/Tag"
+
+	registry := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
+	registry.Map()["Address"] = &huma.Schema{
+		Type: "object",
+		Properties: map[string]*huma.Schema{
+			"street": {Type: "string"},
+			"city":   {Type: "string"},
+		},
+		Required: []string{"street", "city"},
+	}
+	registry.Map()["Tag"] = &huma.Schema{Type: "string"}
+
+	t.Run("top-level ref", func(t *testing.T) {
+		optional := makeOptionalSchema(registry, &huma.Schema{Ref: addressRef})
+
+		assert.Empty(t, optional.Ref)
+		assert.Equal(t, "object", optional.Type)
+		assert.Empty(t, optional.Required)
+		assert.Len(t, optional.Properties, 2)
+		assert.Equal(t, "string", optional.Properties["street"].Type)
+		assert.Equal(t, "string", optional.Properties["city"].Type)
+	})
+
+	t.Run("property ref", func(t *testing.T) {
+		parent := &huma.Schema{
+			Type: "object",
+			Properties: map[string]*huma.Schema{
+				"address": {Ref: addressRef},
+			},
+			Required: []string{"address"},
+		}
+
+		optional := makeOptionalSchema(registry, parent)
+
+		assert.Empty(t, optional.Required)
+		address := optional.Properties["address"]
+		require.NotNil(t, address)
+		assert.Empty(t, address.Ref)
+		assert.Equal(t, "object", address.Type)
+		assert.Empty(t, address.Required)
+	})
+
+	t.Run("items ref", func(t *testing.T) {
+		parent := &huma.Schema{
+			Type:  "array",
+			Items: &huma.Schema{Ref: tagRef},
+		}
+
+		optional := makeOptionalSchema(registry, parent)
+
+		require.NotNil(t, optional.Items)
+		assert.Empty(t, optional.Items.Ref)
+		assert.Equal(t, "string", optional.Items.Type)
+	})
 }
 
 type findRelativeResourcePathTest struct {

--- a/autopatch/autopatch_test.go
+++ b/autopatch/autopatch_test.go
@@ -453,6 +453,21 @@ func TestMakeOptionalSchemaAnyOf(t *testing.T) {
 	assert.Equal(t, "number", optionalSchema.AnyOf[1].Type)
 }
 
+func TestMakeOptionalSchemaOneOf(t *testing.T) {
+	originalSchema := &huma.Schema{
+		OneOf: []*huma.Schema{
+			{Type: "string"},
+			{Type: "number"},
+		},
+	}
+
+	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
+
+	assert.Len(t, optionalSchema.OneOf, 2)
+	assert.Equal(t, "string", optionalSchema.OneOf[0].Type)
+	assert.Equal(t, "number", optionalSchema.OneOf[1].Type)
+}
+
 func TestMakeOptionalSchemaAllOf(t *testing.T) {
 	minLength := 1
 	maxLength := 100

--- a/autopatch/autopatch_test.go
+++ b/autopatch/autopatch_test.go
@@ -774,6 +774,115 @@ func TestMakeOptionalSchemaRefs(t *testing.T) {
 	})
 }
 
+func TestMakeOptionalSchemaAdditionalProperties(t *testing.T) {
+	t.Run("boolean additionalProperties", func(t *testing.T) {
+		for _, val := range []bool{true, false} {
+			original := &huma.Schema{
+				Type: "object",
+				Properties: map[string]*huma.Schema{
+					"name": {Type: "string"},
+				},
+				Required:             []string{"name"},
+				AdditionalProperties: val,
+			}
+
+			optional := testMakeOptionalSchema(testRegistry(), original)
+
+			assert.Equal(t, val, optional.AdditionalProperties)
+			assert.Empty(t, optional.Required)
+		}
+	})
+
+	t.Run("inline schema additionalProperties", func(t *testing.T) {
+		original := &huma.Schema{
+			Type: "object",
+			AdditionalProperties: &huma.Schema{
+				Type: "object",
+				Properties: map[string]*huma.Schema{
+					"value": {Type: "string"},
+				},
+				Required: []string{"value"},
+			},
+		}
+
+		optional := testMakeOptionalSchema(testRegistry(), original)
+
+		addl, ok := optional.AdditionalProperties.(*huma.Schema)
+		require.True(t, ok)
+		assert.Equal(t, "object", addl.Type)
+		assert.Empty(t, addl.Required)
+		assert.Equal(t, "string", addl.Properties["value"].Type)
+	})
+
+	t.Run("ref additionalProperties", func(t *testing.T) {
+		const tagRef = "#/components/schemas/Tag"
+
+		registry := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
+		registry.Map()["Tag"] = &huma.Schema{
+			Type: "object",
+			Properties: map[string]*huma.Schema{
+				"label": {Type: "string"},
+			},
+			Required: []string{"label"},
+		}
+
+		original := &huma.Schema{
+			Type:                 "object",
+			AdditionalProperties: &huma.Schema{Ref: tagRef},
+		}
+
+		optional := testMakeOptionalSchema(registry, original)
+
+		addl, ok := optional.AdditionalProperties.(*huma.Schema)
+		require.True(t, ok)
+		assert.Empty(t, addl.Ref)
+		assert.Equal(t, "object", addl.Type)
+		assert.Empty(t, addl.Required)
+		assert.Equal(t, "string", addl.Properties["label"].Type)
+	})
+
+	t.Run("recursive ref additionalProperties", func(t *testing.T) {
+		const nodeRef = "#/components/schemas/Node"
+
+		registry := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
+		registry.Map()["Node"] = &huma.Schema{
+			Type: "object",
+			Properties: map[string]*huma.Schema{
+				"name": {Type: "string"},
+				"named": {
+					Type: "object",
+					AdditionalProperties: &huma.Schema{Ref: nodeRef},
+				},
+			},
+			Required: []string{"name"},
+		}
+
+		optional := testMakeOptionalSchema(registry, &huma.Schema{Ref: nodeRef})
+
+		assert.Empty(t, optional.Required)
+		named := optional.Properties["named"]
+		require.NotNil(t, named)
+		addl, ok := named.AdditionalProperties.(*huma.Schema)
+		require.True(t, ok)
+		assert.Equal(t, nodeRef, addl.Ref)
+	})
+
+	t.Run("unresolvable ref additionalProperties", func(t *testing.T) {
+		const externalRef = "https://example.com/schemas/Thing.json"
+
+		original := &huma.Schema{
+			Type:                 "object",
+			AdditionalProperties: &huma.Schema{Ref: externalRef},
+		}
+
+		optional := testMakeOptionalSchema(testRegistry(), original)
+
+		addl, ok := optional.AdditionalProperties.(*huma.Schema)
+		require.True(t, ok)
+		assert.Equal(t, externalRef, addl.Ref)
+	})
+}
+
 type findRelativeResourcePathTest struct {
 	requestPath string
 	putPath     string

--- a/autopatch/autopatch_test.go
+++ b/autopatch/autopatch_test.go
@@ -438,21 +438,6 @@ func TestMakeOptionalSchemaBasicProperties(t *testing.T) {
 	assert.Empty(t, optionalSchema.Required)
 }
 
-func TestMakeOptionalSchemaAnyOf(t *testing.T) {
-	originalSchema := &huma.Schema{
-		AnyOf: []*huma.Schema{
-			{Type: "string"},
-			{Type: "number"},
-		},
-	}
-
-	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
-
-	assert.Len(t, optionalSchema.AnyOf, 2)
-	assert.Equal(t, "string", optionalSchema.AnyOf[0].Type)
-	assert.Equal(t, "number", optionalSchema.AnyOf[1].Type)
-}
-
 func TestMakeOptionalSchemaOneOf(t *testing.T) {
 	originalSchema := &huma.Schema{
 		OneOf: []*huma.Schema{
@@ -466,6 +451,21 @@ func TestMakeOptionalSchemaOneOf(t *testing.T) {
 	assert.Len(t, optionalSchema.OneOf, 2)
 	assert.Equal(t, "string", optionalSchema.OneOf[0].Type)
 	assert.Equal(t, "number", optionalSchema.OneOf[1].Type)
+}
+
+func TestMakeOptionalSchemaAnyOf(t *testing.T) {
+	originalSchema := &huma.Schema{
+		AnyOf: []*huma.Schema{
+			{Type: "string"},
+			{Type: "number"},
+		},
+	}
+
+	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
+
+	assert.Len(t, optionalSchema.AnyOf, 2)
+	assert.Equal(t, "string", optionalSchema.AnyOf[0].Type)
+	assert.Equal(t, "number", optionalSchema.AnyOf[1].Type)
 }
 
 func TestMakeOptionalSchemaAllOf(t *testing.T) {

--- a/autopatch/autopatch_test.go
+++ b/autopatch/autopatch_test.go
@@ -297,6 +297,65 @@ func TestExplicitDisable(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code, w.Body.String())
 }
 
+func TestPatchRecursiveNode(t *testing.T) {
+	type Node struct {
+		Name     string  `json:"name"`
+		Children []*Node `json:"children,omitempty"`
+	}
+
+	db := map[string]*Node{
+		"root": {Name: "root", Children: []*Node{{Name: "child"}}},
+	}
+
+	_, api := humatest.New(t)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-node",
+		Method:      http.MethodGet,
+		Path:        "/nodes/{id}",
+		Errors:      []int{404},
+	}, func(ctx context.Context, input *struct {
+		ID string `path:"id"`
+	}) (*struct {
+		Body *Node
+	}, error) {
+		node := db[input.ID]
+		if node == nil {
+			return nil, huma.Error404NotFound("Not found")
+		}
+		return &struct{ Body *Node }{Body: node}, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "put-node",
+		Method:      http.MethodPut,
+		Path:        "/nodes/{id}",
+		Errors:      []int{404},
+	}, func(ctx context.Context, input *struct {
+		ID   string `path:"id"`
+		Body Node
+	}) (*struct {
+		Body *Node
+	}, error) {
+		node := input.Body
+		db[input.ID] = &node
+		return &struct{ Body *Node }{Body: db[input.ID]}, nil
+	})
+
+	AutoPatch(api)
+
+	path := api.OpenAPI().Paths["/nodes/{id}"]
+	require.NotNil(t, path)
+	require.NotNil(t, path.Patch)
+
+	w := api.Patch("/nodes/root",
+		"Content-Type: application/merge-patch+json",
+		strings.NewReader(`{"name": "updated"}`),
+	)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"name":"updated"`)
+}
+
 func TestDeprecatedPatch(t *testing.T) {
 	_, api := humatest.New(t)
 
@@ -420,6 +479,10 @@ func testRegistry() huma.Registry {
 	return huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
 }
 
+func testMakeOptionalSchema(registry huma.Registry, s *huma.Schema) *huma.Schema {
+	return makeOptionalSchema(registry, s, map[string]struct{}{})
+}
+
 func TestMakeOptionalSchemaBasicProperties(t *testing.T) {
 	originalSchema := &huma.Schema{
 		Type: "object",
@@ -430,7 +493,7 @@ func TestMakeOptionalSchemaBasicProperties(t *testing.T) {
 		Required: []string{"id", "name"},
 	}
 
-	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
+	optionalSchema := testMakeOptionalSchema(testRegistry(), originalSchema)
 
 	assert.Equal(t, "object", optionalSchema.Type)
 	assert.Contains(t, optionalSchema.Properties, "id")
@@ -446,7 +509,7 @@ func TestMakeOptionalSchemaOneOf(t *testing.T) {
 		},
 	}
 
-	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
+	optionalSchema := testMakeOptionalSchema(testRegistry(), originalSchema)
 
 	assert.Len(t, optionalSchema.OneOf, 2)
 	assert.Equal(t, "string", optionalSchema.OneOf[0].Type)
@@ -461,7 +524,7 @@ func TestMakeOptionalSchemaAnyOf(t *testing.T) {
 		},
 	}
 
-	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
+	optionalSchema := testMakeOptionalSchema(testRegistry(), originalSchema)
 
 	assert.Len(t, optionalSchema.AnyOf, 2)
 	assert.Equal(t, "string", optionalSchema.AnyOf[0].Type)
@@ -478,7 +541,7 @@ func TestMakeOptionalSchemaAllOf(t *testing.T) {
 		},
 	}
 
-	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
+	optionalSchema := testMakeOptionalSchema(testRegistry(), originalSchema)
 
 	assert.Len(t, optionalSchema.AllOf, 2)
 	assert.Equal(t, 1, *optionalSchema.AllOf[0].MinLength)
@@ -492,14 +555,14 @@ func TestMakeOptionalSchemaNot(t *testing.T) {
 		},
 	}
 
-	optionalSchema := makeOptionalSchema(testRegistry(), originalSchema)
+	optionalSchema := testMakeOptionalSchema(testRegistry(), originalSchema)
 
 	assert.NotNil(t, optionalSchema.Not)
 	assert.Equal(t, "null", optionalSchema.Not.Type)
 }
 
 func TestMakeOptionalSchemaNilInput(t *testing.T) {
-	assert.Nil(t, makeOptionalSchema(testRegistry(), nil))
+	assert.Nil(t, testMakeOptionalSchema(testRegistry(), nil))
 }
 
 func TestReplaceNulls(t *testing.T) {
@@ -609,7 +672,7 @@ func TestMakeOptionalSchemaNestedSchemas(t *testing.T) {
 		Required: []string{"nested"},
 	}
 
-	optionalNestedSchema := makeOptionalSchema(testRegistry(), nestedSchema)
+	optionalNestedSchema := testMakeOptionalSchema(testRegistry(), nestedSchema)
 
 	assert.Empty(t, optionalNestedSchema.Required)
 	assert.Empty(t, optionalNestedSchema.Properties["nested"].Required)
@@ -631,7 +694,7 @@ func TestMakeOptionalSchemaRefs(t *testing.T) {
 	registry.Map()["Tag"] = &huma.Schema{Type: "string"}
 
 	t.Run("top-level ref", func(t *testing.T) {
-		optional := makeOptionalSchema(registry, &huma.Schema{Ref: addressRef})
+		optional := testMakeOptionalSchema(registry, &huma.Schema{Ref: addressRef})
 
 		assert.Empty(t, optional.Ref)
 		assert.Equal(t, "object", optional.Type)
@@ -650,7 +713,7 @@ func TestMakeOptionalSchemaRefs(t *testing.T) {
 			Required: []string{"address"},
 		}
 
-		optional := makeOptionalSchema(registry, parent)
+		optional := testMakeOptionalSchema(registry, parent)
 
 		assert.Empty(t, optional.Required)
 		address := optional.Properties["address"]
@@ -666,11 +729,48 @@ func TestMakeOptionalSchemaRefs(t *testing.T) {
 			Items: &huma.Schema{Ref: tagRef},
 		}
 
-		optional := makeOptionalSchema(registry, parent)
+		optional := testMakeOptionalSchema(registry, parent)
 
 		require.NotNil(t, optional.Items)
 		assert.Empty(t, optional.Items.Ref)
 		assert.Equal(t, "string", optional.Items.Type)
+	})
+
+	t.Run("unresolvable external ref", func(t *testing.T) {
+		const externalRef = "https://example.com/schemas/Thing.json"
+
+		optional := testMakeOptionalSchema(registry, &huma.Schema{Ref: externalRef})
+
+		require.NotNil(t, optional)
+		assert.Equal(t, externalRef, optional.Ref)
+		assert.Empty(t, optional.Type)
+	})
+
+	t.Run("recursive self reference", func(t *testing.T) {
+		const nodeRef = "#/components/schemas/Node"
+
+		registry := huma.NewMapRegistry("#/components/schemas/", huma.DefaultSchemaNamer)
+		registry.Map()["Node"] = &huma.Schema{
+			Type: "object",
+			Properties: map[string]*huma.Schema{
+				"name": {Type: "string"},
+				"children": {
+					Type:  "array",
+					Items: &huma.Schema{Ref: nodeRef},
+				},
+			},
+			Required: []string{"name"},
+		}
+
+		optional := testMakeOptionalSchema(registry, &huma.Schema{Ref: nodeRef})
+
+		assert.Empty(t, optional.Ref)
+		assert.Equal(t, "object", optional.Type)
+		assert.Empty(t, optional.Required)
+		assert.Equal(t, "string", optional.Properties["name"].Type)
+		assert.Equal(t, "array", optional.Properties["children"].Type)
+		require.NotNil(t, optional.Properties["children"].Items)
+		assert.Equal(t, nodeRef, optional.Properties["children"].Items.Ref)
 	})
 }
 


### PR DESCRIPTION
Pass the schema registry to autopatch's `makeOptionalSchema` method, so it can be leveraged to resolve refs