### PR TITLE
fix(casing): stop transforming an index after its part is removed

### DIFF
--- a/casing/casing.go
+++ b/casing/casing.go
@@ -214,9 +214,10 @@ func Join(parts []string, sep string, transform ...TransformFunc) string {
 			parts[i] = t(parts[i])
 
 			if parts[i] == "" {
-				// Transformer completely removed this part.
+				// Removing the part shifts the rest down, so stop transforming this index.
 				parts = append(parts[:i], parts[i+1:]...)
 				i--
+				break
 			}
 		}
 	}

--- a/casing/casing_test.go
+++ b/casing/casing_test.go
@@ -89,6 +89,23 @@ func TestRemovePart(t *testing.T) {
 	}))
 }
 
+func TestRemovePartWithMultipleTransforms(t *testing.T) {
+	drop := func(part string) string {
+		if part == "and" {
+			return ""
+		}
+
+		return part
+	}
+
+	// Camel always appends strings.Title, so a removing transform in first
+	// position leaves two transforms for the shifted index.
+	assert.Equal(t, "OneTwo", casing.Camel("and-one-two", drop))
+
+	suffix := func(part string) string { return part + "x" }
+	assert.Equal(t, "onex_twox", casing.Join([]string{"one", "and", "two"}, "_", drop, suffix))
+}
+
 func TestRightAlign(t *testing.T) {
 	assert.Equal(t, "stream_1080p", casing.Snake("Stream1080P"))
 


### PR DESCRIPTION
`casing.Camel` panics when a transform removes the first part.

```go
drop := func(p string) string { if p == "and" { return "" }; return p }
casing.Camel("and-one-two", drop)
```

```
panic: runtime error: index out of range [-1]
github.com/danielgtaylor/huma/v2/casing.Join(...) casing/casing.go:214
github.com/danielgtaylor/huma/v2/casing.Camel(...) casing/casing.go:296
```

Same root cause, silently wrong value when the removed part is not first:

```go
suffix := func(s string) string { return s + "x" }
casing.Join([]string{"one", "and", "two"}, "_", drop, suffix)
// "onexx_twox"   want "onex_twox"  -  "one" gets suffixed twice
```

### Cause

`casing/casing.go:212`:

```go
for i := 0; i < len(parts); i++ {
    for _, t := range transform {
        parts[i] = t(parts[i])

        if parts[i] == "" {
            // Transformer completely removed this part.
            parts = append(parts[:i], parts[i+1:]...)
            i--
        }
    }
}
```

`i--` is the **outer** loop's correction, but it is applied while the **inner** transform loop is
still running. The next transform in the list then reads `parts[i]` at the decremented index — the
element before the one that was removed, which has already been transformed. With the removed part
first, `i` becomes `-1`.

`Camel` (`casing/casing.go:295`) always does `append(transform, strings.Title)`, so every
`Camel`/`LowerCamel` call has at least two transforms and a single removing transform is enough to
reach it.

### The change

`break` out of the inner loop after removing the part, so the outer `i--` and `i++` land on the
element that shifted into this position and it starts its transform chain from the beginning.

### Why the tests missed it

`TestRemovePart` (`casing/casing_test.go:82`) exercises removal with exactly **one** transform, via
`Snake`. It still gives `"one_two"`, unchanged by this PR. The next step — a second transform, or
`Camel`, which supplies one implicitly — is where it breaks.

### Tests

`TestRemovePartWithMultipleTransforms`, covering both the panic and the double-transform value.
Mutation-checked in both directions:

- **Revert the fix** (drop `break`): `panic: runtime error: index out of range [-1]`
- **Over-correct** (keep `break`, drop `i--`): `expected: "OneTwo" actual: "oneTwo"` and
  `expected: "onex_twox"` — so the test pins the boundary from both sides rather than just one.

`go test -race ./...` passes across all 21 packages. `gofmt -l casing/` empty, `go vet ./casing/`
clean.

**Observable change:** only on inputs that currently panic or double-transform. No existing test
changes result.

### One more, not bundled

`LowerCamel("")` panics too, at `casing/casing.go:300`, which indexes `runes[0]` without a length
check — also reachable from any all-punctuation input, since `Split("_")` returns an empty slice. A
separate root cause, so I left it out to keep this PR to one; happy to fold it in or send it after.

---

Disclosure: found and prepared with AI assistance (Claude). Every figure above is from a run on this
branch, and the root cause is one I traced and verified by hand.
