### PR TITLE
fix: distinguish collection and element matches when walking input

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -371,8 +371,28 @@ func findHeaders(t reflect.Type) *findResult[*headerInfo] {
 }
 
 type findResultPath[T comparable] struct {
+	// Path is a sequence of struct field indices to walk, where `collectionElem`
+	// means "step into the elements of this slice, array, or map".
 	Path  []int
 	Value T
+}
+
+// collectionElem is a path step meaning "into the elements of this slice, array
+// or map". Field indices are never negative, so it can't collide with one. A
+// path that stops at a collection instead of stepping into it means the
+// collection's own type is the match.
+const collectionElem = -1
+
+// collectionPath returns the rest of the path after the step into a
+// collection's elements. Arriving at a collection without that step means the
+// path was recorded wrong, e.g. a new kind was added to `_findInType` without
+// marking its elements.
+func collectionPath(path []int) []int {
+	if len(path) == 0 || path[0] != collectionElem {
+		panic("expected a collection element path step, please file a bug")
+	}
+
+	return path[1:]
 }
 
 type findResult[T comparable] struct {
@@ -398,16 +418,30 @@ func (r *findResult[T]) every(current reflect.Value, path []int, v T, f func(ref
 	case reflect.Struct:
 		r.every(current.Field(path[0]), path[1:], v, f)
 	case reflect.Slice, reflect.Array:
+		elem := collectionPath(path)
 		for j := 0; j < current.Len(); j++ {
-			r.every(current.Index(j), path, v, f)
+			r.every(current.Index(j), elem, v, f)
 		}
 	case reflect.Map:
+		elem := collectionPath(path)
 		for _, k := range current.MapKeys() {
-			r.every(current.MapIndex(k), path, v, f)
+			item := addressableMapValue(current, k)
+			r.every(item, elem, v, f)
+			current.SetMapIndex(k, item)
 		}
 	default:
 		panic("unsupported")
 	}
+}
+
+// addressableMapValue returns a settable copy of the value stored at the given
+// key. Map values are never addressable, so callers must work on a copy and
+// write it back via `SetMapIndex` for changes like defaults or resolver
+// mutations to survive.
+func addressableMapValue(m reflect.Value, key reflect.Value) reflect.Value {
+	item := reflect.New(m.Type().Elem()).Elem()
+	item.Set(m.MapIndex(key))
+	return item
 }
 
 // Every iterates over all paths in the result, applying the provided function
@@ -429,16 +463,13 @@ func jsonName(field reflect.StructField) string {
 }
 
 // everyPB traverses and processes a value using a path, building paths with
-// PathBuffer, and applying a function to leaf nodes.
+// PathBuffer, and applying a function to leaf nodes. A path stopping at a
+// collection means the collection itself is the match; a `collectionElem` step
+// means the match is inside it.
 func (r *findResult[T]) everyPB(current reflect.Value, path []int, pb *PathBuffer, v T, f func(reflect.Value, T)) {
-	switch reflect.Indirect(current).Kind() {
-	case reflect.Slice, reflect.Array, reflect.Map:
-		// Ignore these. We only care about the leaf nodes.
-	default:
-		if len(path) == 0 {
-			f(current, v)
-			return
-		}
+	if len(path) == 0 {
+		f(current, v)
+		return
 	}
 
 	current = reflect.Indirect(current)
@@ -481,19 +512,23 @@ func (r *findResult[T]) everyPB(current reflect.Value, path []int, pb *PathBuffe
 			pb.Pop()
 		}
 	case reflect.Slice, reflect.Array:
+		elem := collectionPath(path)
 		for j := 0; j < current.Len(); j++ {
 			pb.PushIndex(j)
-			r.everyPB(current.Index(j), path, pb, v, f)
+			r.everyPB(current.Index(j), elem, pb, v, f)
 			pb.Pop()
 		}
 	case reflect.Map:
+		elem := collectionPath(path)
 		for _, k := range current.MapKeys() {
 			if k.Kind() == reflect.String {
 				pb.Push(k.String())
 			} else {
 				pb.Push(fmt.Sprintf("%v", k.Interface()))
 			}
-			r.everyPB(current.MapIndex(k), path, pb, v, f)
+			item := addressableMapValue(current, k)
+			r.everyPB(item, elem, pb, v, f)
+			current.SetMapIndex(k, item)
 			pb.Pop()
 		}
 	default:
@@ -566,10 +601,13 @@ func _findInType[T comparable](t reflect.Type, path []int, result *findResult[T]
 				delete(visited, t)
 			}
 		}
-	case reflect.Slice, reflect.Array:
-		_findInType[T](t.Elem(), path, result, onType, onField, recurseFields, visited, ignore...)
-	case reflect.Map:
-		_findInType[T](t.Elem(), path, result, onType, onField, recurseFields, visited, ignore...)
+	case reflect.Slice, reflect.Array, reflect.Map:
+		// Record that the match is inside the collection rather than on the
+		// collection's own type, so the walkers know to descend into elements.
+		// Both can match, e.g. `type Items []Item` where each has a resolver, in
+		// which case two paths are recorded and both run.
+		elem := append(append([]int{}, path...), collectionElem)
+		_findInType[T](t.Elem(), elem, result, onType, onField, recurseFields, visited, ignore...)
 	}
 }
 

--- a/huma_internal_test.go
+++ b/huma_internal_test.go
@@ -1,0 +1,16 @@
+package huma
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A path that arrives at a collection must step into its elements. Anything
+// else means the path was recorded wrong, e.g. a kind was added to
+// `_findInType` without marking its elements.
+func TestCollectionPath(t *testing.T) {
+	assert.Equal(t, []int{2}, collectionPath([]int{collectionElem, 2}))
+	assert.Panics(t, func() { collectionPath([]int{2}) })
+	assert.Panics(t, func() { collectionPath(nil) })
+}

--- a/huma_test.go
+++ b/huma_test.go
@@ -4080,6 +4080,151 @@ func TestResolverInFixedArray(t *testing.T) {
 	assert.Equal(t, "body.items[0]", got.Path)
 }
 
+// CollectionResolverArray and CollectionResolverSlice have resolvers on the
+// collection type itself rather than on an element type.
+type CollectionResolverArray [2]float64
+
+func (c *CollectionResolverArray) Resolve(_ huma.Context) []error {
+	*c = CollectionResolverArray{1, 2}
+	return nil
+}
+
+type CollectionResolverSlice []float64
+
+func (c *CollectionResolverSlice) Resolve(_ huma.Context) []error {
+	*c = CollectionResolverSlice{3, 4}
+	return nil
+}
+
+func TestResolverOnCollectionType(t *testing.T) {
+	r, app := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+	var got struct {
+		Array  CollectionResolverArray
+		Slice  CollectionResolverSlice
+		Nested []CollectionResolverArray
+	}
+	huma.Register(app, huma.Operation{
+		OperationID: "test",
+		Method:      http.MethodPost,
+		Path:        "/test",
+	}, func(ctx context.Context, input *struct {
+		Body struct {
+			Array  CollectionResolverArray   `json:"array"`
+			Slice  CollectionResolverSlice   `json:"slice"`
+			Nested []CollectionResolverArray `json:"nested"`
+		}
+	}) (*struct{}, error) {
+		got.Array = input.Body.Array
+		got.Slice = input.Body.Slice
+		got.Nested = input.Body.Nested
+		return nil, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"array":[0,0],"slice":[0],"nested":[[0,0],[0,0]]}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code, w.Body.String())
+	assert.Equal(t, CollectionResolverArray{1, 2}, got.Array)
+	assert.Equal(t, CollectionResolverSlice{3, 4}, got.Slice)
+	// Each element of the outer slice is itself the match, so the resolver runs
+	// on the elements rather than on the slice.
+	assert.Equal(t, []CollectionResolverArray{{1, 2}, {1, 2}}, got.Nested)
+}
+
+// BothResolverItems and BothResolverItem both have a resolver, so both the
+// collection and its elements must be resolved, each exactly once.
+type BothResolverItem struct {
+	Name  string `json:"name"`
+	Count int    `json:"count,omitempty"`
+}
+
+func (i *BothResolverItem) Resolve(_ huma.Context) []error {
+	i.Count++
+	return nil
+}
+
+type BothResolverItems []BothResolverItem
+
+func (i *BothResolverItems) Resolve(_ huma.Context) []error {
+	*i = append(*i, BothResolverItem{Name: "appended"})
+	return nil
+}
+
+func TestResolverOnCollectionAndElement(t *testing.T) {
+	r, app := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+	var got BothResolverItems
+	huma.Register(app, huma.Operation{
+		OperationID: "test",
+		Method:      http.MethodPost,
+		Path:        "/test",
+	}, func(ctx context.Context, input *struct {
+		Body struct {
+			Items BothResolverItems `json:"items"`
+		}
+	}) (*struct{}, error) {
+		got = input.Body.Items
+		return nil, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"items":[{"name":"a"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code, w.Body.String())
+	require.Len(t, got, 2, "the collection resolver should run exactly once")
+	assert.Equal(t, "a", got[0].Name)
+	assert.Equal(t, 1, got[0].Count, "the element resolver should run exactly once")
+}
+
+type MapValueResolverItem struct {
+	Value    string `json:"value,omitempty" default:"default"`
+	Resolved string `json:"resolved,omitempty"`
+}
+
+func (i *MapValueResolverItem) Resolve(_ huma.Context) []error {
+	i.Resolved = "yes"
+	return nil
+}
+
+// TestDefaultsInMapValue covers defaults and resolver mutations on values only
+// reachable through a map. Map values are copies, so they are written back to
+// the map after being visited, otherwise the changes would be lost.
+func TestDefaultsInMapValue(t *testing.T) {
+	r, app := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+	var got struct {
+		Structs map[string]MapValueResolverItem
+		Arrays  map[string][1]MapValueResolverItem
+	}
+	huma.Register(app, huma.Operation{
+		OperationID: "test",
+		Method:      http.MethodPost,
+		Path:        "/test",
+	}, func(ctx context.Context, input *struct {
+		Body struct {
+			Structs map[string]MapValueResolverItem    `json:"structs"`
+			Arrays  map[string][1]MapValueResolverItem `json:"arrays"`
+		}
+	}) (*struct{}, error) {
+		got.Structs = input.Body.Structs
+		got.Arrays = input.Body.Arrays
+		return nil, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(`{"structs":{"a":{}},"arrays":{"a":[{}]}}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	assert.NotPanics(t, func() { r.ServeHTTP(w, req) })
+	assert.Equal(t, http.StatusNoContent, w.Code, w.Body.String())
+	assert.Equal(t, "default", got.Structs["a"].Value)
+	assert.Equal(t, "yes", got.Structs["a"].Resolved)
+	assert.Equal(t, "default", got.Arrays["a"][0].Value)
+	assert.Equal(t, "yes", got.Arrays["a"][0].Resolved)
+}
+
 type ResolverCustomStatus struct{}
 
 func (r *ResolverCustomStatus) Resolve(ctx huma.Context) []error {


### PR DESCRIPTION
Follow-up to #1076, which surfaced two silent issues in the input walker.

**Resolver on a named collection type returned a 500.** `type Coords [2]float64` with a `Resolve` method: `everyPB` treated every collection as a container to walk through, so it stepped past the array and tried to run a resolver on each `float64`. The cause is that `_findInType` recorded the same path whether the match was on the collection's own type or on its element type. It now records a marker step when descending into elements, so both are exact and the kind-based guess is gone. This also fixes the case where a collection and its element both have resolvers, which previously ran the element's twice and the collection's never.

**Defaults and resolvers reached through a map panicked** with `reflect: reflect.Value.Set using unaddressable value`, because map values are copies. The value is now copied out, walked, then written back with `SetMapIndex`, so defaults and resolver mutations inside maps stick. `map[string]Struct` with a `default:` tag panics on main today, so that is fixed too.

Tests cover resolvers on named array, slice and nested collection types, collections whose elements also resolve, and defaults plus resolver mutations through maps. Each fails without these changes. Benchmarks are flat except map bodies, about 4% for the write-back.

Known limitation, not addressed here: an omitted optional `[N]T` field runs resolvers and defaults on N zero elements, since a Go array is always N values. That matches existing behaviour for non-pointer struct fields; `[]T` and `*[N]T` work as expected.