### PR TITLE
fix: trim OWS after commas when splitting list parameters

### DIFF
--- a/conditional/params_test.go
+++ b/conditional/params_test.go
@@ -1,11 +1,13 @@
 package conditional
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/humatest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -138,6 +140,45 @@ func TestIfModifiedSince(t *testing.T) {
 	perr := p.PreconditionFailed("", before)
 	require.Error(t, perr)
 	assert.Equal(t, http.StatusPreconditionFailed, perr.GetStatus())
+}
+
+func TestIfNoneMatchOWSAfterComma(t *testing.T) {
+	// RFC 9110 §5.6.1 list grammar permits optional whitespace around each
+	// comma, e.g. `If-None-Match: "a", "b"`. Every element after the first
+	// must still match (issue #1084).
+	_, api := humatest.New(t)
+	huma.Register(api, huma.Operation{
+		OperationID: "conditional",
+		Method:      http.MethodGet,
+		Path:        "/resource",
+	}, func(ctx context.Context, input *struct {
+		Params
+	}) (*struct {
+		Body string `json:"body"`
+	}, error) {
+		if err := input.Params.PreconditionFailed("target-tag", time.Time{}); err != nil {
+			return nil, err
+		}
+		return &struct {
+			Body string `json:"body"`
+		}{Body: "ok"}, nil
+	})
+
+	// The OWS lands on the second element; without the fix it never matches
+	// and the request returns 200 instead of 304.
+	res := api.Get("/resource", `If-None-Match: "other-tag", "target-tag"`)
+	assert.Equal(t, http.StatusNotModified, res.Code)
+
+	// First-position elements keep working, with and without whitespace.
+	res = api.Get("/resource", `If-None-Match: "target-tag", "other-tag"`)
+	assert.Equal(t, http.StatusNotModified, res.Code)
+
+	res = api.Get("/resource", `If-None-Match: "other-tag","target-tag"`)
+	assert.Equal(t, http.StatusNotModified, res.Code)
+
+	// A non-matching list still serves the resource.
+	res = api.Get("/resource", `If-None-Match: "other-tag", "yet-another-tag"`)
+	assert.Equal(t, http.StatusOK, res.Code)
 }
 
 func TestIfUnmodifiedSince(t *testing.T) {

--- a/huma.go
+++ b/huma.go
@@ -1869,6 +1869,13 @@ func parseInto(ctx Context, f reflect.Value, value string, preSplit []string, p 
 				values = (&u).Query()[p.Name]
 			} else {
 				values = strings.Split(value, ",")
+				// RFC 9110 §5.6.1 list grammar allows optional whitespace
+				// (OWS) around each comma, e.g. `If-None-Match: "a", "b"`.
+				// Strip it so later elements are not compared with a leading
+				// space (e.g. `conditional.Params` ETag matching).
+				for i, v := range values {
+					values[i] = strings.Trim(v, " \t")
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

Fixes #1084

## Problem

`parseInto` splits list-style header/query params on a literal comma:

```go
values = strings.Split(value, ",")
```

RFC 9110 §5.6.1 list grammar permits optional whitespace (OWS) around each comma, so a conventional `If-None-Match: "a", "b"` produces `["\"a\"", " \"b\""]` — every element after the first keeps a leading space. `conditional.trimETag` strips quotes but not whitespace, so the space-tainted element can never equal a bare ETag: a 304-eligible request silently returns a full 200.

**Reproduction:**
```
If-None-Match: "target-tag"          → 304 (correct)
If-None-Match: "other-tag","target-tag" → 304 (correct)
If-None-Match: "other-tag", "target-tag" → 200 (bug)
```

## Fix

Trim OWS (`" \t"`) from each element at the shared split site in `parseInto`. This fixes every list-style header/query param at once rather than just the `conditional` package, matching the fix location suggested in the issue.

## Tests

`TestIfNoneMatchOWSAfterComma` in `conditional/params_test.go` registers a real operation with embedded `Params` and asserts:

| Case | Verifies |
|------|----------|
| `"other-tag", "target-tag"` (OWS on second element) | 304 — fails without the fix |
| `"target-tag", "other-tag"` (OWS elsewhere) | 304 |
| `"other-tag","target-tag"` (no space) | 304 |
| non-matching list | 200 |

All existing tests continue to pass (`go test -race ./...`).