### PR TITLE
feat(docs): enhance Scalar renderer with custom script and font sourc…

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,7 +2,9 @@ package huma
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -216,7 +218,10 @@ type Config struct {
 	// JSON-marshaled into the docs HTML. Scalar and SwaggerUI use it, Stoplight
 	// Elements ignores it.
 	//
-	// Scalar reads it from the `data-configuration` attribute. See
+	// Scalar receives it via `Scalar.createApiReference`, so all options
+	// including multi-document `sources` are supported; it must marshal to a
+	// JSON object. Huma sets the `url` field to the OpenAPI spec unless
+	// `url`, `sources`, or `content` is set here. See
 	// https://github.com/scalar/scalar/blob/main/documentation/configuration.md
 	// for the options.
 	//
@@ -225,6 +230,24 @@ type Config struct {
 	// for the options. Huma owns the `url` and `dom_id` fields, so setting
 	// them here does nothing.
 	DocsRendererConfig any
+
+	// DocsScriptURL overrides the docs renderer script URL when using the
+	// Scalar renderer, for example to use a newer `@scalar/api-reference`
+	// version than the built-in default without waiting for a Huma release.
+	// Other renderers ignore it.
+	DocsScriptURL string
+
+	// DocsScriptIntegrity is the Subresource Integrity hash (e.g.
+	// `sha384-...`) for the script at DocsScriptURL. It is only used when
+	// DocsScriptURL is set. If left empty, the script tag is emitted without
+	// an `integrity` attribute, disabling integrity verification.
+	DocsScriptIntegrity string
+
+	// DocsFontSrc overrides the CSP `font-src` source list when using the
+	// Scalar renderer, for example `'self' data:` or another font host if a
+	// custom DocsScriptURL bundle loads fonts from somewhere other than the
+	// default `https://fonts.scalar.com`. Other renderers ignore it.
+	DocsFontSrc string
 
 	// SchemasPath is the path to the API schemas. If set to `/schemas` it will
 	// allow clients to get `/schemas/{schema}` to view the schema in a browser
@@ -627,6 +650,113 @@ func NewAPI(config Config, a Adapter) API {
 	return newAPI
 }
 
+func validateDocsScriptValue(name, value string) {
+	if strings.ContainsAny(value, ";'\" \t\r\n<>") {
+		panic("invalid " + name + ": must not contain whitespace, quotes, ';', '<', or '>'")
+	}
+}
+
+const scalarDefaultScriptURL = "https://unpkg.com/@scalar/api-reference@1.66.1/dist/browser/standalone.js"
+const scalarDefaultScriptIntegrity = "sha384-RkhHYpdjsrJH9sH8RmczPchxNiHEhmW300QwMB/8yg6feduTZu9FBN4W0DJnp50Z"
+const scalarDefaultFontSrc = "https://fonts.scalar.com"
+
+func scalarScriptURL(config Config) (string, string) {
+	if config.DocsScriptURL == "" {
+		return scalarDefaultScriptURL, scalarDefaultScriptIntegrity
+	}
+	validateDocsScriptValue("DocsScriptURL", config.DocsScriptURL)
+	if config.DocsScriptIntegrity != "" {
+		validateDocsScriptValue("DocsScriptIntegrity", config.DocsScriptIntegrity)
+	}
+	return config.DocsScriptURL, config.DocsScriptIntegrity
+}
+
+func scalarFontSrc(config Config) string {
+	if config.DocsFontSrc == "" {
+		return scalarDefaultFontSrc
+	}
+	if strings.ContainsAny(config.DocsFontSrc, ";<>\r\n") {
+		panic("invalid DocsFontSrc: must not contain ';', '<', '>', or newlines")
+	}
+	return config.DocsFontSrc
+}
+
+// scalarConfigJSON builds the object passed to `Scalar.createApiReference`
+// from DocsRendererConfig, pointing `url` at the OpenAPI spec unless the
+// config already declares a document via `url`, `sources`, or `content`.
+func scalarConfigJSON(config Config, openAPIPath string) []byte {
+	docsConfig := map[string]json.RawMessage{}
+	if config.DocsRendererConfig != nil {
+		b, err := json.Marshal(config.DocsRendererConfig)
+		if err != nil {
+			panic("failed to marshal DocsRendererConfig: " + err.Error())
+		}
+		if err := json.Unmarshal(b, &docsConfig); err != nil {
+			panic("DocsRendererConfig must be a JSON object: " + err.Error())
+		}
+	}
+
+	_, hasURL := docsConfig["url"]
+	_, hasSources := docsConfig["sources"]
+	_, hasContent := docsConfig["content"]
+	if !hasURL && !hasSources && !hasContent {
+		u, err := json.Marshal(openAPIPath + ".json")
+		if err != nil {
+			panic("failed to marshal OpenAPI path: " + err.Error())
+		}
+		docsConfig["url"] = u
+	}
+
+	out, err := json.Marshal(docsConfig)
+	if err != nil {
+		panic("failed to marshal DocsRendererConfig: " + err.Error())
+	}
+	return out
+}
+
+func scalarCSP(config Config, scriptURL string, initScript string) []string {
+	initHash := sha256.Sum256([]byte(initScript))
+	return []string{
+		"default-src 'none'",
+		"base-uri 'none'",
+		"connect-src 'self'",
+		"font-src " + scalarFontSrc(config),
+		"form-action 'none'",
+		"frame-ancestors 'none'",
+		"sandbox allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads",
+		"script-src " + scriptURL + " 'sha256-" + base64.StdEncoding.EncodeToString(initHash[:]) + "'",
+		"style-src 'unsafe-inline'", // TODO: Somehow drop 'unsafe-inline'
+	}
+}
+
+func scalarPage(title string, scriptURL string, scriptIntegrity string, initScript string) []byte {
+	integrityAttr := ""
+	if scriptIntegrity != "" {
+		integrityAttr = ` integrity="` + scriptIntegrity + `"`
+	}
+
+	return []byte(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="referrer" content="no-referrer">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>` + title + `</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="` + scriptURL + `" crossorigin` + integrityAttr + `></script>
+    <script>` + initScript + `</script>
+  </body>
+</html>`)
+}
+
+func scalarDocs(config Config, openAPIPath string, title string) ([]string, []byte) {
+	scriptURL, scriptIntegrity := scalarScriptURL(config)
+	initScript := "Scalar.createApiReference('#app', " + string(scalarConfigJSON(config, openAPIPath)) + ")"
+	return scalarCSP(config, scriptURL, initScript), scalarPage(title, scriptURL, scriptIntegrity, initScript)
+}
+
 func (a *api) registerDocsRoute() {
 	openAPIPath := a.config.OpenAPIPath
 	if prefix := getAPIPrefix(a.OpenAPI()); prefix != "" {
@@ -650,40 +780,7 @@ func (a *api) registerDocsRoute() {
 		if title == "" {
 			title = "Scalar in HTML"
 		}
-
-		csp = []string{
-			"default-src 'none'",
-			"base-uri 'none'",
-			"connect-src 'self'",
-			"form-action 'none'",
-			"frame-ancestors 'none'",
-			"sandbox allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads",
-			"script-src 'unsafe-eval' https://unpkg.com/@scalar/api-reference@1.44.20/dist/browser/standalone.js", // TODO: Somehow drop 'unsafe-eval'
-			"style-src 'unsafe-inline'", // TODO: Somehow drop 'unsafe-inline'
-		}
-
-		var configAttr string
-		if a.config.DocsRendererConfig != nil {
-			b, err := json.Marshal(a.config.DocsRendererConfig)
-			if err != nil {
-				panic("failed to marshal DocsRendererConfig: " + err.Error())
-			}
-			configAttr = ` data-configuration="` + html.EscapeString(string(b)) + `"`
-		}
-
-		body = []byte(`<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="referrer" content="no-referrer">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>` + title + `</title>
-  </head>
-  <body>
-    <script id="api-reference" data-url="` + openAPIPath + `.json"` + configAttr + `></script>
-    <script src="https://unpkg.com/@scalar/api-reference@1.44.20/dist/browser/standalone.js" crossorigin integrity="sha384-tMz7GAo6dMy55x9tLFtH+sHtogji6Scmb+feBR31TAHmvSPRUTboK9H3M5NFaP4R"></script>
-  </body>
-</html>`)
+		csp, body = scalarDocs(a.config, openAPIPath, title)
 	case DocsRendererStoplightElements:
 		if title == "" {
 			title = "Elements in HTML"
@@ -778,11 +875,13 @@ func (a *api) registerDocsRoute() {
 		panic("missing CSP for docs renderer: " + a.config.DocsRenderer)
 	}
 
+	cspHeader := strings.Join(csp, "; ")
+
 	a.adapter.Handle(&Operation{
 		Method: http.MethodGet,
 		Path:   a.config.DocsPath,
 	}, func(ctx Context) {
-		ctx.SetHeader("Content-Security-Policy", strings.Join(csp, "; "))
+		ctx.SetHeader("Content-Security-Policy", cspHeader)
 		ctx.SetHeader("Content-Type", "text/html")
 		ctx.BodyWriter().Write(body)
 	})

--- a/api.go
+++ b/api.go
@@ -231,23 +231,9 @@ type Config struct {
 	// them here does nothing.
 	DocsRendererConfig any
 
-	// DocsScriptURL overrides the docs renderer script URL when using the
-	// Scalar renderer, for example to use a newer `@scalar/api-reference`
-	// version than the built-in default without waiting for a Huma release.
-	// Other renderers ignore it.
-	DocsScriptURL string
-
-	// DocsScriptIntegrity is the Subresource Integrity hash (e.g.
-	// `sha384-...`) for the script at DocsScriptURL. It is only used when
-	// DocsScriptURL is set. If left empty, the script tag is emitted without
-	// an `integrity` attribute, disabling integrity verification.
-	DocsScriptIntegrity string
-
-	// DocsFontSrc overrides the CSP `font-src` source list when using the
-	// Scalar renderer, for example `'self' data:` or another font host if a
-	// custom DocsScriptURL bundle loads fonts from somewhere other than the
-	// default `https://fonts.scalar.com`. Other renderers ignore it.
-	DocsFontSrc string
+	// DocsScalar configures the Scalar docs renderer script and CSP. The zero
+	// value uses the built-in defaults. Other renderers ignore it.
+	DocsScalar ScalarDocsConfig
 
 	// SchemasPath is the path to the API schemas. If set to `/schemas` it will
 	// allow clients to get `/schemas/{schema}` to view the schema in a browser
@@ -280,6 +266,27 @@ type Config struct {
 	// for example, if you need access to the path settings that may be changed
 	// by the user after the defaults have been set.
 	CreateHooks []func(Config) Config
+}
+
+// ScalarDocsConfig customizes the Scalar docs renderer. The zero value uses
+// the built-in pinned `@scalar/api-reference` script with its integrity hash
+// and the default `https://fonts.scalar.com` font source.
+type ScalarDocsConfig struct {
+	// ScriptURL overrides the docs renderer script URL, for example to use a
+	// newer `@scalar/api-reference` version than the built-in default without
+	// waiting for a Huma release.
+	ScriptURL string
+
+	// ScriptIntegrity is the Subresource Integrity hash (e.g. `sha384-...`)
+	// for the script at ScriptURL. It is only used when ScriptURL is set. If
+	// left empty, the script tag is emitted without an `integrity` attribute,
+	// disabling integrity verification.
+	ScriptIntegrity string
+
+	// FontSrc overrides the CSP `font-src` source list, for example
+	// `'self' data:` or another font host if a custom ScriptURL bundle loads
+	// fonts from somewhere other than the default `https://fonts.scalar.com`.
+	FontSrc string
 }
 
 // configProvider is an internal interface to get the configuration from an
@@ -651,8 +658,8 @@ func NewAPI(config Config, a Adapter) API {
 }
 
 func validateDocsScriptValue(name, value string) {
-	if strings.ContainsAny(value, ";'\" \t\r\n<>") {
-		panic("invalid " + name + ": must not contain whitespace, quotes, ';', '<', or '>'")
+	if strings.ContainsAny(value, ";,'\" \t\r\n<>") {
+		panic("invalid " + name + ": must not contain whitespace, quotes, ';', ',', '<', or '>'")
 	}
 }
 
@@ -660,25 +667,30 @@ const scalarDefaultScriptURL = "https://unpkg.com/@scalar/api-reference@1.66.1/d
 const scalarDefaultScriptIntegrity = "sha384-RkhHYpdjsrJH9sH8RmczPchxNiHEhmW300QwMB/8yg6feduTZu9FBN4W0DJnp50Z"
 const scalarDefaultFontSrc = "https://fonts.scalar.com"
 
-func scalarScriptURL(config Config) (string, string) {
-	if config.DocsScriptURL == "" {
-		return scalarDefaultScriptURL, scalarDefaultScriptIntegrity
-	}
-	validateDocsScriptValue("DocsScriptURL", config.DocsScriptURL)
-	if config.DocsScriptIntegrity != "" {
-		validateDocsScriptValue("DocsScriptIntegrity", config.DocsScriptIntegrity)
-	}
-	return config.DocsScriptURL, config.DocsScriptIntegrity
+type scalarScript struct {
+	url       string
+	integrity string
 }
 
-func scalarFontSrc(config Config) string {
-	if config.DocsFontSrc == "" {
+func scalarScriptFor(config ScalarDocsConfig) scalarScript {
+	if config.ScriptURL == "" {
+		return scalarScript{url: scalarDefaultScriptURL, integrity: scalarDefaultScriptIntegrity}
+	}
+	validateDocsScriptValue("DocsScalar.ScriptURL", config.ScriptURL)
+	if config.ScriptIntegrity != "" {
+		validateDocsScriptValue("DocsScalar.ScriptIntegrity", config.ScriptIntegrity)
+	}
+	return scalarScript{url: config.ScriptURL, integrity: config.ScriptIntegrity}
+}
+
+func scalarFontSrc(config ScalarDocsConfig) string {
+	if config.FontSrc == "" {
 		return scalarDefaultFontSrc
 	}
-	if strings.ContainsAny(config.DocsFontSrc, ";<>\r\n") {
-		panic("invalid DocsFontSrc: must not contain ';', '<', '>', or newlines")
+	if strings.ContainsAny(config.FontSrc, ";,<>\r\n") {
+		panic("invalid DocsScalar.FontSrc: must not contain ';', ',', '<', '>', or newlines")
 	}
-	return config.DocsFontSrc
+	return config.FontSrc
 }
 
 // scalarConfigJSON builds the object passed to `Scalar.createApiReference`
@@ -714,7 +726,7 @@ func scalarConfigJSON(config Config, openAPIPath string) []byte {
 	return out
 }
 
-func scalarCSP(config Config, scriptURL string, initScript string) []string {
+func scalarCSP(config ScalarDocsConfig, script scalarScript, initScript string) []string {
 	initHash := sha256.Sum256([]byte(initScript))
 	return []string{
 		"default-src 'none'",
@@ -724,15 +736,15 @@ func scalarCSP(config Config, scriptURL string, initScript string) []string {
 		"form-action 'none'",
 		"frame-ancestors 'none'",
 		"sandbox allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-downloads",
-		"script-src " + scriptURL + " 'sha256-" + base64.StdEncoding.EncodeToString(initHash[:]) + "'",
+		"script-src " + script.url + " 'sha256-" + base64.StdEncoding.EncodeToString(initHash[:]) + "'",
 		"style-src 'unsafe-inline'", // TODO: Somehow drop 'unsafe-inline'
 	}
 }
 
-func scalarPage(title string, scriptURL string, scriptIntegrity string, initScript string) []byte {
+func scalarPage(title string, script scalarScript, initScript string) []byte {
 	integrityAttr := ""
-	if scriptIntegrity != "" {
-		integrityAttr = ` integrity="` + scriptIntegrity + `"`
+	if script.integrity != "" {
+		integrityAttr = ` integrity="` + script.integrity + `"`
 	}
 
 	return []byte(`<!doctype html>
@@ -741,20 +753,14 @@ func scalarPage(title string, scriptURL string, scriptIntegrity string, initScri
     <meta charset="utf-8">
     <meta name="referrer" content="no-referrer">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>` + title + `</title>
+    <title>` + html.EscapeString(title) + `</title>
   </head>
   <body>
     <div id="app"></div>
-    <script src="` + scriptURL + `" crossorigin` + integrityAttr + `></script>
+    <script src="` + script.url + `" crossorigin` + integrityAttr + `></script>
     <script>` + initScript + `</script>
   </body>
 </html>`)
-}
-
-func scalarDocs(config Config, openAPIPath string, title string) ([]string, []byte) {
-	scriptURL, scriptIntegrity := scalarScriptURL(config)
-	initScript := "Scalar.createApiReference('#app', " + string(scalarConfigJSON(config, openAPIPath)) + ")"
-	return scalarCSP(config, scriptURL, initScript), scalarPage(title, scriptURL, scriptIntegrity, initScript)
 }
 
 func (a *api) registerDocsRoute() {
@@ -780,7 +786,10 @@ func (a *api) registerDocsRoute() {
 		if title == "" {
 			title = "Scalar in HTML"
 		}
-		csp, body = scalarDocs(a.config, openAPIPath, title)
+		script := scalarScriptFor(a.config.DocsScalar)
+		initScript := "Scalar.createApiReference('#app', " + string(scalarConfigJSON(a.config, openAPIPath)) + ")"
+		csp = scalarCSP(a.config.DocsScalar, script, initScript)
+		body = scalarPage(title, script, initScript)
 	case DocsRendererStoplightElements:
 		if title == "" {
 			title = "Elements in HTML"

--- a/api_test.go
+++ b/api_test.go
@@ -219,6 +219,14 @@ func TestDocsRenderers(t *testing.T) {
 		resp := api.Get("/docs")
 		assert.Equal(t, http.StatusOK, resp.Code)
 		assert.Contains(t, resp.Body.String(), "@scalar/api-reference")
+		assert.Contains(t, resp.Body.String(), "@scalar/api-reference@1.66.1")
+
+		csp := resp.Header().Get("Content-Security-Policy")
+		assert.NotContains(t, csp, "unsafe-eval")
+		assert.Contains(t, csp, "style-src 'unsafe-inline'")
+		assert.Contains(t, csp, "font-src https://fonts.scalar.com")
+		assert.Regexp(t, `script-src [^;]+ 'sha256-[A-Za-z0-9+/]+=*'`, csp)
+		assert.NotContains(t, csp, "'nonce-")
 	})
 
 	t.Run("ScalarRendererConfig", func(t *testing.T) {
@@ -238,9 +246,51 @@ func TestDocsRenderers(t *testing.T) {
 
 		resp := api.Get("/docs")
 		assert.Equal(t, http.StatusOK, resp.Code)
-		assert.Contains(t, resp.Body.String(), `data-configuration="`)
-		assert.Contains(t, resp.Body.String(), `&#34;theme&#34;:&#34;mars&#34;`)
-		assert.Contains(t, resp.Body.String(), `&#34;hideModels&#34;:true`)
+		assert.Contains(t, resp.Body.String(), `Scalar.createApiReference('#app', `)
+		assert.Contains(t, resp.Body.String(), `"theme":"mars"`)
+		assert.Contains(t, resp.Body.String(), `"hideModels":true`)
+		assert.Contains(t, resp.Body.String(), `"url":"/openapi.json"`)
+	})
+
+	t.Run("ScalarRendererMultiDocument", func(t *testing.T) {
+		_, api := humatest.New(t, huma.Config{
+			OpenAPI: &huma.OpenAPI{
+				Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
+			},
+			DocsPath:     "/docs",
+			DocsRenderer: huma.DocsRendererScalar,
+			DocsRendererConfig: map[string]any{
+				"sources": []map[string]any{
+					{"url": "/openapi.json", "title": "Main"},
+					{"url": "/other/openapi.json", "title": "Other"},
+				},
+			},
+			OpenAPIPath: "/openapi",
+			Formats:     huma.DefaultFormats,
+		})
+
+		resp := api.Get("/docs")
+		assert.Equal(t, http.StatusOK, resp.Code)
+		body := resp.Body.String()
+		assert.Contains(t, body, `"sources":[`)
+		assert.Contains(t, body, `"title":"Other"`)
+		assert.NotContains(t, body, `"url":"/openapi.json","sources"`)
+		assert.NotRegexp(t, `\{"sources":\[.*\],"url"`, body)
+	})
+
+	t.Run("ScalarRendererConfigNotObject", func(t *testing.T) {
+		assert.Panics(t, func() {
+			humatest.New(t, huma.Config{
+				OpenAPI: &huma.OpenAPI{
+					Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
+				},
+				DocsPath:           "/docs",
+				DocsRenderer:       huma.DocsRendererScalar,
+				DocsRendererConfig: []string{"not", "an", "object"},
+				OpenAPIPath:        "/openapi",
+				Formats:            huma.DefaultFormats,
+			})
+		})
 	})
 
 	t.Run("ScalarRendererConfigInvalid", func(t *testing.T) {
@@ -254,6 +304,94 @@ func TestDocsRenderers(t *testing.T) {
 				DocsRendererConfig: make(chan int),
 				OpenAPIPath:        "/openapi",
 				Formats:            huma.DefaultFormats,
+			})
+		})
+	})
+
+	t.Run("ScalarCustomScript", func(t *testing.T) {
+		_, api := humatest.New(t, huma.Config{
+			OpenAPI: &huma.OpenAPI{
+				Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
+			},
+			DocsPath:            "/docs",
+			DocsRenderer:        huma.DocsRendererScalar,
+			DocsScriptURL:       "https://cdn.example.com/scalar/standalone.js",
+			DocsScriptIntegrity: "sha384-custom",
+			OpenAPIPath:         "/openapi",
+			Formats:             huma.DefaultFormats,
+		})
+
+		resp := api.Get("/docs")
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Contains(t, resp.Body.String(), `src="https://cdn.example.com/scalar/standalone.js"`)
+		assert.Contains(t, resp.Body.String(), `integrity="sha384-custom"`)
+		assert.NotContains(t, resp.Body.String(), "@scalar/api-reference")
+		assert.Contains(t, resp.Header().Get("Content-Security-Policy"), "script-src https://cdn.example.com/scalar/standalone.js")
+	})
+
+	t.Run("ScalarCustomScriptNoIntegrity", func(t *testing.T) {
+		_, api := humatest.New(t, huma.Config{
+			OpenAPI: &huma.OpenAPI{
+				Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
+			},
+			DocsPath:      "/docs",
+			DocsRenderer:  huma.DocsRendererScalar,
+			DocsScriptURL: "https://cdn.example.com/scalar/standalone.js",
+			OpenAPIPath:   "/openapi",
+			Formats:       huma.DefaultFormats,
+		})
+
+		resp := api.Get("/docs")
+		assert.Equal(t, http.StatusOK, resp.Code)
+		assert.Contains(t, resp.Body.String(), `src="https://cdn.example.com/scalar/standalone.js"`)
+		assert.NotContains(t, resp.Body.String(), "integrity=")
+	})
+
+	t.Run("ScalarCustomFontSrc", func(t *testing.T) {
+		_, api := humatest.New(t, huma.Config{
+			OpenAPI: &huma.OpenAPI{
+				Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
+			},
+			DocsPath:     "/docs",
+			DocsRenderer: huma.DocsRendererScalar,
+			DocsFontSrc:  "'self' data:",
+			OpenAPIPath:  "/openapi",
+			Formats:      huma.DefaultFormats,
+		})
+
+		resp := api.Get("/docs")
+		assert.Equal(t, http.StatusOK, resp.Code)
+		csp := resp.Header().Get("Content-Security-Policy")
+		assert.Contains(t, csp, "font-src 'self' data:")
+		assert.NotContains(t, csp, "fonts.scalar.com")
+	})
+
+	t.Run("ScalarInvalidFontSrc", func(t *testing.T) {
+		assert.Panics(t, func() {
+			humatest.New(t, huma.Config{
+				OpenAPI: &huma.OpenAPI{
+					Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
+				},
+				DocsPath:     "/docs",
+				DocsRenderer: huma.DocsRendererScalar,
+				DocsFontSrc:  "https://fonts.example.com; script-src 'unsafe-eval'",
+				OpenAPIPath:  "/openapi",
+				Formats:      huma.DefaultFormats,
+			})
+		})
+	})
+
+	t.Run("ScalarInvalidScriptURL", func(t *testing.T) {
+		assert.Panics(t, func() {
+			humatest.New(t, huma.Config{
+				OpenAPI: &huma.OpenAPI{
+					Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
+				},
+				DocsPath:      "/docs",
+				DocsRenderer:  huma.DocsRendererScalar,
+				DocsScriptURL: "https://cdn.example.com/a.js; script-src 'unsafe-eval'",
+				OpenAPIPath:   "/openapi",
+				Formats:       huma.DefaultFormats,
 			})
 		})
 	})

--- a/api_test.go
+++ b/api_test.go
@@ -313,12 +313,14 @@ func TestDocsRenderers(t *testing.T) {
 			OpenAPI: &huma.OpenAPI{
 				Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
 			},
-			DocsPath:            "/docs",
-			DocsRenderer:        huma.DocsRendererScalar,
-			DocsScriptURL:       "https://cdn.example.com/scalar/standalone.js",
-			DocsScriptIntegrity: "sha384-custom",
-			OpenAPIPath:         "/openapi",
-			Formats:             huma.DefaultFormats,
+			DocsPath:     "/docs",
+			DocsRenderer: huma.DocsRendererScalar,
+			DocsScalar: huma.ScalarDocsConfig{
+				ScriptURL:       "https://cdn.example.com/scalar/standalone.js",
+				ScriptIntegrity: "sha384-custom",
+			},
+			OpenAPIPath: "/openapi",
+			Formats:     huma.DefaultFormats,
 		})
 
 		resp := api.Get("/docs")
@@ -334,11 +336,13 @@ func TestDocsRenderers(t *testing.T) {
 			OpenAPI: &huma.OpenAPI{
 				Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
 			},
-			DocsPath:      "/docs",
-			DocsRenderer:  huma.DocsRendererScalar,
-			DocsScriptURL: "https://cdn.example.com/scalar/standalone.js",
-			OpenAPIPath:   "/openapi",
-			Formats:       huma.DefaultFormats,
+			DocsPath:     "/docs",
+			DocsRenderer: huma.DocsRendererScalar,
+			DocsScalar: huma.ScalarDocsConfig{
+				ScriptURL: "https://cdn.example.com/scalar/standalone.js",
+			},
+			OpenAPIPath: "/openapi",
+			Formats:     huma.DefaultFormats,
 		})
 
 		resp := api.Get("/docs")
@@ -354,7 +358,7 @@ func TestDocsRenderers(t *testing.T) {
 			},
 			DocsPath:     "/docs",
 			DocsRenderer: huma.DocsRendererScalar,
-			DocsFontSrc:  "'self' data:",
+			DocsScalar:   huma.ScalarDocsConfig{FontSrc: "'self' data:"},
 			OpenAPIPath:  "/openapi",
 			Formats:      huma.DefaultFormats,
 		})
@@ -374,7 +378,7 @@ func TestDocsRenderers(t *testing.T) {
 				},
 				DocsPath:     "/docs",
 				DocsRenderer: huma.DocsRendererScalar,
-				DocsFontSrc:  "https://fonts.example.com; script-src 'unsafe-eval'",
+				DocsScalar:   huma.ScalarDocsConfig{FontSrc: "https://fonts.example.com; script-src 'unsafe-eval'"},
 				OpenAPIPath:  "/openapi",
 				Formats:      huma.DefaultFormats,
 			})
@@ -387,13 +391,61 @@ func TestDocsRenderers(t *testing.T) {
 				OpenAPI: &huma.OpenAPI{
 					Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
 				},
-				DocsPath:      "/docs",
-				DocsRenderer:  huma.DocsRendererScalar,
-				DocsScriptURL: "https://cdn.example.com/a.js; script-src 'unsafe-eval'",
-				OpenAPIPath:   "/openapi",
-				Formats:       huma.DefaultFormats,
+				DocsPath:     "/docs",
+				DocsRenderer: huma.DocsRendererScalar,
+				DocsScalar:   huma.ScalarDocsConfig{ScriptURL: "https://cdn.example.com/a.js; script-src 'unsafe-eval'"},
+				OpenAPIPath:  "/openapi",
+				Formats:      huma.DefaultFormats,
 			})
 		})
+	})
+
+	t.Run("ScalarScriptURLComma", func(t *testing.T) {
+		assert.Panics(t, func() {
+			humatest.New(t, huma.Config{
+				OpenAPI: &huma.OpenAPI{
+					Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
+				},
+				DocsPath:     "/docs",
+				DocsRenderer: huma.DocsRendererScalar,
+				DocsScalar:   huma.ScalarDocsConfig{ScriptURL: "https://cdn.example.com/a.js,script-src-elem"},
+				OpenAPIPath:  "/openapi",
+				Formats:      huma.DefaultFormats,
+			})
+		})
+	})
+
+	t.Run("ScalarFontSrcComma", func(t *testing.T) {
+		assert.Panics(t, func() {
+			humatest.New(t, huma.Config{
+				OpenAPI: &huma.OpenAPI{
+					Info: &huma.Info{Title: "Test API", Version: "1.0.0"},
+				},
+				DocsPath:     "/docs",
+				DocsRenderer: huma.DocsRendererScalar,
+				DocsScalar:   huma.ScalarDocsConfig{FontSrc: "https://fonts.example.com,default-src *"},
+				OpenAPIPath:  "/openapi",
+				Formats:      huma.DefaultFormats,
+			})
+		})
+	})
+
+	t.Run("ScalarTitleEscaped", func(t *testing.T) {
+		_, api := humatest.New(t, huma.Config{
+			OpenAPI: &huma.OpenAPI{
+				Info: &huma.Info{Title: `Test </title><script>alert(1)</script>`, Version: "1.0.0"},
+			},
+			DocsPath:     "/docs",
+			DocsRenderer: huma.DocsRendererScalar,
+			OpenAPIPath:  "/openapi",
+			Formats:      huma.DefaultFormats,
+		})
+
+		resp := api.Get("/docs")
+		assert.Equal(t, http.StatusOK, resp.Code)
+		body := resp.Body.String()
+		assert.NotContains(t, body, "<title>Test </title><script>alert(1)</script>")
+		assert.Contains(t, body, "&lt;/title&gt;&lt;script&gt;alert(1)&lt;/script&gt;")
 	})
 
 	t.Run("SwaggerUIRenderer", func(t *testing.T) {


### PR DESCRIPTION
Closes: #1103

## Summary

- Bump the pinned Scalar renderer from `@scalar/api-reference@1.44.20` to `1.66.1` with a fresh SRI hash, and add `Config.DocsScalar` (`ScalarDocsConfig` with `ScriptURL`, `ScriptIntegrity`, `FontSrc`) to override the script location and font source without waiting for a huma release. Override values are validated at registration (rejecting `;`, `,`, quotes, whitespace, `<`, `>`) to prevent CSP and HTML injection.
- Switch the Scalar docs page from the declarative `data-configuration` attribute to the `Scalar.createApiReference('#app', {...})` JS API, allowed via a CSP `sha256` hash of the static inline script. This makes the full Scalar configuration work through `DocsRendererConfig`, including multi-document `sources`; huma injects the default `url` only when the config declares none of `url`, `sources`, or `content`.
- Tighten the Scalar CSP: drop `'unsafe-eval'` from `script-src` (verified unused by 1.66.1 in-browser) and add `font-src` for `https://fonts.scalar.com` (previously blocked by the `default-src 'none'` fallback, breaking font loading). `style-src 'unsafe-inline'` remains — Scalar applies inline `style` attributes, which no nonce or hash can allow; tracked by the existing TODO.
- Escape the page title with `html.EscapeString` and precompute the CSP header once at registration in `registerDocsRoute` (`api.go`).
- Extract the Scalar branch of `registerDocsRoute` into focused helpers: `scalarScriptFor`, `scalarFontSrc`, `scalarConfigJSON`, `scalarCSP`, `scalarPage`.
- Extend `TestDocsRenderers` with coverage for custom script URL/integrity, font-src override, multi-document config, config-shape validation, CSP/comma injection rejection, and title escaping.

## Breaking Changes

- `DocsRendererConfig` for the Scalar renderer must now marshal to a JSON object; any other JSON shape panics at API creation (previously any JSON value was serialized into `data-configuration`).
- The Scalar docs HTML no longer contains the `<script id="api-reference" data-url=... data-configuration=...>` element; anything scraping or post-processing that markup must adapt to the new `<div id="app">` + inline `Scalar.createApiReference` structure.