### PR TITLE
fix: Surface the Body field's example tag as the request body media

### DIFF
--- a/huma.go
+++ b/huma.go
@@ -1544,6 +1544,12 @@ func setRequestBodyFromBody(op *Operation, registry Registry, fBody reflect.Stru
 		}
 		s := SchemaFromField(registry, fBody, hint)
 		op.RequestBody.Content[contentType].Schema = s
+
+		// Surface the `example` tag from the Body field on the media type, as
+		// examples set alongside a schema `$ref` are ignored by many tools.
+		if s != nil && len(s.Examples) > 0 && op.RequestBody.Content[contentType].Example == nil && len(op.RequestBody.Content[contentType].Examples) == 0 {
+			op.RequestBody.Content[contentType].Example = s.Examples[0]
+		}
 	}
 }
 

--- a/huma_test.go
+++ b/huma_test.go
@@ -1275,6 +1275,29 @@ func TestFeatures(t *testing.T) {
 			},
 		},
 		{
+			Name: "request-body-example-promoted-to-media-type",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPut,
+					Path:   "/body",
+				}, func(ctx context.Context, input *struct {
+					Body struct {
+						Name string `json:"name"`
+					} `example:"{\"name\": \"world\"}"`
+				}) (*struct{}, error) {
+					return nil, nil
+				})
+				content := api.OpenAPI().Paths["/body"].Put.RequestBody.Content["application/json"]
+				// The example from the Body field is surfaced on the media
+				// type, since examples alongside a schema $ref are ignored
+				// by many tools.
+				require.NotNil(t, content.Example)
+			},
+			Method: http.MethodPut,
+			URL:    "/body",
+			Body:   `{"name": "world"}`,
+		},
+		{
 			Name: "request-body-nameHint",
 			Register: func(t *testing.T, api huma.API) {
 				huma.Register(api, huma.Operation{


### PR DESCRIPTION
Fixes #991.

Surface the Body field's example tag as the request body media type example in setRequestBodyFromBody, since it previously only landed as an ignored $ref-sibling in the schema.

Files: `huma.go`