### PR TITLE
feat: strip router path patterns from the OpenAPI document

### DIFF
--- a/huma_test.go
+++ b/huma_test.go
@@ -25,9 +25,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	_ "github.com/danielgtaylor/huma/v2/formats/cbor"
 	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/go-chi/chi/v5"
 )
 
 var NewExampleAdapter = humatest.NewAdapter
@@ -4974,4 +4976,34 @@ func TestWriteResponseTransformErrorStatus(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
 	assert.Contains(t, string(body), "error transforming response")
+}
+
+func TestRegexPathParamNormalizedInOpenAPI(t *testing.T) {
+	// Chi-style `{id:[0-9]+}` patterns route fine but are not valid OpenAPI
+	// paths; the documented path must keep only the parameter name (issue #922).
+	router := chi.NewMux()
+	api := humachi.New(router, huma.DefaultConfig("Test", "1.0.0"))
+	huma.Register(api, huma.Operation{
+		OperationID: "get-user",
+		Method:      http.MethodGet,
+		Path:        "/users/{id:[0-9]+}",
+	}, func(ctx context.Context, input *struct {
+		ID string `path:"id"`
+	}) (*struct {
+		Body string `json:"body"`
+	}, error) {
+		return &struct {
+			Body string `json:"body"`
+		}{Body: input.ID}, nil
+	})
+
+	paths := api.OpenAPI().Paths
+	require.Contains(t, paths, "/users/{id}", "regex must be stripped from the documented path")
+	require.NotContains(t, paths, "/users/{id:[0-9]+}")
+
+	// The router still matches the regex route end to end.
+	req, _ := http.NewRequest(http.MethodGet, "/users/123", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/openapi.go
+++ b/openapi.go
@@ -1528,10 +1528,15 @@ func (o *OpenAPI) AddOperation(op *Operation) {
 		}
 	}
 
-	item := o.Paths[op.Path]
+	// Router-specific path parameter patterns (e.g. chi's `{id:[0-9]+}`) are
+	// not valid OpenAPI paths, so document the operation under the normalized
+	// path while leaving op.Path untouched for the router.
+	docPath := normalizeOpenAPIPath(op.Path)
+
+	item := o.Paths[docPath]
 	if item == nil {
 		item = &PathItem{}
-		o.Paths[op.Path] = item
+		o.Paths[docPath] = item
 	}
 
 	switch op.Method {
@@ -1558,6 +1563,47 @@ func (o *OpenAPI) AddOperation(op *Operation) {
 	for _, f := range o.OnAddOperation {
 		f(o, op)
 	}
+}
+
+// normalizeOpenAPIPath strips router-specific path parameter patterns (e.g.
+// chi's `{id:[0-9]+}`) so the documented OpenAPI path contains only the
+// parameter name (`{id}`). Brace-aware scanning keeps quantifiers such as
+// `{3}` inside the pattern from terminating the segment early.
+func normalizeOpenAPIPath(path string) string {
+	var b strings.Builder
+	b.Grow(len(path))
+	start := -1 // index of an open '{' whose segment has not been copied yet
+	depth := 0
+	for i := 0; i < len(path); i++ {
+		switch path[i] {
+		case '{':
+			if start < 0 {
+				start = i
+			}
+			depth++
+		case '}':
+			depth--
+			if start >= 0 && depth == 0 {
+				seg := path[start : i+1]
+				if k := strings.IndexByte(seg, ':'); k >= 0 {
+					b.WriteString(seg[:k])
+					b.WriteByte('}')
+				} else {
+					b.WriteString(seg)
+				}
+				start = -1
+			}
+		default:
+			if start < 0 {
+				b.WriteByte(path[i])
+			}
+		}
+	}
+	if start >= 0 {
+		// Unbalanced '{': copy the remainder verbatim.
+		b.WriteString(path[start:])
+	}
+	return b.String()
 }
 
 // MarshalJSON serializes the OpenAPI object into JSON with custom handling for unused schemas in components.


### PR DESCRIPTION
## Summary

Fixes #922

## Problem

Chi supports regex in path parameters, e.g. `/users/{id:[0-9]+}`, and huma routes them fine — but the same path is used verbatim as the OpenAPI `paths` key, so the generated document contains an invalid path:

```json
"/users/{id:[0-9]+}": { ... }
```

**Reproduction:** register any operation on a regex path with `humachi` and inspect `api.OpenAPI().Paths`.

## Fix

Normalize the *documented* path in `AddOperation` — `{id:[0-9]+}` becomes `{id}` — while leaving `op.Path` untouched so the router keeps the regex. The normalization uses a brace-aware scan, so quantifiers like `{3}` inside the pattern do not terminate the segment early (`{id:[a-z]{3}}` → `{id}`).

## Tests

`TestRegexPathParamNormalizedInOpenAPI` in `huma_test.go`:

| Assertion | Verifies |
|-----------|----------|
| `Paths` contains `/users/{id}` | regex stripped from the document |
| `Paths` does not contain `/users/{id:[0-9]+}` | raw pattern not documented |
| `GET /users/123` via the chi router | routing still works end to end |

All existing tests continue to pass (`go test -race ./...`).