### PR TITLE
fix: close multipart file handles after mime-type validation

### DIFF
--- a/formdata.go
+++ b/formdata.go
@@ -48,6 +48,7 @@ func (v MimeTypeValidator) Validate(fh *multipart.FileHeader, location string) (
 	if err != nil {
 		return "", &ErrorDetail{Message: "Failed to open file", Location: location}
 	}
+	defer file.Close()
 
 	mimeType := fh.Header.Get("Content-Type")
 	if mimeType == "" {
@@ -178,6 +179,7 @@ func readFile(
 	}
 	contentType, validationErr := validator.Validate(fh, location)
 	if validationErr != nil {
+		f.Close()
 		return FormFile{}, validationErr
 	}
 	return FormFile{

--- a/formdata_internal_test.go
+++ b/formdata_internal_test.go
@@ -1,0 +1,84 @@
+package huma
+
+import (
+	"bytes"
+	"mime/multipart"
+	"runtime/debug"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// limitFileDescriptors lowers the process soft RLIMIT_NOFILE and disables the
+// garbage collector for the duration of the test. This makes leaked file
+// handles observable: the GC finalizer would otherwise close unreachable
+// handles and a high descriptor limit would absorb small leaks. The previous
+// values are restored via t.Cleanup.
+func limitFileDescriptors(t *testing.T) {
+	t.Helper()
+	var rl syscall.Rlimit
+	require.NoError(t, syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl))
+	orig := rl
+	if rl.Cur > 80 {
+		rl.Cur = 80
+	}
+	require.NoError(t, syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rl))
+	origGC := debug.SetGCPercent(-1)
+	t.Cleanup(func() {
+		debug.SetGCPercent(origGC)
+		syscall.Setrlimit(syscall.RLIMIT_NOFILE, &orig)
+	})
+}
+
+// diskBackedFileHeader parses a one-file-part multipart body with a zero-byte
+// memory threshold, so the part is stored in a temporary file on disk and each
+// FileHeader.Open returns a real *os.File. The returned form must be cleaned
+// up with RemoveAll.
+func diskBackedFileHeader(t *testing.T, contentType string) (*multipart.Form, *multipart.FileHeader) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	part, err := w.CreateFormFile("file", "test.txt")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("hello, world!"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	form, err := multipart.NewReader(&buf, w.Boundary()).ReadForm(0)
+	require.NoError(t, err)
+	fh := form.File["file"][0]
+	fh.Header.Set("Content-Type", contentType)
+	return form, fh
+}
+
+func TestMimeTypeValidatorClosesFile(t *testing.T) {
+	form, fh := diskBackedFileHeader(t, "text/plain")
+	defer form.RemoveAll()
+	limitFileDescriptors(t)
+
+	validator := NewMimeTypeValidator(&Encoding{ContentType: "text/plain"})
+	for range 200 {
+		_, detail := validator.Validate(fh, "file")
+		// A leaked handle per call exhausts the descriptor limit within the
+		// loop; with the fix every handle is closed and this never fails.
+		require.Nil(t, detail, "Validate unexpectedly failed: %v", detail)
+	}
+}
+
+func TestReadFileClosesOnValidationError(t *testing.T) {
+	form, fh := diskBackedFileHeader(t, "text/plain")
+	defer form.RemoveAll()
+	limitFileDescriptors(t)
+
+	validator := NewMimeTypeValidator(&Encoding{ContentType: "image/png"})
+	for range 200 {
+		_, detail := readFile(fh, "file", validator)
+		// A leaked handle per call exhausts the descriptor limit within the
+		// loop and surfaces as "Failed to open file" instead of the expected
+		// mime-type error; with the fix every handle is closed and this never
+		// happens.
+		require.NotNil(t, detail)
+		require.Contains(t, detail.Message, "Invalid mime type")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1077

## Problem

`MimeTypeValidator.Validate` opens the uploaded file to sniff its content type and never closes it. For any part above the adapter multipart memory threshold (8 KiB for `humago`), that handle is a real file on disk, so the descriptor stays held until the GC finalizer runs. `readFile` also opens a handle before validation and returns without closing it when validation fails.

`multipart.Form.RemoveAll()` only unlinks the temp file; it does not close handles returned by `FileHeader.Open()`. A service doing a lot of uploads can drift on file descriptors, and bursts can exhaust the descriptor limit before the finalizer runs.

**Reproduction:** upload a file larger than the adapter memory threshold with a mime type that fails validation in a loop; the process accumulates two open file descriptors per request.

## Fix

1. `Validate`: `defer file.Close()` immediately after the open check, covering the success, sniff-error, and invalid-mime-type paths.
2. `readFile`: close its handle before returning the validation error (the success path transfers ownership to the caller).

## Tests

Two regression tests added to `formdata_internal_test.go`, both driving a disk-backed part with the GC disabled and `RLIMIT_NOFILE` lowered to 80 so leaked descriptors are observable:

| Test | Verifies |
|------|----------|
| `TestMimeTypeValidatorClosesFile` | 200 validations leak no descriptors (fails without the fix with `EMFILE` after ~50 iterations) |
| `TestReadFileClosesOnValidationError` | 200 rejected reads keep returning the mime-type error, not `Failed to open file` |

All existing tests continue to pass (`go test -race ./...`).