### PR TITLE
fix: run middleware added by group modifiers

### DIFF
--- a/group.go
+++ b/group.go
@@ -44,7 +44,9 @@ type groupAdapter struct {
 
 func (a *groupAdapter) Handle(op *Operation, handler func(Context)) {
 	a.group.ModifyOperation(op, func(op *Operation) {
-		a.Adapter.Handle(op, handler)
+		// Modifiers may have added operation middlewares; wrap them here so
+		// the runtime chain reflects the final (post-modifier) operation.
+		a.Adapter.Handle(op, op.Middlewares.Handler(handler))
 	})
 }
 

--- a/huma.go
+++ b/huma.go
@@ -878,7 +878,7 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 			}
 		}
 	}
-	a.Handle(&op, api.Middlewares().Handler(op.Middlewares.Handler(func(ctx Context) {
+	requestHandler := func(ctx Context) {
 		var input I
 
 		// Get the validation dependencies from the shared pool.
@@ -1298,7 +1298,16 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 		} else {
 			ctx.SetStatus(status)
 		}
-	})))
+	}
+
+	if _, isGroup := api.(*Group); isGroup {
+		// Group adapters re-run the modifier chain and wrap the final
+		// operation's middlewares, so a pre-wrap here would both miss
+		// modifier-added middleware and double-run directly-set ones.
+		a.Handle(&op, api.Middlewares().Handler(requestHandler))
+	} else {
+		a.Handle(&op, api.Middlewares().Handler(op.Middlewares.Handler(requestHandler)))
+	}
 }
 
 func parseDeepObjectQuery(query url.Values, name string) map[string]string {

--- a/huma_test.go
+++ b/huma_test.go
@@ -4975,3 +4975,29 @@ func TestWriteResponseTransformErrorStatus(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, res.StatusCode)
 	assert.Contains(t, string(body), "error transforming response")
 }
+func TestGroupModifierMiddlewareRuns(t *testing.T) {
+	// Middleware appended to op.Middlewares by a group modifier must run at
+	// request time, not only appear in the OpenAPI document (issue #804).
+	_, api := humatest.New(t)
+	group := huma.NewGroup(api, "/v1")
+	group.UseSimpleModifier(func(o *huma.Operation) {
+		o.Middlewares = append(o.Middlewares, func(ctx huma.Context, next func(huma.Context)) {
+			ctx.SetHeader("X-Modifier-Middleware", "ran")
+			next(ctx)
+		})
+	})
+	huma.Register(group, huma.Operation{
+		Method: http.MethodGet,
+		Path:   "/thing",
+	}, func(ctx context.Context, input *struct{}) (*struct {
+		Body string `json:"body"`
+	}, error) {
+		return &struct {
+			Body string `json:"body"`
+		}{Body: "ok"}, nil
+	})
+
+	res := api.Get("/v1/thing")
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, "ran", res.Header().Get("X-Modifier-Middleware"))
+}


### PR DESCRIPTION
## Summary

Fixes #804

## Problem

Middleware appended to `op.Middlewares` inside a group modifier never runs at request time — even though it does appear in the generated OpenAPI document.

**Root cause:** `PrefixModifier` copies the operation for fan-out (so multiple prefixes can be documented and registered), which means operation modifiers mutate a *copy*. `huma.Register` builds the runtime handler chain from the original operation's `op.Middlewares`:

```go
a.Handle(&op, api.Middlewares().Handler(op.Middlewares.Handler(...)))
```

The original op never sees the modifier's changes, so the middleware is missing from the chain. Tags/Security/Errors worked because they only matter for the document, which uses the modified copy.

**Reproduction:** register an operation on a group whose `UseSimpleModifier` appends a middleware, send a request — the middleware never runs.

## Fix

- `Register` (group path): skip the `op.Middlewares` pre-wrap — the original op's list is stale by definition; the group adapter handles it.
- `groupAdapter.Handle`: wrap the handler with the final post-modifier operation's `op.Middlewares` before delegating to the underlying adapter.

This runs modifier-added middleware exactly once and avoids double-running directly-set operation middlewares (which would happen if both the original and the copy were wrapped).

## Tests

`TestGroupModifierMiddlewareRuns` registers an operation in a group whose modifier appends a middleware setting a response header, then asserts:

| Assertion | Verifies |
|-----------|----------|
| Request returns 200 | handler still executes |
| `X-Modifier-Middleware: ran` header present | modifier middleware actually ran |

All existing tests continue to pass (`go test -race ./...`).
