### PR TITLE
feat: pointer query params

### DIFF
--- a/docs/docs/features/request-inputs.md
+++ b/docs/docs/features/request-inputs.md
@@ -28,16 +28,39 @@ Requests can have parameters and/or a body as input to the handler function. Inp
 
 The following parameter types are supported out of the box:
 
-| Type                | Example Inputs         |
-| ------------------- | ---------------------- |
-| `bool`              | `true`, `false`        |
-| `[u]int[16/32/64]`  | `1234`, `5`, `-1`      |
-| `float32/64`        | `1.234`, `1.0`         |
-| `string`            | `hello`, `t`           |
-| `time.Time`         | `2020-01-01T12:00:00Z` |
-| slice, e.g. `[]int` | `1,2,3`, `tag1,tag2`   |
+| Type                        | Example Inputs         |
+| --------------------------- | ---------------------- |
+| `bool`                      | `true`, `false`        |
+| `[u]int[16/32/64]`          | `1234`, `5`, `-1`      |
+| `float32/64`                | `1.234`, `1.0`         |
+| `string`                    | `hello`, `t`           |
+| `time.Time`                 | `2020-01-01T12:00:00Z` |
+| slice, e.g. `[]int`         | `1,2,3`, `tag1,tag2`   |
+| pointer, e.g. `*int`        | `1234`, or `nil`       |
 
 For example, if the parameter is a query param and the type is `[]string` it might look like `?tags=tag1,tag2` in the URI. Query parameters also support specifying the same parameter multiple times by setting the `explode` tag, e.g. `query:"tags,explode"` would parse a query string like `?tags=tag1&tags=tag2` instead of a comma separated list. The comma separated list is faster and recommended for most use cases.
+
+### Optional parameters
+
+Any of the types above can be a pointer, in which case `nil` means the parameter was not provided in the request. This is useful when the zero value has meaning to your application, e.g. telling "the client did not filter" apart from "the client filtered on `false`":
+
+```go title="code.go"
+type MyInput struct {
+	// nil, or a pointer to true/false.
+	Active *bool `query:"active"`
+	// nil, or a pointer to the tags that were sent.
+	Tags *[]string `query:"tags"`
+}
+```
+
+A few things to be aware of:
+
+- Pointers work for path, query, header, and cookie parameters. Multipart form fields do not support them yet and panic at registration.
+- **Pointers do not make a parameter optional.** Query, header, and cookie params are already optional by default; path params are always required. See [Optional / Required](./request-validation.md#optional-required).
+- A parameter that is present but empty, e.g. `?tags=`, counts as **not provided** and leaves the pointer `nil`.
+- A `default` tag always wins over `nil`, so a parameter with a default is never `nil`.
+- Pointer parameters are documented as [nullable](./request-validation.md#nullable). Add `nullable:"false"` if you would rather the generated schema say e.g. `type: string` instead of `type: [string, "null"]`, since a parameter can never actually carry a literal `null` over the wire.
+- Slices of pointers (`[]*string`) and multiple levels of indirection (`**string`) are not supported.
 
 For cookies, the default behavior is to read the cookie _value_ from the request and convert it to one of the types above. If you want to access the entire cookie, you can use `http.Cookie` as the type instead:
 
@@ -47,44 +70,61 @@ type MyInput struct {
 }
 ```
 
-Then you can access e.g. `input.Session.Name` or `input.Session.Value`.
+Then you can access e.g. `input.Session.Name` or `input.Session.Value`. Use `*http.Cookie` if you want `nil` when the cookie is absent.
 
 ### Custom wrapper types
 
-Request parameters can be parsed into custom wrapper types, by implementing the [`ParamWrapper`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#ParamWrapper) interface, which should give access to the wrapper field as a [`reflect.Value`](https://pkg.go.dev/reflect#Value).
+Request parameters can be parsed into custom wrapper types, by implementing the [`ParamWrapper`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#ParamWrapper) interface, which should give access to the wrapper field as a [`reflect.Value`](https://pkg.go.dev/reflect#Value). Huma parses that inner field exactly as if it were the parameter itself, so comma-separated lists, `explode`, time formats and validation all keep working.
 
-Interface [`ParamReactor`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#ParamReactor) may optionally be implemented to define a callback to execute after a request parameter was parsed.
+Interface [`ParamReactor`](https://pkg.go.dev/github.com/danielgtaylor/huma/v2#ParamReactor) may optionally be implemented to define a callback to execute after a request parameter was parsed, which is where a wrapper can derive its own state from the parsed value.
 
-Example usage with a custom wrapper to handle null query parameters:
+To simply tell "not provided" apart from a zero value, reach for a [pointer](#optional-parameters) instead.
+Wrapper types earn their keep when you want to compute something from the parsed value. For example, a set that de-duplicates a repeated parameter and answers membership in constant time:
 
 ```go
-type OptionalParam[T any] struct {
-	Value T
-	IsSet bool
+type Set[T comparable] struct {
+	Values []T
+	index  map[T]struct{}
 }
 
-// Define schema to use wrapped type
-func (o OptionalParam[T]) Schema(r huma.Registry) *huma.Schema {
-	return huma.SchemaFromType(r, reflect.TypeOf(o.Value))
+// Document the parameter as the wrapped slice type.
+func (s Set[T]) Schema(r huma.Registry) *huma.Schema {
+	return huma.SchemaFromType(r, reflect.TypeFor[[]T]())
 }
 
-// Expose wrapped value to receive parsed value from Huma
-// MUST have pointer receiver
-func (o *OptionalParam[T]) Receiver() reflect.Value {
-	return reflect.ValueOf(o).Elem().Field(0)
+// Expose the slice for Huma to parse into.
+// MUST have pointer receiver, and the field MUST be exported.
+func (s *Set[T]) Receiver() reflect.Value {
+	return reflect.ValueOf(s).Elem().Field(0)
 }
 
-// React to request param being parsed to update internal state
-// MUST have pointer receiver
-func (o *OptionalParam[T]) OnParamSet(isSet bool, parsed any) {
-	o.IsSet = isSet
+// Once Huma has filled in Values, drop duplicates and build the index.
+// MUST have pointer receiver.
+func (s *Set[T]) OnParamSet(isSet bool, parsed any) {
+	s.index = make(map[T]struct{}, len(s.Values))
+	unique := s.Values[:0]
+	for _, v := range s.Values {
+		if _, ok := s.index[v]; ok {
+			continue
+		}
+		s.index[v] = struct{}{}
+		unique = append(unique, v)
+	}
+	s.Values = unique
+}
+
+func (s Set[T]) Has(v T) bool {
+	_, ok := s.index[v]
+	return ok
 }
 
 // Define request input with the wrapper type
 type MyRequestInput struct {
-    MaybeText OptionalParam[string] `query:"text"`
+	Tags Set[string] `query:"tags"`
 }
 ```
+
+The parameter is still documented as a plain array of strings, and for `?tags=b,a,b` the handler sees `Tags.Values` of `["b", "a"]` with `Tags.Has("a")` reporting true.
 
 ## Request Body
 
@@ -215,6 +255,8 @@ huma.Register(api, huma.Operation{
 ```
 
 The files are decoded according to the specified contentType. If no contentType is provided, it defaults to `application/octet-stream`.
+
+Unlike other [parameters](#optional-parameters), form fields cannot be pointers — registering one panics. Use `huma.FormFile` and check its `IsSet` field for optional files, and a meaningful zero value for other fields.
 
 Non-file fields in multipart form data can be unmarshalled from JSON and validated, by setting their content-type to `application/json`. Field content in the request must be valid JSON.
 

--- a/docs/docs/features/request-validation.md
+++ b/docs/docs/features/request-validation.md
@@ -32,7 +32,7 @@ Fields being optional/required is determined automatically but can be overridden
 
 Path parameters are always required. Cookie, header, and query parameters are optional unless explicitly marked with `required:"true"`. All other fields (like those in a request body or multipart form) follow the default required status.
 
-Pointers have no effect on optional/required. The same rules apply regardless of whether the struct is being used for request input or response output. Some examples:
+Pointers have no effect on optional/required — for [parameters](./request-inputs.md#optional-parameters) as well as for object fields. A pointer parameter means "may be absent, in which case it is `nil`", which is orthogonal to whether the client is *allowed* to omit it. The same rules apply regardless of whether the struct is being used for request input or response output. Some examples:
 
 ```go
 type MyStruct struct {
@@ -81,6 +81,8 @@ Fields being nullable is determined automatically but can be overridden as neede
     1. To a `boolean`, `integer`, `number`, `string`, `array`: it is nullable
     2. To an `object`: **panic** saying this is not currently supported
 5. If a struct has a field `_` with `nullable: true`, the struct is nullable enabling users to opt-in for `object` without the `anyOf`/`oneOf` complication.
+
+These rules apply to [parameters](./request-inputs.md#optional-parameters) too, so a `*string` query param is documented as `type: [string, "null"]`. A parameter is text on the wire and can never actually carry a literal `null`, so use `nullable:"false"` if you would rather generated clients see a plain `string`.
 
 Here are some examples:
 
@@ -165,6 +167,8 @@ Built-in string formats include:
 The `default` field validation tag listed above is used to both document the existence of a server-side default value as well as to automatically have Huma set that value for you. This is useful for fields that are optional but have a default value if not provided.
 
 Similar to how the standard library JSON unmarshaler works, it is recommended to use pointers for scalar types where the zero value has semantic meaning to your application. For example, if you have a `bool` field that defaults to `true`, you should use a `*bool` field and set the default to `true`. This way, if the field is not provided, the default value will be used.
+
+The same applies to [parameters](./request-inputs.md#optional-parameters), e.g. ``Verbose *bool `query:"verbose" default:"true"` ``. A parameter with a default is never `nil`: leave the default off if you want to tell "not provided" apart from an explicitly sent value.
 
 ```go title="code.go"
 type MyInput struct {

--- a/huma.go
+++ b/huma.go
@@ -104,6 +104,7 @@ type paramFieldInfo struct {
 	Name        string
 	Loc         string
 	Required    bool
+	IsPointer   bool // IsPointer reports that the struct field is a `*T`
 	Default     string
 	TimeFormat  string
 	Explode     bool
@@ -159,13 +160,22 @@ type paramLocation struct {
 // Returns a paramLocation and true if f carries a recognised parameter tag, or
 // nil and false if no tag is found (i.e. the field is not a parameter).
 //
-// Panics if the field type is a pointer, which is not currently supported for
-// any parameter location.
+// A pointer field means the parameter is optional, with `nil` standing for "not
+// provided". Panics for pointer forms that are not supported, i.e. multiple
+// levels of indirection or a multipart form parameter.
 func parseParamLocation(f reflect.StructField, registry Registry) (*paramLocation, bool) {
-	pfi := &paramFieldInfo{Type: f.Type}
+	// Work with the element type from here on, so that the rest of the param
+	// machinery (schema hints, parsing) sees the type the value is parsed into.
+	t := f.Type
+	isPointer := t.Kind() == reflect.Pointer
+	if isPointer {
+		t = t.Elem()
+	}
 
-	if reflect.PointerTo(f.Type).Implements(paramWrapperType) {
-		pfi.Type = reflect.New(f.Type).Interface().(ParamWrapper).Receiver().Type()
+	pfi := &paramFieldInfo{Type: t, IsPointer: isPointer}
+
+	if reflect.PointerTo(t).Implements(paramWrapperType) {
+		pfi.Type = reflect.New(t).Interface().(ParamWrapper).Receiver().Type()
 	}
 
 	if def := f.Tag.Get("default"); def != "" {
@@ -203,7 +213,7 @@ func parseParamLocation(f reflect.StructField, registry Registry) (*paramLocatio
 	case f.Tag.Get("cookie") != "":
 		pfi.Loc = "cookie"
 		pfi.Name = f.Tag.Get("cookie")
-		if f.Type == cookieType {
+		if t == cookieType {
 			// Special case: parsed from a string input to an `http.Cookie` struct.
 			pfi.Type = stringType
 		}
@@ -211,14 +221,16 @@ func parseParamLocation(f reflect.StructField, registry Registry) (*paramLocatio
 		return nil, false
 	}
 
-	// Pointer check comes after tag detection — untagged pointer fields are fine.
-	if f.Type.Kind() == reflect.Pointer {
-		// TODO: support pointers? The problem is that when we dynamically
-		// create an instance of the input struct the `params.Every(...)`
-		// call cannot set them as the value is `reflect.Invalid` unless
-		// dynamically allocated, but we don't know when to allocate until
-		// after the `Every` callback has run. Doable, but a bigger change.
-		panic("pointers are not supported for form/header/path/query parameters")
+	// Pointer checks come after tag detection — untagged pointer fields are fine.
+	if isPointer {
+		if t.Kind() == reflect.Pointer {
+			panic(fmt.Errorf("multiple levels of pointer indirection are not supported for %s parameter '%s' (field '%s' of type '%s')", pfi.Loc, pfi.Name, f.Name, f.Type))
+		}
+		if pfi.Loc == "form" {
+			// The multipart form binding path does not allocate pointers yet, so
+			// such a field would silently stay nil. Fail fast until it does.
+			panic(fmt.Errorf("pointers are not supported for form parameter '%s' (field '%s' of type '%s')", pfi.Name, f.Name, f.Type))
+		}
 	}
 
 	return result, true
@@ -819,6 +831,19 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 
 	resolvers := findResolvers(resolverType, inputType)
 	defaults := findDefaults(registry, inputType)
+	// Parameter defaults are applied while the parameters themselves are
+	// parsed (a missing value falls back to the tag in `getParamValue`), so
+	// drop params from the body-time default pass: re-applying a default
+	// there would re-inflate a pointer that a parse failure deliberately left
+	// nil, and would overwrite an explicitly provided zero value.
+	defaults.Paths = slices.DeleteFunc(defaults.Paths, func(d findResultPath[any]) bool {
+		for _, p := range inputParams.Paths {
+			if slices.Equal(p.Path, d.Path) {
+				return true
+			}
+		}
+		return false
+	})
 
 	// Pre-compute query parameter validation data to reduce per-request allocations.
 	knownParams := make(map[string]struct{})
@@ -847,6 +872,13 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 		rawBodyInputParams = findParams(registry, &op, rawBodyDataT)
 		for i := range rawBodyInputParams.Paths {
 			p := rawBodyInputParams.Paths[i].Value
+			if p.IsPointer {
+				// Every param-tagged field of a multipart data struct is bound
+				// from the form values whatever its tag says, and that path
+				// does not allocate pointers yet. Only `form`-tagged pointers
+				// panic in parseParamLocation, so catch the rest here.
+				panic(fmt.Errorf("pointers are not supported for %s parameter '%s' in a multipart form data struct (type '*%s')", p.Loc, p.Name, p.Type))
+			}
 			if p.Loc != "form" || p.Type == formFileType || p.Type == formFilesType {
 				continue
 			}
@@ -935,14 +967,22 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 		}
 
 		inputParams.Every(v, func(f reflect.Value, p *paramFieldInfo) {
-			f = reflect.Indirect(f)
-			if f.Kind() == reflect.Invalid {
+			if !f.IsValid() {
 				return
 			}
 
 			pb.Reset()
 			pb.Push(p.Loc)
 			pb.Push(p.Name)
+
+			// Pointer params are parsed into a temporary value which is only
+			// assigned to the field once parsing succeeds, so a `nil` field
+			// always means "not provided". Resolvers run even when parameter
+			// validation fails, so they must never see a half-parsed value.
+			target := f
+			if p.IsPointer {
+				target = reflect.New(f.Type().Elem()).Elem()
+			}
 
 			if p.Loc == "cookie" {
 				if cookies == nil {
@@ -952,17 +992,20 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 						cookies[c.Name] = c
 					}
 				}
-				if c, ok := cookies[p.Name]; ok && f.Type() == cookieType {
+				if c, ok := cookies[p.Name]; ok && target.Type() == cookieType {
 					// Special case: http.Cookie type, meaning we want the entire parsed
 					// cookie struct, not just the value.
-					f.Set(reflect.ValueOf(c).Elem())
+					target.Set(reflect.ValueOf(c).Elem())
+					if p.IsPointer {
+						f.Set(target.Addr())
+					}
 					return
 				}
 			}
 
-			var receiver = f
-			if f.Addr().Type().Implements(paramWrapperType) {
-				receiver = f.Addr().Interface().(ParamWrapper).Receiver()
+			var receiver = target
+			if target.Addr().Type().Implements(paramWrapperType) {
+				receiver = target.Addr().Interface().(ParamWrapper).Receiver()
 			}
 
 			var pv any
@@ -981,7 +1024,14 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 					}
 					return
 				}
+				errsBefore := len(res.Errors)
 				pv = setDeepObjectValue(pb, res, receiver, value)
+				if p.IsPointer && len(res.Errors) > errsBefore {
+					// A subfield failed to parse; return before the pointer is
+					// published so a half-parsed struct is never visible, just
+					// like the plain parse-error path below.
+					return
+				}
 			} else {
 				value := getParamValue(*p, ctx, cookies)
 				isSet = value != ""
@@ -1000,8 +1050,12 @@ func Register[I, O any](api API, op Operation, handler func(context.Context, *I)
 				}
 			}
 
-			if f.Addr().Type().Implements(paramReactorType) {
-				f.Addr().Interface().(ParamReactor).OnParamSet(isSet, pv)
+			if target.Addr().Type().Implements(paramReactorType) {
+				target.Addr().Interface().(ParamReactor).OnParamSet(isSet, pv)
+			}
+
+			if p.IsPointer {
+				f.Set(target.Addr())
 			}
 
 			if !op.SkipValidateParams {

--- a/huma_internal_test.go
+++ b/huma_internal_test.go
@@ -1,9 +1,13 @@
 package huma
 
 import (
+	"net/http"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // A path that arrives at a collection must step into its elements. Anything
@@ -13,4 +17,53 @@ func TestCollectionPath(t *testing.T) {
 	assert.Equal(t, []int{2}, collectionPath([]int{collectionElem, 2}))
 	assert.Panics(t, func() { collectionPath([]int{2}) })
 	assert.Panics(t, func() { collectionPath(nil) })
+}
+
+// optParam is a minimal ParamWrapper used to check that pointer dereferencing
+// in parseParamLocation happens before the wrapper is detected.
+type optParam struct {
+	Value int
+	IsSet bool
+}
+
+func (o *optParam) Receiver() reflect.Value {
+	return reflect.ValueOf(o).Elem().Field(0)
+}
+
+// Pointer params are dereferenced at registration so that the rest of the param
+// machinery sees the type values are parsed into. The order matters: the deref
+// must happen before the ParamWrapper and http.Cookie special cases.
+func TestParseParamLocationPointer(t *testing.T) {
+	registry := NewMapRegistry("#/components/schemas/", DefaultSchemaNamer)
+
+	for _, tc := range []struct {
+		name      string
+		field     reflect.StructField
+		isPointer bool
+		typ       reflect.Type
+	}{
+		{"string", reflect.StructField{Name: "P", Type: reflect.TypeFor[string](), Tag: `query:"p"`}, false, stringType},
+		{"ptr-string", reflect.StructField{Name: "P", Type: reflect.TypeFor[*string](), Tag: `query:"p"`}, true, stringType},
+		{"ptr-time", reflect.StructField{Name: "P", Type: reflect.TypeFor[*time.Time](), Tag: `query:"p"`}, true, timeType},
+		{"ptr-slice", reflect.StructField{Name: "P", Type: reflect.TypeFor[*[]string](), Tag: `query:"p"`}, true, reflect.TypeFor[[]string]()},
+		// http.Cookie is parsed from the cookie's string value.
+		{"cookie", reflect.StructField{Name: "P", Type: reflect.TypeFor[http.Cookie](), Tag: `cookie:"p"`}, false, stringType},
+		{"ptr-cookie", reflect.StructField{Name: "P", Type: reflect.TypeFor[*http.Cookie](), Tag: `cookie:"p"`}, true, stringType},
+		// The wrapper exposes an int receiver, so that is what gets parsed.
+		{"ptr-wrapper", reflect.StructField{Name: "P", Type: reflect.TypeFor[*optParam](), Tag: `query:"p"`}, true, reflect.TypeFor[int]()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pl, ok := parseParamLocation(tc.field, registry)
+			require.True(t, ok)
+			assert.Equal(t, tc.isPointer, pl.pfi.IsPointer)
+			assert.Equal(t, tc.typ, pl.pfi.Type)
+		})
+	}
+}
+
+// Untagged pointer fields are not parameters and must not be rejected.
+func TestParseParamLocationIgnoresUntagged(t *testing.T) {
+	registry := NewMapRegistry("#/components/schemas/", DefaultSchemaNamer)
+	_, ok := parseParamLocation(reflect.StructField{Name: "P", Type: reflect.TypeFor[**string]()}, registry)
+	assert.False(t, ok)
 }

--- a/huma_test.go
+++ b/huma_test.go
@@ -107,6 +107,37 @@ func (m *MyCustomUnmarshaler) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// PointerParams exercises pointer parameters across every location and every
+// supported scalar type. A `nil` field means the parameter was not provided.
+type PointerParams struct {
+	PathStr   *string            `path:"str"`
+	Str       *string            `query:"str"`
+	Int       *int               `query:"int"`
+	Uint      *uint32            `query:"uint"`
+	Float     *float64           `query:"float"`
+	Bool      *bool              `query:"bool"`
+	Time      *time.Time         `query:"time"`
+	URL       *url.URL           `query:"url"`
+	Custom    *MyTextUnmarshaler `query:"custom"`
+	Header    *string            `header:"X-Str"`
+	HeaderInt *int               `header:"X-Int"`
+	Cookie    *string            `cookie:"str"`
+}
+
+// nilCheckingResolverSawNil records what the resolver below observed. Resolvers
+// run even when parameter parsing failed, so a pointer whose value could not be
+// parsed must still be nil rather than a half-parsed zero value.
+var nilCheckingResolverSawNil bool
+
+type NilCheckingResolver struct {
+	Num *int `query:"num"`
+}
+
+func (r *NilCheckingResolver) Resolve(ctx huma.Context) []error {
+	nilCheckingResolverSawNil = r.Num == nil
+	return nil
+}
+
 type OptionalParam[T any] struct {
 	Value T
 	IsSet bool
@@ -803,6 +834,229 @@ func TestFeatures(t *testing.T) {
 			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
 				assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 				assert.Contains(t, resp.Body.String(), "unsupported param type: []struct {}")
+			},
+		},
+		{
+			Name: "params-pointers-present",
+			Register: func(t *testing.T, api huma.API) {
+				op := huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test/{str}",
+				}
+				huma.Register(api, op, func(ctx context.Context, i *PointerParams) (*struct{}, error) {
+					require.NotNil(t, i.PathStr)
+					assert.Equal(t, "path", *i.PathStr)
+					require.NotNil(t, i.Str)
+					assert.Equal(t, "hello", *i.Str)
+					require.NotNil(t, i.Int)
+					assert.Equal(t, 42, *i.Int)
+					require.NotNil(t, i.Uint)
+					assert.Equal(t, uint32(7), *i.Uint)
+					require.NotNil(t, i.Float)
+					assert.InDelta(t, 1.5, *i.Float, 0)
+					require.NotNil(t, i.Bool)
+					// The zero value: proves nil and false are distinguishable,
+					// which is the whole point of https://github.com/danielgtaylor/huma/issues/393
+					assert.False(t, *i.Bool)
+					require.NotNil(t, i.Time)
+					assert.True(t, i.Time.Equal(time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)))
+					require.NotNil(t, i.URL)
+					assert.Equal(t, "https://example.com/x", i.URL.String())
+					require.NotNil(t, i.Custom)
+					assert.Equal(t, "Hello, World!", i.Custom.value)
+					require.NotNil(t, i.Header)
+					assert.Equal(t, "head", *i.Header)
+					require.NotNil(t, i.HeaderInt)
+					assert.Equal(t, 5, *i.HeaderInt)
+					require.NotNil(t, i.Cookie)
+					assert.Equal(t, "cook", *i.Cookie)
+					return nil, nil
+				})
+
+				// A pointer parameter is documented as optional and nullable.
+				for _, p := range api.OpenAPI().Paths["/test/{str}"].Get.Parameters {
+					if p.Name == "str" && p.In == "query" {
+						assert.False(t, p.Required)
+						b, err := p.Schema.MarshalJSON()
+						require.NoError(t, err)
+						assert.JSONEq(t, `{"type":["string","null"]}`, string(b))
+					}
+					if p.Name == "str" && p.In == "path" {
+						// Path params are always required, pointer or not.
+						assert.True(t, p.Required)
+					}
+				}
+			},
+			Method: http.MethodGet,
+			URL:    "/test/path?str=hello&int=42&uint=7&float=1.5&bool=false&time=2023-01-01T12:00:00Z&url=https://example.com/x&custom=anything",
+			Headers: map[string]string{
+				"X-Str":  "head",
+				"X-Int":  "5",
+				"Cookie": "str=cook",
+			},
+		},
+		{
+			// The core regression test for issue #393: absent means nil, not zero.
+			Name: "params-pointers-absent",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test/{str}",
+				}, func(ctx context.Context, i *PointerParams) (*struct{}, error) {
+					assert.Nil(t, i.Str)
+					assert.Nil(t, i.Int)
+					assert.Nil(t, i.Uint)
+					assert.Nil(t, i.Float)
+					assert.Nil(t, i.Bool)
+					assert.Nil(t, i.Time)
+					assert.Nil(t, i.URL)
+					assert.Nil(t, i.Custom)
+					assert.Nil(t, i.Header)
+					assert.Nil(t, i.HeaderInt)
+					assert.Nil(t, i.Cookie)
+					return nil, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/test/path",
+		},
+		{
+			// A present-but-empty value counts as not provided. Documented
+			// limitation: there is no cheap presence check for headers/cookies.
+			Name: "params-pointer-empty-value",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Str *string `query:"str"`
+				}) (*struct{}, error) {
+					assert.Nil(t, i.Str)
+					return nil, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/test?str=",
+		},
+		{
+			Name: "params-pointer-nullable-false",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Str *string `query:"str" nullable:"false"`
+				}) (*struct{}, error) {
+					return nil, nil
+				})
+
+				p := api.OpenAPI().Paths["/test"].Get.Parameters[0]
+				b, err := p.Schema.MarshalJSON()
+				require.NoError(t, err)
+				assert.JSONEq(t, `{"type":"string"}`, string(b))
+			},
+			Method: http.MethodGet,
+			URL:    "/test",
+		},
+		{
+			Name: "params-pointer-required-missing",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Str *string `query:"str" required:"true"`
+				}) (*struct{}, error) {
+					return nil, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/test",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+				assert.Contains(t, resp.Body.String(), "required query parameter is missing")
+			},
+		},
+		{
+			Name: "params-pointer-default-absent",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPut,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					// A body is present so `setDefaults` also walks the input
+					// struct, proving it leaves the already-set pointer alone.
+					Body struct {
+						Value string `json:"value"`
+					}
+					Num *int `query:"num" default:"5"`
+				}) (*struct{}, error) {
+					require.NotNil(t, i.Num)
+					assert.Equal(t, 5, *i.Num)
+					return nil, nil
+				})
+			},
+			Method:  http.MethodPut,
+			URL:     "/test",
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    `{"value": "x"}`,
+		},
+		{
+			Name: "params-pointer-default-present",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Num *int `query:"num" default:"5"`
+				}) (*struct{}, error) {
+					require.NotNil(t, i.Num)
+					assert.Equal(t, 7, *i.Num)
+					return nil, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/test?num=7",
+		},
+		{
+			// A value that fails to parse must leave the pointer nil, since
+			// resolvers still run before the 422 is written.
+			Name: "params-pointer-invalid",
+			Register: func(t *testing.T, api huma.API) {
+				nilCheckingResolverSawNil = false
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *NilCheckingResolver) (*struct{}, error) {
+					return nil, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/test?num=abc",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+				assert.Contains(t, resp.Body.String(), "invalid integer")
+				assert.True(t, nilCheckingResolverSawNil, "resolver saw a non-nil pointer for an unparsable value")
+			},
+		},
+		{
+			// Validation runs against the parsed scalar, not the pointer.
+			Name: "params-pointer-validation",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Num *int `query:"num" minimum:"5"`
+				}) (*struct{}, error) {
+					return nil, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/test?num=1",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+				assert.Contains(t, resp.Body.String(), "expected number >= 5")
 			},
 		},
 		{
@@ -4311,20 +4565,47 @@ func TestResolverWithPointer(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, w.Code, w.Body.String())
 }
 
-func TestParamPointerPanics(t *testing.T) {
-	// For now, we don't support these, so we panic rather than have subtle
-	// bugs that are hard to track down.
-	_, app := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+func TestParamPointerUnsupported(t *testing.T) {
+	// Pointer params are supported, but a few forms can't be, so we panic at
+	// registration rather than have subtle bugs that are hard to track down.
+	op := huma.Operation{
+		OperationID: "bug",
+		Method:      http.MethodGet,
+		Path:        "/bug",
+	}
 
-	assert.Panics(t, func() {
-		huma.Register(app, huma.Operation{
-			OperationID: "bug",
-			Method:      http.MethodGet,
-			Path:        "/bug",
-		}, func(ctx context.Context, input *struct {
-			Param *string `query:"param"`
-		}) (*struct{}, error) {
-			return nil, nil
+	t.Run("double-pointer", func(t *testing.T) {
+		_, app := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+		assert.PanicsWithError(t, "multiple levels of pointer indirection are not supported for query parameter 'param' (field 'Param' of type '**string')", func() {
+			huma.Register(app, op, func(ctx context.Context, input *struct {
+				Param **string `query:"param"`
+			}) (*struct{}, error) {
+				return nil, nil
+			})
+		})
+	})
+
+	// Multipart form binding does not allocate pointers yet, so these must fail
+	// fast at registration rather than silently stay nil.
+	t.Run("form-scalar", func(t *testing.T) {
+		_, app := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+		assert.PanicsWithError(t, "pointers are not supported for form parameter 'param' (field 'Param' of type '*string')", func() {
+			huma.Register(app, op, func(ctx context.Context, input *struct {
+				Param *string `form:"param"`
+			}) (*struct{}, error) {
+				return nil, nil
+			})
+		})
+	})
+
+	t.Run("form-file", func(t *testing.T) {
+		_, app := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+		assert.PanicsWithError(t, "pointers are not supported for form parameter 'param' (field 'Param' of type '*huma.FormFile')", func() {
+			huma.Register(app, op, func(ctx context.Context, input *struct {
+				Param *huma.FormFile `form:"param"`
+			}) (*struct{}, error) {
+				return nil, nil
+			})
 		})
 	})
 }

--- a/huma_test.go
+++ b/huma_test.go
@@ -138,6 +138,39 @@ func (r *NilCheckingResolver) Resolve(ctx huma.Context) []error {
 	return nil
 }
 
+// deepObjectNilCheckingResolverSawNil records what the resolver below observed
+// for a deepObject pointer whose subfield failed to parse.
+var deepObjectNilCheckingResolverSawNil bool
+
+type DeepObjectNilCheckingResolver struct {
+	Filter *struct {
+		Name string `json:"name"`
+		Age  int    `json:"age"`
+	} `query:"filter,deepObject"`
+}
+
+func (r *DeepObjectNilCheckingResolver) Resolve(ctx huma.Context) []error {
+	deepObjectNilCheckingResolverSawNil = r.Filter == nil
+	return nil
+}
+
+// defaultedNilCheckingResolverSawNil records what the resolver below observed
+// for an unparsable pointer param with a `default` tag on a request that also
+// carries a body: the body-time default pass must not re-inflate the pointer.
+var defaultedNilCheckingResolverSawNil bool
+
+type DefaultedNilCheckingResolver struct {
+	Body struct {
+		Value string `json:"value"`
+	}
+	Num *int `query:"num" default:"5"`
+}
+
+func (r *DefaultedNilCheckingResolver) Resolve(ctx huma.Context) []error {
+	defaultedNilCheckingResolverSawNil = r.Num == nil
+	return nil
+}
+
 type OptionalParam[T any] struct {
 	Value T
 	IsSet bool
@@ -1040,6 +1073,51 @@ func TestFeatures(t *testing.T) {
 			},
 		},
 		{
+			// A deepObject subfield that fails to parse must leave the pointer
+			// nil rather than publish a half-parsed struct.
+			Name: "params-pointer-deepobject-invalid",
+			Register: func(t *testing.T, api huma.API) {
+				deepObjectNilCheckingResolverSawNil = false
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *DeepObjectNilCheckingResolver) (*struct{}, error) {
+					return nil, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/test?filter[name]=bob&filter[age]=abc",
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+				assert.Contains(t, resp.Body.String(), "invalid integer")
+				assert.True(t, deepObjectNilCheckingResolverSawNil, "resolver saw a half-parsed deepObject pointer")
+			},
+		},
+		{
+			// The same unparsable value on a request that carries a body: the
+			// defaults applied after body parsing must not re-inflate the
+			// pointer the parse failure left nil.
+			Name: "params-pointer-invalid-with-body",
+			Register: func(t *testing.T, api huma.API) {
+				defaultedNilCheckingResolverSawNil = false
+				huma.Register(api, huma.Operation{
+					Method: http.MethodPut,
+					Path:   "/test",
+				}, func(ctx context.Context, i *DefaultedNilCheckingResolver) (*struct{}, error) {
+					return nil, nil
+				})
+			},
+			Method:  http.MethodPut,
+			URL:     "/test?num=abc",
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    `{"value": "x"}`,
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+				assert.Contains(t, resp.Body.String(), "invalid integer")
+				assert.True(t, defaultedNilCheckingResolverSawNil, "defaults re-inflated a pointer left nil by a parse failure")
+			},
+		},
+		{
 			// Validation runs against the parsed scalar, not the pointer.
 			Name: "params-pointer-validation",
 			Register: func(t *testing.T, api huma.API) {
@@ -1058,6 +1136,66 @@ func TestFeatures(t *testing.T) {
 				assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
 				assert.Contains(t, resp.Body.String(), "expected number >= 5")
 			},
+		},
+		{
+			// Pointers to slices, structs and wrapper types fall out of the same
+			// mechanism as scalars: `nil` means the parameter was not provided.
+			Name: "params-pointer-composite-present",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Tags   *[]string `query:"tags"`
+					Nums   *[]int    `query:"nums,explode"`
+					Filter *struct {
+						Name string `json:"name"`
+					} `query:"filter,deepObject"`
+					Cookie  *http.Cookie        `cookie:"sess"`
+					Wrapped *OptionalParam[int] `query:"wrapped"`
+				}) (*struct{}, error) {
+					require.NotNil(t, i.Tags)
+					assert.Equal(t, []string{"a", "b"}, *i.Tags)
+					require.NotNil(t, i.Nums)
+					assert.Equal(t, []int{1, 2}, *i.Nums)
+					require.NotNil(t, i.Filter)
+					assert.Equal(t, "bob", i.Filter.Name)
+					require.NotNil(t, i.Cookie)
+					assert.Equal(t, "sess", i.Cookie.Name)
+					assert.Equal(t, "abc", i.Cookie.Value)
+					require.NotNil(t, i.Wrapped)
+					assert.Equal(t, 9, i.Wrapped.Value)
+					assert.True(t, i.Wrapped.IsSet)
+					return nil, nil
+				})
+			},
+			Method:  http.MethodGet,
+			URL:     "/test?tags=a,b&nums=1&nums=2&filter[name]=bob&wrapped=9",
+			Headers: map[string]string{"Cookie": "sess=abc"},
+		},
+		{
+			Name: "params-pointer-composite-absent",
+			Register: func(t *testing.T, api huma.API) {
+				huma.Register(api, huma.Operation{
+					Method: http.MethodGet,
+					Path:   "/test",
+				}, func(ctx context.Context, i *struct {
+					Tags   *[]string `query:"tags"`
+					Filter *struct {
+						Name string `json:"name"`
+					} `query:"filter,deepObject"`
+					Cookie  *http.Cookie        `cookie:"sess"`
+					Wrapped *OptionalParam[int] `query:"wrapped"`
+				}) (*struct{}, error) {
+					assert.Nil(t, i.Tags)
+					assert.Nil(t, i.Filter)
+					assert.Nil(t, i.Cookie)
+					assert.Nil(t, i.Wrapped)
+					return nil, nil
+				})
+			},
+			Method: http.MethodGet,
+			URL:    "/test",
 		},
 		{
 			Name: "parse-with-param-receiver",
@@ -3173,10 +3311,10 @@ Content-Type: text/plain
 			},
 			Method: http.MethodGet,
 			URL:    "/transform",
-Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
-	assert.Equal(t, http.StatusOK, resp.Code)
-	assert.JSONEq(t, `null`, resp.Body.String())
-},
+			Assert: func(t *testing.T, resp *httptest.ResponseRecorder) {
+				assert.Equal(t, http.StatusOK, resp.Code)
+				assert.JSONEq(t, `null`, resp.Body.String())
+			},
 		},
 		{
 			Name: "schema-url-from-x-forwarded-host",
@@ -4603,6 +4741,26 @@ func TestParamPointerUnsupported(t *testing.T) {
 		assert.PanicsWithError(t, "pointers are not supported for form parameter 'param' (field 'Param' of type '*huma.FormFile')", func() {
 			huma.Register(app, op, func(ctx context.Context, input *struct {
 				Param *huma.FormFile `form:"param"`
+			}) (*struct{}, error) {
+				return nil, nil
+			})
+		})
+	})
+
+	// A pointer param carrying any other location tag inside a multipart form
+	// data struct is still bound from the form values, so it must fail fast at
+	// registration too.
+	t.Run("multipart-data-pointer", func(t *testing.T) {
+		_, app := humatest.New(t, huma.DefaultConfig("Test API", "1.0.0"))
+		assert.PanicsWithError(t, "pointers are not supported for query parameter 'x' in a multipart form data struct (type '*string')", func() {
+			huma.Register(app, huma.Operation{
+				OperationID: "bug",
+				Method:      http.MethodPost,
+				Path:        "/bug",
+			}, func(ctx context.Context, input *struct {
+				RawBody huma.MultipartFormFiles[struct {
+					X *string `query:"x"`
+				}]
 			}) (*struct{}, error) {
 				return nil, nil
 			})


### PR DESCRIPTION
Hello,

I started using this awesome project and was a bit annoyed by the need to declare additional structs instead of using pointer. I had a use case were a query parameters not passed has a different semantic than being false. 

So I gave a Go at the issue. I am not an expert in reflection and thus was helped by AI doing the code. 

The idea is to check if the reflection type is a pointer and if so, use the pointed object and store the fact that it's a pointer to be used later on.

It should fix #393.