### PR TITLE
fix: document error codes added by group modifiers

### DIFF
--- a/group.go
+++ b/group.go
@@ -106,6 +106,9 @@ func (g *Group) DocumentOperation(op *Operation) {
 			if op.Hidden {
 				return
 			}
+			// All group modifiers have run by this point; define the error
+			// responses so codes appended by modifiers are documented.
+			defineOperationErrors(op, g.OpenAPI().Components.Schemas)
 			g.OpenAPI().AddOperation(op)
 		}
 	})

--- a/huma.go
+++ b/huma.go
@@ -802,18 +802,13 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 	}
 	outHeaders, outStatusIndex, outBodyIndex, outBodyFunc := processOutputType(outputType, &op, registry)
 
-	if len(op.Errors) > 0 {
-		if len(inputParams.Paths) > 0 || hasInputBody {
-			op.Errors = append(op.Errors, http.StatusUnprocessableEntity)
-		}
-		op.Errors = append(op.Errors, http.StatusInternalServerError)
-	}
-	defineErrors(&op, registry)
-
 	if documenter, ok := api.(OperationDocumenter); ok {
-		// Enables customization of OpenAPI documentation behavior for operations.
+		// Group modifiers run inside the documenter chain; operation errors
+		// are defined by the innermost documenter right before the operation
+		// is added to the document, so codes added by modifiers are included.
 		documenter.DocumentOperation(&op)
 	} else if !op.Hidden {
+		defineOperationErrors(&op, registry)
 		oapi.AddOperation(&op)
 	}
 
@@ -1755,6 +1750,20 @@ func processOutputType(outputType reflect.Type, op *Operation, registry Registry
 		}
 	}
 	return outHeaders, outStatusIndex, outBodyIndex, outBodyFunc
+}
+
+// defineOperationErrors appends the standard 422 validation and 500 error
+// codes when the operation declares error responses, then defines the error
+// response schemas. It runs after operation modifiers so codes added by
+// modifiers are also documented.
+func defineOperationErrors(op *Operation, registry Registry) {
+	if len(op.Errors) > 0 {
+		if op.RequestBody != nil || len(op.Parameters) > 0 {
+			op.Errors = append(op.Errors, http.StatusUnprocessableEntity)
+		}
+		op.Errors = append(op.Errors, http.StatusInternalServerError)
+	}
+	defineErrors(op, registry)
 }
 
 // defineErrors extracts possible error responses and defines them on the

--- a/huma_test.go
+++ b/huma_test.go
@@ -4975,3 +4975,40 @@ func TestWriteResponseTransformErrorStatus(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
 	assert.Contains(t, string(body), "error transforming response")
 }
+
+func TestGroupModifierErrorsDocumented(t *testing.T) {
+	// Error codes appended by a group modifier must be reflected in the
+	// generated OpenAPI document (issue #878).
+	_, api := humatest.New(t)
+	group := huma.NewGroup(api, "/internal")
+	group.UseSimpleModifier(func(op *huma.Operation) {
+		op.Tags = append(op.Tags, "Internal")
+		op.Errors = append(op.Errors, http.StatusUnauthorized)
+	})
+	huma.Register(group, huma.Operation{
+		OperationID: "get-thing",
+		Method:      http.MethodGet,
+		Path:        "/thing/{id}",
+	}, func(ctx context.Context, input *struct {
+		ID string `path:"id"`
+	}) (*struct {
+		Body struct {
+			ID string `json:"id"`
+		}
+	}, error) {
+		return &struct {
+			Body struct {
+				ID string `json:"id"`
+			}
+		}{Body: struct {
+			ID string `json:"id"`
+		}{ID: input.ID}}, nil
+	})
+
+	op := api.OpenAPI().Paths["/internal/thing/{id}"].Get
+	require.NotNil(t, op)
+	assert.Contains(t, op.Tags, "Internal")
+	require.Contains(t, op.Responses, "401", "modifier-added Errors must be documented")
+	require.Contains(t, op.Responses, "422")
+	require.Contains(t, op.Responses, "500")
+}


### PR DESCRIPTION
## Summary

Fixes #878

## Problem

When a group modifier appends to `op.Errors`, the generated OpenAPI document does not include the new error responses — while `Tags`, `Security`, and `Middlewares` changes from the same modifier are reflected correctly.

**Root cause:** `huma.Register` called `defineErrors` (which consumes `op.Errors` into `op.Responses`) *before* invoking `OperationDocumenter`, where group modifiers run. The other fields are read directly from the operation by `AddOperation` after the modifiers, which is why they worked.

**Reproduction:**
```go
internalApi.UseSimpleModifier(func(op *huma.Operation) {
	op.Tags = append(op.Tags, "Internal")        // appears in the doc ✓
	op.Errors = append(op.Errors, 401)           // missing from the doc ✗
})
```

## Fix

Move the error definition to the innermost document step — after all group modifiers have run and immediately before `AddOperation`:

- `Register` (plain API path): call `defineOperationErrors` right before `AddOperation`.
- `Group.DocumentOperation`: call it at the end of the modifier chain, before delegating or adding.
- New `defineOperationErrors` helper preserves the previous 422/500 auto-append behavior, using the documented operation state (`op.RequestBody`, `op.Parameters`) as the equivalent condition.

## Tests

`TestGroupModifierErrorsDocumented` registers an operation in a group whose modifier adds `401` and asserts:

| Response | Without fix | With fix |
|----------|-------------|----------|
| `401` (modifier-added) | missing | present |
| `422` / `500` (auto-appended) | present | present |
| `Tags` from modifier | present | present |

All existing tests continue to pass (`go test -race ./...`).